### PR TITLE
v0.3 UI: グラフ data point に hover tooltip を追加 (Issue #17)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-transcript-analyzer",
   "description": "Automatically collect and visualize Claude Code Skills and Subagents usage",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "kkoichi"
   }

--- a/dashboard/template.html
+++ b/dashboard/template.html
@@ -426,6 +426,61 @@
     padding: 1px 5px;
     border-radius: 4px;
   }
+
+  /* ---------- data tooltip (graph data points) ---------- */
+  /* `?` ヘルプ (.help-pop) は説明テキスト中心、こちらはデータ値中心。
+     位置はマウス追従、フォントは mono で値を強調、左に accent stripe。 */
+  .data-tip {
+    position: fixed;
+    z-index: 60;
+    top: 0; left: 0;
+    pointer-events: none;
+    background: var(--bg-app);
+    border: 1px solid var(--line-strong);
+    border-left: 3px solid var(--peri);
+    border-radius: var(--r-sm);
+    padding: 6px 10px 7px;
+    font-family: var(--ff-mono);
+    font-size: 11.5px;
+    line-height: 1.45;
+    color: var(--ink);
+    box-shadow:
+      0 1px 2px rgba(0,0,0,0.30),
+      0 8px 24px rgba(0,0,0,0.45);
+    white-space: nowrap;
+    visibility: hidden;
+    opacity: 0;
+    transform: translate3d(0,0,0);
+    transition: opacity 90ms ease;
+  }
+  .data-tip[data-show="true"] { visibility: visible; opacity: 1; }
+  .data-tip[data-kind="proj"] { border-left-color: var(--peach); }
+  .data-tip .lbl {
+    color: var(--ink-faint);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-right: 6px;
+    font-family: var(--ff-sans);
+    font-weight: 500;
+  }
+  .data-tip .val {
+    color: var(--ink);
+    font-weight: 600;
+  }
+  .data-tip .sep { color: var(--ink-faint); margin: 0 6px; }
+  .data-tip .ttl {
+    display: block;
+    color: var(--ink);
+    font-weight: 600;
+    font-size: 12px;
+    margin-bottom: 2px;
+    font-family: var(--ff-mono);
+  }
+  .stack .seg { cursor: default; }
+  .stack-legend .leg-row { cursor: default; }
+  /* sparkline 用の hit-area circle はマウスを受ける */
+  .spark-svg .dot-hit { cursor: default; }
 </style>
 </head>
 <body>
@@ -529,6 +584,8 @@
       <span>stdlib only · no third-party js</span>
     </footer>
   </div>
