### PR TITLE
pylint CI を修正：pytest インストールと sys.path 設定を追加

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
+        pip install pylint pytest
     - name: Analysing the code with pylint
       run: |
         pylint $(git ls-files '*.py')

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[MASTER]
+init-hook='import sys; sys.path.insert(0, ".")'
+
+[IMPORTS]
+known-third-party=pytest


### PR DESCRIPTION
## Summary

- `.pylintrc` を新規作成し、`init-hook` でプロジェクトルートを `sys.path` に追加 → `dashboard.server` / `reports.export_html` の `E0401` 解消
- `.pylintrc` の `known-third-party=pytest` で pytest を外部ライブラリとして認識 → テストファイルの `E0401` 解消
- `pylint.yml` の `pip install` に `pytest` を追加
- `pylint.yml` の Python バージョンを `3.8/3.9/3.10` → `3.10/3.11/3.12` に更新

Fixes #4

## Test plan

- [ ] GitHub Actions の Pylint ワークフローが 3.10/3.11/3.12 の全バージョンで green になることを確認
- [ ] ローカルの既存テスト 153/153 がパスすることを確認済み（`python3 -m pytest tests/`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)