+
+  <div class="data-tip" id="dataTooltip" role="tooltip" aria-hidden="true"></div>
 
 <script>
 (async function(){
@@ -653,10 +710,17 @@
     const peakIdx = days.findIndex(d => d.count === max);
     const peakDate = days[peakIdx].date;
 
-    const dots = days.map((d,i) => d.count > 0
-      ? '<circle cx="' + xs(i).toFixed(2) + '" cy="' + ys(d.count).toFixed(2) + '" r="1.7" fill="#8aa6ff" fill-opacity="0.85"/>'
-      : ''
-    ).join('');
+    const dots = days.map((d,i) => {
+      if (d.count <= 0) return '';
+      const cx = xs(i).toFixed(2);
+      const cy = ys(d.count).toFixed(2);
+      const al = d.date + ': ' + d.count + ' events';
+      // 可視 dot + 透明な hit-area circle（hover usability 向上 + data 属性キャリア）
+      return '<circle cx="' + cx + '" cy="' + cy + '" r="1.7" fill="#8aa6ff" fill-opacity="0.85"/>' +
+        '<circle class="dot-hit" cx="' + cx + '" cy="' + cy + '" r="6" fill="transparent" ' +
+        'data-tip="daily" data-d="' + d.date + '" data-c="' + d.count + '" ' +
+        'tabindex="0" role="img" aria-label="' + al + '"/>';
+    }).join('');
 
     const ticks = days.map((d,i) => i % Math.ceil(days.length/8) === 0
       ? '<text x="' + xs(i).toFixed(2) + '" y="' + (H - 3) + '" font-size="9.5" font-family="JetBrains Mono, monospace" fill="#7e8290" text-anchor="middle">' + d.date.slice(5) + '</text>'
@@ -702,16 +766,22 @@
   const projs = (data.project_breakdown||[]);
   const projTotal = projs.reduce((s,p)=>s+p.count, 0);
   const palette = ['#6fe3c8','#ff8a76','#8aa6ff','#ffc97a','#ff6f9c','#a78bfa','#7ed3a3','#ffa86b','#5dc9e2','#e6a8e8'];
+  function projPct(p) { return projTotal ? (p.count/projTotal*100).toFixed(1) + '%' : '0.0%'; }
+  function projAria(p, pct) { return esc(p.project) + ': ' + fmtN(p.count) + ' events (' + pct + ')'; }
   document.getElementById('stack').innerHTML = projs.map((p, i) => {
     const w = projTotal ? (p.count/projTotal*100) : 0;
-    return '<div class="seg" title="' + esc(p.project) + ' · ' + p.count + '" style="background:' + palette[i % palette.length] + ';width:' + w + '%"></div>';
+    const pct = projPct(p);
+    return '<div class="seg" data-tip="proj" data-p="' + esc(p.project) + '" data-c="' + p.count + '" data-pct="' + pct + '" ' +
+      'tabindex="0" role="img" aria-label="' + projAria(p, pct) + '" ' +
+      'style="background:' + palette[i % palette.length] + ';width:' + w + '%"></div>';
   }).join('');
   document.getElementById('stackLegend').innerHTML = projs.map((p, i) => {
-    const pct = projTotal ? (p.count/projTotal*100).toFixed(1) + '%' : '0.0%';
+    const pct = projPct(p);
     const display = p.project.length > 28 ? p.project.slice(0,26) + '…' : p.project;
-    return '<div class="leg-row">' +
+    return '<div class="leg-row" data-tip="proj" data-p="' + esc(p.project) + '" data-c="' + p.count + '" data-pct="' + pct + '" ' +
+      'tabindex="0" aria-label="' + projAria(p, pct) + '">' +
       '<div class="sw" style="background:' + palette[i % palette.length] + '"></div>' +
-      '<div class="pn" title="' + esc(p.project) + '">' + esc(display) + '</div>' +
+      '<div class="pn">' + esc(display) + '</div>' +
       '<div class="pc">' + fmtN(p.count) + '</div>' +
       '<div class="pp">' + pct + '</div>' +
     '</div>';
@@ -782,6 +852,106 @@
       const btn = document.querySelector('button[data-help-id="' + pop.id + '"]');
       if (btn) placePop(pop, btn);
     });
+  });
+
+  // ============================================================
+  //  Data tooltip (graph data points, [data-tip] elements)
+  // ============================================================
+  const dtip = document.getElementById('dataTooltip');
+  let dtipActive = null;
+
+  function dtipShow(html, kind) {
+    dtip.innerHTML = html;
+    dtip.setAttribute('data-kind', kind);
+    dtip.setAttribute('data-show', 'true');
+    dtip.setAttribute('aria-hidden', 'false');
+  }
+  function dtipHide() {
+    dtip.removeAttribute('data-show');
+    dtip.setAttribute('aria-hidden', 'true');
+    dtipActive = null;
+  }
+  function dtipMove(clientX, clientY) {
+    const offset = 14;
+    let x = clientX + offset;
+    let y = clientY + offset;
+    const tw = dtip.offsetWidth;
+    const th = dtip.offsetHeight;
+    if (x + tw > window.innerWidth - 8) x = clientX - offset - tw;
+    if (y + th > window.innerHeight - 8) y = clientY - offset - th;
+    if (x < 4) x = 4;
+    if (y < 4) y = 4;
+    dtip.style.transform = 'translate3d(' + x + 'px,' + y + 'px,0)';
+  }
+  function dtipBuild(el) {
+    const kind = el.getAttribute('data-tip');
+    if (kind === 'daily') {
+      const d = el.getAttribute('data-d');
+      const c = el.getAttribute('data-c');
+      return {
+        kind: 'daily',
+        html: '<span class="ttl">' + esc(d) + '</span>' +
+              '<span class="lbl">events</span><span class="val">' + fmtN(c) + '</span>'
+      };
+    }
+    if (kind === 'proj') {
+      const p = el.getAttribute('data-p');
+      const c = el.getAttribute('data-c');
+      const pct = el.getAttribute('data-pct');
+      return {
+        kind: 'proj',
+        html: '<span class="ttl">' + esc(p) + '</span>' +
+              '<span class="lbl">events</span><span class="val">' + fmtN(c) + '</span>' +
+              '<span class="sep">·</span>' +
+              '<span class="lbl">share</span><span class="val">' + esc(pct) + '</span>'
+      };
+    }
+    return null;
+  }
+
+  document.addEventListener('mouseover', function(e) {
+    const el = e.target.closest('[data-tip]');
+    if (!el) return;
+    if (el !== dtipActive) {
+      const info = dtipBuild(el);
+      if (!info) return;
+      dtipShow(info.html, info.kind);
+      dtipActive = el;
+    }
+    dtipMove(e.clientX, e.clientY);
+  });
+
+  document.addEventListener('mousemove', function(e) {
+    if (!dtipActive) return;
+    const el = e.target.closest('[data-tip]');
+    if (el === dtipActive) {
+      dtipMove(e.clientX, e.clientY);
+    }
+  });
+
+  document.addEventListener('mouseout', function(e) {
+    if (!dtipActive) return;
+    const el = e.target.closest('[data-tip]');
+    if (el !== dtipActive) return;
+    if (e.relatedTarget && dtipActive.contains(e.relatedTarget)) return;
+    dtipHide();
+  });
+
+  // keyboard fallback: focus する要素にも tooltip を出す
+  document.addEventListener('focusin', function(e) {
+    const el = e.target.closest('[data-tip]');
+    if (!el) return;
+    const info = dtipBuild(el);
+    if (!info) return;
+    dtipShow(info.html, info.kind);
+    dtipActive = el;
+    const r = el.getBoundingClientRect();
+    dtipMove(r.right, r.bottom);
+  });
+
+  document.addEventListener('focusout', function(e) {
+    const el = e.target.closest('[data-tip]');
+    if (el && el === dtipActive) dtipHide();
   });
 })();
 </script>

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -667,3 +667,79 @@ class TestHTTPEndpoints:
         finally:
             server.shutdown()
             server.server_close()
+
+
+class TestGraphDataTooltip:
+    """Issue #17: sparkline と project stack のデータポイントに floating tooltip を追加。
+
+    - sparkline の各 dot に hover で {date} / {events} を表示
+    - stack の各 seg / legend に hover で {project} / {count} / {percent} を表示
+    - native title= 属性は廃止（OS tooltip との重複表示を避ける）
+    - 既存の `?` ヘルプポップアップとは視覚的に区別される
+    """
+
+    def test_template_has_data_tooltip_element(self, tmp_path):
+        """共有 floating tooltip 要素 (#dataTooltip) が body に存在する。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        assert 'id="dataTooltip"' in template
+
+    def test_template_has_data_tooltip_css(self, tmp_path):
+        """data-tip 用の CSS クラス（.data-tip）が定義されている。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        assert ".data-tip" in template
+        # fixed positioning でマウス追従できる
+        assert "position: fixed" in template
+
+    def test_data_tooltip_visually_distinct_from_help_pop(self, tmp_path):
+        """データ tooltip は help-pop と別クラスで定義され、視覚的に区別できる。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        # help-pop と data-tip は別の class 名
+        assert ".data-tip" in template
+        assert ".help-pop" in template
+        # data-tip は値中心なので mono フォントを使う
+        assert "data-tip" in template
+
+    def test_sparkline_dots_have_data_attributes(self, tmp_path):
+        """sparkline の dot に data-tip="daily" + data-d / data-c が付与される。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        # JS の dots 生成箇所で data-tip="daily" を埋め込んでいる
+        assert 'data-tip="daily"' in template
+        assert "data-d=" in template
+        assert "data-c=" in template
+
+    def test_project_stack_has_data_attributes(self, tmp_path):
+        """stack seg / legend の各行に data-tip="proj" + data-p / data-c / data-pct が付与される。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        assert 'data-tip="proj"' in template
+        assert "data-p=" in template
+        assert "data-pct=" in template
+
+    def test_no_native_title_on_project_stack_segments(self, tmp_path):
+        """seg と legend pn の native title= は削除済み（floating tooltip に置き換え）。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        # 削除前は `<div class="seg" title=` / `<div class="pn" title=` を含んでいた
+        assert '<div class="seg" title=' not in template
+        assert "class=\"seg\" title=" not in template
+        assert "class=\"pn\" title=" not in template
+
+    def test_data_tooltip_handler_attached(self, tmp_path):
+        """delegated mouseover ハンドラで data-tip 要素を捕捉している。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        # mouseover/mousemove/mouseout のいずれか + data-tip セレクタ
+        assert "mouseover" in template or "mouseenter" in template
+        assert "mousemove" in template
+        assert "[data-tip]" in template
+
+    def test_data_tooltip_has_aria_label_for_accessibility(self, tmp_path):
+        """hover 対象要素に aria-label を付与（最低限のキーボード/SR 対応）。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        # ranking 系（既存の `title=` 付き）はスコープ外。daily / proj に aria-label を付ける
+        assert "aria-label" in template


### PR DESCRIPTION
Issue #17 対応。

## Summary
- sparkline の各 dot に hover → `{YYYY-MM-DD} / {N events}` の floating tooltip
- project stack の seg / legend に hover → `{project} / {count} / {全体比 %}` の floating tooltip
- 共有 `#dataTooltip` 要素を 1 個だけ用意して delegated handler で使い回し（DOM 増殖を避ける）
- 既存 `?` ヘルプポップアップと視覚的に差別化:
  - `.help-pop` = 説明テキスト中心 / 多行 / 最大 280px
  - `.data-tip` = 値中心 / 1〜2 行 / mono フォント / 左 3px の accent stripe（daily=peri、proj=peach）
- native `title="…"` 属性は廃止（OS tooltip 重複表示を防ぐ）
- `tabindex="0"` + `focusin/focusout` fallback でキーボード到達 & 簡易タッチ対応

## 受け入れ条件
- [x] sparkline の各 dot に hover → `{YYYY-MM-DD} / {N events}` 表示、mousemove で追従
- [x] stack seg / legend に hover → `{project} / {count} / {percent}` 表示
- [x] 既存の `?` ヘルプポップアップとは視覚的に区別がつく（accent stripe + クラス分離 + z-index 60 vs 50）
- [x] native `title="..."` 属性は削除（重複表示なし）
- [x] レスポンシブ確認: 1440 / 1280 / 375（モバイル）すべてレイアウト崩れなし
- [x] 既存テスト全件 pass（259 / 259）+ `TestGraphDataTooltip` で 8 ケース追加
- [x] live サーバー & 静的エクスポート両方で動作（共通 `dashboard/template.html` 経由）

## 実装メモ
- sparkline dot は **可視 1.7px dot + 透明な r=6 hit-area circle** の 2 層構造にして hover usability を向上。hit-area の方が `data-tip` / `data-d` / `data-c` キャリア。
- 位置追従は `position: fixed` + `transform: translate3d(...)` を mousemove で更新（reflow を避ける）。viewport 端で flip して画面外にはみ出さない。
- 同要素内の子要素間で mouseout が発火するケースは `relatedTarget contains` で吸収。
- `data-tip` 要素は `[data-tip]` セレクタで delegation。kind ごとに `dtipBuild()` で HTML を組み立て、mono の値・サンセリフのラベルでスタイリング。

## スコープ外（issue 通り fast-follow 候補）
- ranking 系 rank-row hover に失敗率 / avg duration の強調表示
- sparkline の累積ライン・ミニマップマーカー追加
- `prefers-color-scheme: light` 対応
- tooltip の上下フリップ
- タッチデバイス専用の長押し挙動（focusin で簡易対応はしているが、タッチ専用 UX は別 issue 扱い）

## Test plan
- [x] `python3 -m pytest tests/` で 259 件パス
- [x] `python3 reports/export_html.py --output /tmp/r.html` を生成、Chrome で hover 動作を視覚確認
  - daily dot (peak 198 / 04-12) → peri stripe 付き tooltip
  - project seg (hobo 1137 / 71.8%) → peach stripe 付き tooltip
  - viewport 1440 / 1280 / 375 でレイアウト維持
- [x] コンソールエラーなし（`list_console_messages` で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)