### PR TITLE
Phase B: ダッシュボードを SSE で live refresh 化 (Issue #20)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1,7 +1,9 @@
 """dashboard/server.py — ローカル HTTP サーバーでダッシュボードを提供する。"""
 import json
 import os
+import select
 import signal
+import socket
 import sys
 import threading
 import time
@@ -9,7 +11,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from subagent_metrics import aggregate_subagent_metrics, usage_invocation_events
@@ -46,8 +48,20 @@ def _resolve_idle_seconds() -> float:
         return 600.0
 
 
+def _resolve_poll_interval() -> float:
+    """`DASHBOARD_POLL_INTERVAL` 未指定 → 1.0s デフォルト、`0` → ファイル監視を無効化。"""
+    raw = os.environ.get("DASHBOARD_POLL_INTERVAL")
+    if raw is None:
+        return 1.0
+    try:
+        return float(raw)
+    except ValueError:
+        return 1.0
+
+
 PORT = _resolve_port()
 IDLE_SECONDS = _resolve_idle_seconds()
+POLL_INTERVAL = _resolve_poll_interval()
 
 TOP_N = 10
 
@@ -213,6 +227,185 @@ def render_static_html(data: dict) -> str:
 _HTML_TEMPLATE = (Path(__file__).resolve().parent / "template.html").read_text(encoding="utf-8")
 
 
+def _peer_disconnected(sock) -> bool:
+    """`sock` の対向が FIN / RST を送って切断したかを non-blocking に判定する。
+
+    SSE は server→client の単方向ストリームなので、client から read 可能になる
+    のは EOF / RST のときだけ。`select` で読み取り可能を検知し `MSG_PEEK` で覗く。
+    """
+    try:
+        readable, _, _ = select.select([sock], [], [], 0)
+    except (ValueError, OSError):
+        return True
+    if not readable:
+        return False
+    try:
+        peek = sock.recv(1, socket.MSG_PEEK)
+    except (BlockingIOError, InterruptedError):
+        return False
+    except OSError:
+        return True
+    return not peek  # b"" なら EOF
+
+
+class SSEClient:
+    """`/events` で接続中の 1 クライアントを表現する。
+
+    write は背景の broadcaster と handler 側 keepalive の両方から走るので
+    `write_lock` で直列化する。書き込み失敗を観測したら `alive` を落とし、
+    server 側の broadcast から自動で除外される。
+    """
+
+    def __init__(self, wfile):
+        self.wfile = wfile
+        self._write_lock = threading.Lock()
+        self.alive = threading.Event()
+        self.alive.set()
+
+    def send(self, payload: bytes) -> bool:
+        with self._write_lock:
+            if not self.alive.is_set():
+                return False
+            try:
+                self.wfile.write(payload)
+                self.wfile.flush()
+                return True
+            except (BrokenPipeError, ConnectionResetError, OSError):
+                self.alive.clear()
+                return False
+
+
+class _SseState:
+    """SSE クライアント集合と書き込み排他制御。
+
+    DashboardServer から SSE 配信状態を切り出してインスタンス属性数を抑える。
+    `register` / `unregister` / `count` / `broadcast` は thread-safe。
+    """
+
+    def __init__(self, keepalive: float):
+        self.clients: List[SSEClient] = []
+        self.lock = threading.Lock()
+        self.keepalive = float(keepalive)
+
+    def register(self, client: SSEClient) -> None:
+        with self.lock:
+            self.clients.append(client)
+
+    def unregister(self, client: SSEClient) -> None:
+        with self.lock:
+            try:
+                self.clients.remove(client)
+            except ValueError:
+                pass
+
+    def count(self) -> int:
+        with self.lock:
+            return len(self.clients)
+
+    def broadcast(self, payload: bytes) -> int:
+        with self.lock:
+            clients = list(self.clients)
+        sent = 0
+        dead: List[SSEClient] = []
+        for c in clients:
+            if c.send(payload):
+                sent += 1
+            else:
+                dead.append(c)
+        if dead:
+            with self.lock:
+                for c in dead:
+                    try:
+                        self.clients.remove(c)
+                    except ValueError:
+                        pass
+        return sent
+
+
+class _FileWatcher:
+    """`(inode, size, mtime)` ベースの軽量ファイル監視。
+
+    GB 級でも内容を読まずに変化を検知する（受け入れ条件）。
+    `interval <= 0` で無効化、`path` 不在は `None` 署名扱いで一度も変更検知しない。
+    """
+
+    def __init__(self, path: Optional[Path], interval: float):
+        self.path: Optional[Path] = Path(path) if path is not None else None
+        self.interval = float(interval)
+        self.thread: Optional[threading.Thread] = None
+
+    def start(self, stop_event: threading.Event, on_change: Callable[[], None]) -> None:
+        if self.interval <= 0:
+            return
+        self.thread = threading.Thread(
+            target=self._loop, args=(stop_event, on_change),
+            daemon=True, name="DashboardFileWatcher",
+        )
+        self.thread.start()
+
+    def _loop(self, stop_event: threading.Event, on_change: Callable[[], None]) -> None:
+        last = self._signature()
+        while not stop_event.wait(self.interval):
+            cur = self._signature()
+            if cur != last:
+                last = cur
+                on_change()
+
+    def _signature(self):
+        if self.path is None:
+            return None
+        try:
+            st = self.path.stat()
+        except (FileNotFoundError, OSError):
+            return None
+        return (st.st_ino, st.st_size, st.st_mtime_ns)
+
+
+class _IdleTracker:
+    """idle カウンタと watchdog スレッド。
+
+    `seconds <= 0` で watchdog 無効。SSE 接続中は `sse_count_fn() > 0` が
+    返る前提で外部から touch を継続発火させ、idle 進行を凍結する。
+    """
+
+    def __init__(self, seconds: float):
+        self.seconds = float(seconds)
+        self.activity_lock = threading.Lock()
+        self.last_activity = time.monotonic()
+        self.thread: Optional[threading.Thread] = None
+
+    def touch(self) -> None:
+        with self.activity_lock:
+            self.last_activity = time.monotonic()
+
+    def idle_for(self) -> float:
+        with self.activity_lock:
+            return time.monotonic() - self.last_activity
+
+    def start(self, stop_event: threading.Event,
+              sse_count_fn: Callable[[], int],
+              on_idle: Callable[[], None]) -> None:
+        if self.seconds <= 0:
+            return
+        check_interval = max(0.05, min(self.seconds / 2.0, 1.0))
+        self.thread = threading.Thread(
+            target=self._loop, args=(stop_event, sse_count_fn, on_idle, check_interval),
+            daemon=True, name="DashboardIdleWatchdog",
+        )
+        self.thread.start()
+
+    def _loop(self, stop_event, sse_count_fn, on_idle, check_interval) -> None:
+        while not stop_event.wait(check_interval):
+            # SSE クライアントが 1 つでもあれば idle 進行を凍結（受け入れ条件）。
+            # touch() で last_activity を更新するので idle_for() も同時にリセットされる。
+            if sse_count_fn() > 0:
+                self.touch()
+                continue
+            if self.idle_for() > self.seconds:
+                on_idle()
+                return
+
+
 class DashboardHandler(BaseHTTPRequestHandler):
     def do_GET(self):
         # idle カウンタリセット (DashboardServer 利用時のみ; 旧 HTTPServer 直叩きテスト互換のため defensive)
@@ -223,6 +416,8 @@ class DashboardHandler(BaseHTTPRequestHandler):
             self._serve_api()
         elif self.path == "/healthz":
             self._serve_healthz()
+        elif self.path == "/events":
+            self._serve_events()
         else:
             self._serve_html()
 
@@ -254,6 +449,61 @@ class DashboardHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _serve_events(self):
+        """`/events` SSE エンドポイント。サーバー shutdown / クライアント切断まで block する。
+
+        - 初回に comment 行を flush して EventSource.onopen を即発火
+        - 登録した `SSEClient` は usage.jsonl 変更時に server 側からブロードキャストされる
+        - keepalive ごとに idle カウンタを touch（SSE 接続中に idle で落とさないため）
+        """
+        register = getattr(self.server, "register_sse_client", None)
+        if register is None:
+            # DashboardServer 以外で叩かれたら 501 (旧 HTTPServer 直叩きテスト互換)
+            self.send_error(501, "SSE not supported on this server")
+            return
+
+        # この接続では HTTP keep-alive で次のリクエストを処理しない
+        self.close_connection = True
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        # nginx などのバッファリングを抑止 (localhost 用途では実害無いが慣例)
+        self.send_header("X-Accel-Buffering", "no")
+        self.end_headers()
+
+        client = SSEClient(self.wfile)
+        if not client.send(b": connected\n\n"):
+            return
+        register(client)
+
+        unregister = getattr(self.server, "unregister_sse_client", None)
+        stop_event = getattr(self.server, "_stop_event", None)
+        touch = getattr(self.server, "touch", None)
+        # SSE keepalive 周期 (秒)。テストでは短く、本番ではデフォ 15s。
+        keepalive = getattr(self.server, "sse_keepalive", 15.0)
+        sock = self.connection  # 切断 (FIN/RST) 検出用
+
+        try:
+            # サーバー停止 / クライアント切断まで long-poll
+            while client.alive.is_set():
+                if stop_event is not None and stop_event.wait(keepalive):
+                    break
+                if stop_event is None:
+                    time.sleep(keepalive)
+                if not client.alive.is_set():
+                    break
+                if _peer_disconnected(sock):
+                    break
+                if not client.send(b": keepalive\n\n"):
+                    break
+                if callable(touch):
+                    touch()
+        finally:
+            if callable(unregister):
+                unregister(client)
+
     def log_message(self, fmt, *args):
         pass
 
@@ -263,56 +513,92 @@ class DashboardServer(ThreadingHTTPServer):
 
     - ThreadingHTTPServer で並行リクエスト処理
     - `idle_seconds > 0` で idle watchdog を起動し、最終リクエストから
-      `idle_seconds` 経過で graceful shutdown
+      `idle_seconds` 経過で graceful shutdown（SSE 接続が 1 つ以上ある間は
+      idle カウンタを touch して凍結）
+    - `poll_interval > 0` で usage.jsonl の (inode, size, mtime) を監視し、
+      変化検知時に SSE クライアントへ `data: refresh\\n\\n` をブロードキャスト
     - `touch()` / `idle_for()` でハンドラから idle カウンタを操作
     """
 
     daemon_threads = True
     allow_reuse_address = True
 
-    def __init__(self, server_address, RequestHandlerClass, *, idle_seconds: float = 0.0):
+    def __init__(self, server_address, RequestHandlerClass, *,
+                 idle_seconds: float = 0.0,
+                 poll_interval: float = 0.0,
+                 usage_jsonl_path: Optional[Path] = None,
+                 sse_keepalive: float = 15.0):
         # bind/activate 失敗時、親 TCPServer.__init__ が `except: self.server_close()` で
         # 我々の override (`_stop_event.set()` を触る) を呼ぶ。属性が無いと AttributeError で
         # 本来の OSError をマスクするため、必ず super().__init__() より前に初期化する。
         self._stop_event = threading.Event()
-        self._activity_lock = threading.Lock()
-        self._last_activity = time.monotonic()
-        self._watchdog_thread: Optional[threading.Thread] = None
-        self.idle_seconds = float(idle_seconds)
+        self._idle = _IdleTracker(idle_seconds)
+        self._sse = _SseState(keepalive=sse_keepalive)
+        self._watcher = _FileWatcher(path=usage_jsonl_path, interval=poll_interval)
         self.started_at = _now_iso()
         super().__init__(server_address, RequestHandlerClass)
-        if self.idle_seconds > 0:
-            self._start_watchdog()
+        self._idle.start(
+            stop_event=self._stop_event,
+            sse_count_fn=self._sse.count,
+            on_idle=self._initiate_shutdown,
+        )
+        self._watcher.start(
+            stop_event=self._stop_event,
+            on_change=lambda: self._sse.broadcast(b"data: refresh\n\n"),
+        )
+
+    # --- public な構成値 (handler / テスト互換のため property で公開) -----
+
+    @property
+    def idle_seconds(self) -> float:
+        return self._idle.seconds
+
+    @property
+    def poll_interval(self) -> float:
+        return self._watcher.interval
+
+    @property
+    def usage_jsonl_path(self) -> Optional[Path]:
+        return self._watcher.path
+
+    @property
+    def sse_keepalive(self) -> float:
+        return self._sse.keepalive
+
+    # --- idle カウンタ -------------------------------------------------
 
     def touch(self) -> None:
-        with self._activity_lock:
-            self._last_activity = time.monotonic()
+        self._idle.touch()
 
     def idle_for(self) -> float:
-        with self._activity_lock:
-            return time.monotonic() - self._last_activity
+        return self._idle.idle_for()
 
-    def _start_watchdog(self) -> None:
-        check_interval = max(0.05, min(self.idle_seconds / 2.0, 1.0))
-        self._watchdog_thread = threading.Thread(
-            target=self._watchdog_loop,
-            args=(check_interval,),
-            daemon=True,
-            name="DashboardIdleWatchdog",
-        )
-        self._watchdog_thread.start()
+    # --- SSE 配信 -------------------------------------------------------
 
-    def _watchdog_loop(self, check_interval: float) -> None:
-        # method スコープで定義しないと `super()` の zero-arg 形式が成立しない
-        # (inner function だと __class__ closure はあっても self の暗黙参照が解けず RuntimeError)。
-        while not self._stop_event.wait(check_interval):
-            if self.idle_for() > self.idle_seconds:
-                # shutdown は serve_forever が exit するまでブロックするので別スレで叩く
-                threading.Thread(target=super().shutdown, daemon=True).start()
-                return
+    def register_sse_client(self, client: SSEClient) -> None:
+        self._sse.register(client)
+
+    def unregister_sse_client(self, client: SSEClient) -> None:
+        self._sse.unregister(client)
+
+    def sse_client_count(self) -> int:
+        return self._sse.count()
+
+    def broadcast_sse(self, payload: bytes) -> int:
+        return self._sse.broadcast(payload)
+
+    # --- ライフサイクル -------------------------------------------------
+
+    def _initiate_shutdown(self) -> None:
+        # serve_forever が exit するまで shutdown はブロックするので別スレで叩く。
+        # ThreadingHTTPServer.shutdown を直接参照することで、override 越しの
+        # 自己再帰 (shutdown → _stop_event.set → 既に set 済み → super().shutdown) を回避。
+        threading.Thread(
+            target=ThreadingHTTPServer.shutdown, args=(self,), daemon=True,
+        ).start()
 
     def shutdown(self) -> None:
-        # 外部 / 内部いずれの shutdown 経路でも watchdog ループを止める
+        # 外部 / 内部いずれの shutdown 経路でも watchdog / watcher ループを止める
         self._stop_event.set()
         super().shutdown()
 
@@ -326,12 +612,23 @@ def create_server(
     idle_seconds: float = 0.0,
     handler_cls=None,
     host: str = "localhost",
+    poll_interval: float = 0.0,
+    usage_jsonl_path: Optional[Path] = None,
+    sse_keepalive: float = 15.0,
 ) -> DashboardServer:
-    """Phase A 仕様の DashboardServer を返す（serve_forever は呼び出し側）。"""
+    """Phase A/B 仕様の DashboardServer を返す（serve_forever は呼び出し側）。
+
+    `poll_interval > 0` で usage.jsonl の変化監視を有効化（Phase B SSE）。
+    `usage_jsonl_path` 未指定時はモジュール変数 `DATA_FILE` を採用。
+    `sse_keepalive` は SSE keepalive ping 周期（秒）。テストでは短く設定。
+    """
     return DashboardServer(
         (host, port),
         handler_cls or DashboardHandler,
         idle_seconds=idle_seconds,
+        poll_interval=poll_interval,
+        usage_jsonl_path=usage_jsonl_path if usage_jsonl_path is not None else DATA_FILE,
+        sse_keepalive=sse_keepalive,
     )
 
 
@@ -419,7 +716,11 @@ def run(
 
 
 def main() -> None:
-    server = create_server(port=PORT, idle_seconds=IDLE_SECONDS)
+    server = create_server(
+        port=PORT,
+        idle_seconds=IDLE_SECONDS,
+        poll_interval=POLL_INTERVAL,
+    )
     run(server, SERVER_JSON_PATH)
 
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -11,7 +11,7 @@ from collections import Counter
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from subagent_metrics import aggregate_subagent_metrics, usage_invocation_events
@@ -291,7 +291,7 @@ class _SseState:
     """
 
     def __init__(self, keepalive: float):
-        self.clients: List[SSEClient] = []
+        self.clients: list[SSEClient] = []
         self.lock = threading.Lock()
         self.keepalive = float(keepalive)
 
@@ -314,7 +314,7 @@ class _SseState:
         with self.lock:
             clients = list(self.clients)
         sent = 0
-        dead: List[SSEClient] = []
+        dead: list[SSEClient] = []
         for c in clients:
             if c.send(payload):
                 sent += 1
@@ -511,7 +511,10 @@ class DashboardHandler(BaseHTTPRequestHandler):
                 if _peer_disconnected(sock):
                     break
                 now = time.monotonic()
-                if now - last_keepalive >= keepalive:
+                # keepalive=0 は「無効化」の意図で渡される想定。`now - last_keepalive >= 0` が
+                # 常に True になって毎 tick で comment が飛ぶのを防ぐため、下限 0 を明示的に
+                # 含める chained comparison でガード。
+                if 0 < keepalive <= now - last_keepalive:
                     if not client.send(b": keepalive\n\n"):
                         break
                     last_keepalive = now

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -227,6 +227,14 @@ def render_static_html(data: dict) -> str:
 _HTML_TEMPLATE = (Path(__file__).resolve().parent / "template.html").read_text(encoding="utf-8")
 
 
+# SSE handler の peer-disconnect チェック周期 (秒)。
+# `sse_keepalive` が長い (本番 15s) ときも、この周期で peer 検知を回すことで
+# ブラウザを閉じた直後に handler が抜け、idle watchdog が再開できる。
+# テストの場合 sse_keepalive をこの値より短くすれば peer check も追従する
+# (ループは min(keepalive, _SSE_PEER_CHECK_INTERVAL) 周期で回る)。
+_SSE_PEER_CHECK_INTERVAL = 1.0
+
+
 def _peer_disconnected(sock) -> bool:
     """`sock` の対向が FIN / RST を送って切断したかを non-blocking に判定する。
 
@@ -483,23 +491,32 @@ class DashboardHandler(BaseHTTPRequestHandler):
         touch = getattr(self.server, "touch", None)
         # SSE keepalive 周期 (秒)。テストでは短く、本番ではデフォ 15s。
         keepalive = getattr(self.server, "sse_keepalive", 15.0)
+        # peer check はこの値以下の周期で回す (codex Finding 2 対策)。
+        # keepalive がこれより短ければ keepalive 周期に揃える。
+        tick = min(keepalive, _SSE_PEER_CHECK_INTERVAL) if keepalive > 0 else _SSE_PEER_CHECK_INTERVAL
         sock = self.connection  # 切断 (FIN/RST) 検出用
+        last_keepalive = time.monotonic()
 
         try:
-            # サーバー停止 / クライアント切断まで long-poll
+            # サーバー停止 / クライアント切断まで long-poll。
+            # tick (≤1s) 周期で peer 切断を検知 → handler が抜けて unregister
+            # → idle watchdog が再開できる。keepalive 送信は経過時間ベース。
             while client.alive.is_set():
-                if stop_event is not None and stop_event.wait(keepalive):
+                if stop_event is not None and stop_event.wait(tick):
                     break
                 if stop_event is None:
-                    time.sleep(keepalive)
+                    time.sleep(tick)
                 if not client.alive.is_set():
                     break
                 if _peer_disconnected(sock):
                     break
-                if not client.send(b": keepalive\n\n"):
-                    break
-                if callable(touch):
-                    touch()
+                now = time.monotonic()
+                if now - last_keepalive >= keepalive:
+                    if not client.send(b": keepalive\n\n"):
+                        break
+                    last_keepalive = now
+                    if callable(touch):
+                        touch()
         finally:
             if callable(unregister):
                 unregister(client)

--- a/dashboard/template.html
+++ b/dashboard/template.html
@@ -134,6 +134,13 @@
     color: var(--coral);
     border-color: var(--coral-soft);
   }
+  .conn-status[data-state="static"] {
+    color: var(--ink-faint);
+    border-color: var(--line);
+  }
+  .conn-status[data-state="static"]::before {
+    display: none;
+  }
   @keyframes conn-pulse {
     0%   { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
     70%  { box-shadow: 0 0 0 6px transparent; opacity: 0.85; }
@@ -645,6 +652,7 @@
     online:    '● 接続中',
     reconnect: '○ 再接続中',
     offline:   '× 停止中',
+    static:    '— 静的レポート',
   };
   function setConnStatus(state) {
     const el = document.getElementById('connStatus');
@@ -852,7 +860,10 @@
 
   // ---- 初回描画 + EventSource (live refresh) ----
   await loadAndRender();
-  if (typeof window.__DATA__ === 'undefined' && typeof EventSource !== 'undefined') {
+  if (typeof window.__DATA__ !== 'undefined') {
+    // 静的 export 経路では EventSource を起動せず、バッジを「静的レポート」表示に固定
+    setConnStatus('static');
+  } else if (typeof EventSource !== 'undefined') {
     setConnStatus('reconnect');
     let offlineTimer = null;
     let firstError = null;

--- a/dashboard/template.html
+++ b/dashboard/template.html
@@ -96,6 +96,50 @@
   .header .meta .k { display: inline-block; min-width: 78px; color: var(--ink-faint); }
   .header .meta .v { color: var(--ink-soft); font-family: var(--ff-mono); }
 
+  /* ---------- live connection badge ---------- */
+  .conn-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 3px 10px;
+    margin-bottom: 6px;
+    font-family: var(--ff-mono);
+    font-size: 11px;
+    border-radius: var(--r-pill);
+    border: 1px solid var(--line);
+    background: var(--bg-panel);
+    color: var(--ink-faint);
+    transition: color 180ms ease, border-color 180ms ease, background 180ms ease;
+  }
+  .conn-status::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+    box-shadow: 0 0 0 0 currentColor;
+  }
+  .conn-status[data-state="online"] {
+    color: var(--mint);
+    border-color: var(--mint-soft);
+  }
+  .conn-status[data-state="online"]::before {
+    animation: conn-pulse 1.6s ease-out infinite;
+  }
+  .conn-status[data-state="reconnect"] {
+    color: var(--peach);
+    border-color: var(--peach-soft);
+  }
+  .conn-status[data-state="offline"] {
+    color: var(--coral);
+    border-color: var(--coral-soft);
+  }
+  @keyframes conn-pulse {
+    0%   { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+    70%  { box-shadow: 0 0 0 6px transparent; opacity: 0.85; }
+    100% { box-shadow: 0 0 0 0 transparent; opacity: 1; }
+  }
+
   /* ---------- KPI ---------- */
   .kpi-row {
     display: grid;
@@ -495,6 +539,7 @@
         </div>
       </div>
       <div class="meta">
+        <div><span class="conn-status" id="connStatus" data-state="reconnect" role="status" aria-live="polite">○ 接続準備中</span></div>
         <div><span class="k">最終更新</span><span class="v" id="lastRx">—</span></div>
         <div><span class="k">セッション</span><span class="v" id="sessVal">—</span></div>
       </div>
@@ -593,11 +638,27 @@
   function fmtN(n){ return Number(n).toLocaleString('en-US'); }
   function pad(s,n){ s=String(s); return s.length>=n?s:('0'.repeat(n-s.length)+s); }
 
+  // ============================================================
+  //  Live connection badge (Phase B)
+  // ============================================================
+  const STATUS_LABEL = {
+    online:    '● 接続中',
+    reconnect: '○ 再接続中',
+    offline:   '× 停止中',
+  };
+  function setConnStatus(state) {
+    const el = document.getElementById('connStatus');
+    if (!el) return;
+    el.dataset.state = state;
+    el.textContent = STATUS_LABEL[state] || '';
+  }
+
+  async function loadAndRender() {
   let data;
   try {
     data = (typeof window.__DATA__ !== 'undefined')
       ? window.__DATA__
-      : await (await fetch('/api/data')).json();
+      : await (await fetch('/api/data', { cache: 'no-store' })).json();
   } catch (e) {
     console.error('データの読み込みに失敗しました:', e);
     return;
@@ -787,6 +848,41 @@
     '</div>';
   }).join('');
   document.getElementById('projSub').textContent = projs.length + ' projects · Σ ' + fmtN(projTotal);
+  } // end loadAndRender
+
+  // ---- 初回描画 + EventSource (live refresh) ----
+  await loadAndRender();
+  if (typeof window.__DATA__ === 'undefined' && typeof EventSource !== 'undefined') {
+    setConnStatus('reconnect');
+    let offlineTimer = null;
+    let firstError = null;
+    const OFFLINE_AFTER_MS = 30000;
+    const es = new EventSource('/events');
+    es.addEventListener('open', () => {
+      setConnStatus('online');
+      firstError = null;
+      if (offlineTimer) { clearTimeout(offlineTimer); offlineTimer = null; }
+    });
+    es.addEventListener('error', () => {
+      // EventSource は readyState=CONNECTING 中に自動再接続を試みる
+      if (es.readyState === EventSource.CONNECTING) {
+        setConnStatus('reconnect');
+        if (firstError === null) firstError = Date.now();
+        if (!offlineTimer) {
+          const remaining = Math.max(0, OFFLINE_AFTER_MS - (Date.now() - firstError));
+          offlineTimer = setTimeout(() => setConnStatus('offline'), remaining);
+        }
+      } else {
+        setConnStatus('offline');
+      }
+    });
+    es.addEventListener('message', (ev) => {
+      // payload は "refresh" のみだが拡張余地として弁別
+      if (typeof ev.data === 'string' && ev.data.indexOf('refresh') !== -1) {
+        loadAndRender().catch(err => console.error('refresh 失敗', err));
+      }
+    });
+  }
 
   // ============================================================
   //  Help popover behavior

--- a/tests/test_dashboard_sse.py
+++ b/tests/test_dashboard_sse.py
@@ -23,6 +23,21 @@ def _start_server_in_thread(server) -> threading.Thread:
     return t
 
 
+def _wait_for_sse_clients(server, expected: int, timeout: float = 2.0) -> None:
+    """SSE クライアント数が `expected` に達するまで polling する deterministic な待機。
+
+    `time.sleep(0.3)` で「だいたい登録されてるはず」を待つと CI 高負荷時に flaky になる。
+    `sse_client_count()` を 20ms 刻みで読みに行く方が時間も短く確実。
+    """
+    deadline = time.monotonic() + timeout
+    while server.sse_client_count() < expected:
+        if time.monotonic() > deadline:
+            raise AssertionError(
+                f"SSE client registration timeout (got {server.sse_client_count()}, expected >= {expected})"
+            )
+        time.sleep(0.02)
+
+
 @dataclass
 class SseConn:
     """raw socket ベースの SSE クライアント。
@@ -43,8 +58,10 @@ class SseConn:
             return b""
 
     def disconnect(self) -> None:
+        # SHUT_WR でクライアント側送信のみ閉じて FIN を即送る。実機ブラウザの close
+        # に近いセマンティクス（read は OS バッファに残った data を吸い切れる）。
         try:
-            self.sock.shutdown(socket.SHUT_RDWR)
+            self.sock.shutdown(socket.SHUT_WR)
         except OSError:
             pass
         try:
@@ -133,8 +150,8 @@ class TestRefreshBroadcast:
             c = _open_sse("127.0.0.1", port)
             # 接続確立 (initial comment) を捨てる
             c.read_some(max_bytes=128, timeout=2.0)
-            # 接続が server に登録されるまで少し待つ
-            time.sleep(0.3)
+            # 接続が server に登録されるまで polling で待つ (CI flake 防止)
+            _wait_for_sse_clients(server, expected=1)
             # usage.jsonl を append 改変 → mtime/size が変わる
             with usage.open("a", encoding="utf-8") as f:
                 f.write(json.dumps({
@@ -165,11 +182,12 @@ class TestRefreshBroadcast:
             b = _open_sse("127.0.0.1", port)
             a.read_some(128, 1.0)
             b.read_some(128, 1.0)
-            time.sleep(0.3)
+            _wait_for_sse_clients(server, expected=2)
             # A を強制切断 (FIN を即送る)
             a.disconnect()
             a = None
-            time.sleep(0.2)
+            # A の unregister が完了するまで待つ (handler の peer-check 周期 ≤ 1s)
+            _wait_for_sse_clients(server, expected=1, timeout=2.5)
             # ファイル変更
             with usage.open("a", encoding="utf-8") as f:
                 f.write("{}\n")

--- a/tests/test_dashboard_sse.py
+++ b/tests/test_dashboard_sse.py
@@ -1,0 +1,259 @@
+"""tests/test_dashboard_sse.py — Issue #20 Phase B: ライブダッシュボードの SSE 配信テスト。
+
+`tests/test_dashboard_live.py` (Phase A) と同じく `load_dashboard_module` を再利用。
+Phase B のスコープ:
+- `/events` エンドポイント (text/event-stream)
+- usage.jsonl の (inode, size, mtime) を 1 秒間隔でポーリングし、変化検知時に
+  全 SSE クライアントへ `data: refresh\\n\\n` をブロードキャスト
+- SSE 接続中は idle watchdog がサーバーを終了させない
+"""
+# pylint: disable=line-too-long
+import json
+import socket
+import threading
+import time
+from dataclasses import dataclass
+
+from test_dashboard import load_dashboard_module
+
+
+def _start_server_in_thread(server) -> threading.Thread:
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return t
+
+
+@dataclass
+class SseConn:
+    """raw socket ベースの SSE クライアント。
+
+    `http.client.HTTPConnection.close()` は macOS で FIN 送信が遅延するケースがあり、
+    サーバー側の peer-disconnect 検知テストが動かない。raw socket + SHUT_WR で
+    即座に FIN を送るほうが実機ブラウザ close の挙動に近い。
+    """
+    sock: socket.socket
+    status: int
+    headers: dict
+
+    def read_some(self, max_bytes: int = 256, timeout: float = 2.0) -> bytes:
+        self.sock.settimeout(timeout)
+        try:
+            return self.sock.recv(max_bytes)
+        except (socket.timeout, OSError):
+            return b""
+
+    def disconnect(self) -> None:
+        try:
+            self.sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        try:
+            self.sock.close()
+        except OSError:
+            pass
+
+
+def _open_sse(host: str, port: int, timeout: float = 3.0) -> SseConn:
+    """`/events` を raw socket で開き、レスポンスヘッダまで読んだ SseConn を返す。"""
+    sock = socket.create_connection((host, port), timeout=timeout)
+    sock.sendall(f"GET /events HTTP/1.1\r\nHost: {host}\r\nAccept: text/event-stream\r\n\r\n".encode())
+    f = sock.makefile("rb", buffering=0)
+    status_line = f.readline().rstrip(b"\r\n")
+    parts = status_line.split(b" ", 2)
+    status = int(parts[1]) if len(parts) >= 2 else 0
+    headers = {}
+    while True:
+        line = f.readline()
+        if line in (b"\r\n", b"\n", b""):
+            break
+        k, _, v = line.rstrip(b"\r\n").partition(b":")
+        headers[k.decode("latin1").lower()] = v.strip().decode("latin1")
+    return SseConn(sock=sock, status=status, headers=headers)
+
+
+class TestEventsEndpoint:
+    """Phase B: `/events` が SSE ストリームを返す。"""
+
+    def test_events_returns_text_event_stream_headers(self, tmp_path):
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        server = mod.create_server(port=0, idle_seconds=0)
+        port = server.server_address[1]
+        _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            assert c.status == 200
+            ctype = c.headers.get("content-type", "")
+            assert "text/event-stream" in ctype, f"Content-Type: {ctype!r}"
+            cache_ctl = c.headers.get("cache-control", "")
+            assert "no-cache" in cache_ctl, f"Cache-Control: {cache_ctl!r}"
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.shutdown()
+            server.server_close()
+
+    def test_events_sends_initial_comment_ping(self, tmp_path):
+        """サーバー → クライアントの最初のバイトとして comment 行 (`:` 始まり) を flush。
+
+        - ブラウザ EventSource の onopen を即座に発火させる
+        - SSE 仕様で comment は `event` を発火しないので無害
+        """
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        server = mod.create_server(port=0, idle_seconds=0)
+        port = server.server_address[1]
+        _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            chunk = c.read_some(max_bytes=128, timeout=2.0)
+            assert chunk.startswith(b":"), f"先頭が comment 行で始まっていない: {chunk!r}"
+            # SSE のメッセージ区切り `\n\n` で終わっている
+            assert b"\n\n" in chunk, f"メッセージ区切りが無い: {chunk!r}"
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.shutdown()
+            server.server_close()
+
+
+class TestRefreshBroadcast:
+    """Phase B: usage.jsonl 変更を検知し全 SSE クライアントへ refresh を配信する。"""
+
+    def test_usage_jsonl_change_broadcasts_refresh(self, tmp_path):
+        usage = tmp_path / "usage.jsonl"
+        usage.write_text("", encoding="utf-8")  # 空ファイルから開始
+        mod = load_dashboard_module(usage)
+        # poll_interval を短くしてテストを早める
+        server = mod.create_server(port=0, idle_seconds=0, poll_interval=0.1)
+        port = server.server_address[1]
+        _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            # 接続確立 (initial comment) を捨てる
+            c.read_some(max_bytes=128, timeout=2.0)
+            # 接続が server に登録されるまで少し待つ
+            time.sleep(0.3)
+            # usage.jsonl を append 改変 → mtime/size が変わる
+            with usage.open("a", encoding="utf-8") as f:
+                f.write(json.dumps({
+                    "event_type": "skill_tool", "skill": "x", "args": "",
+                    "project": "p", "session_id": "s",
+                    "timestamp": "2026-04-27T00:00:00+00:00",
+                }) + "\n")
+            # poll 間隔 + 配信遅延を見込んで 2s deadline で読む
+            data = c.read_some(max_bytes=256, timeout=2.0)
+            assert b"data: refresh" in data, f"refresh が届かなかった: {data!r}"
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.shutdown()
+            server.server_close()
+
+    def test_broadcast_survives_single_client_disconnect(self, tmp_path):
+        """1 クライアントが切断しても、生きている他クライアントへの配信は継続する。"""
+        usage = tmp_path / "usage.jsonl"
+        usage.write_text("", encoding="utf-8")
+        mod = load_dashboard_module(usage)
+        server = mod.create_server(port=0, idle_seconds=0, poll_interval=0.1)
+        port = server.server_address[1]
+        _start_server_in_thread(server)
+        a = b = None
+        try:
+            a = _open_sse("127.0.0.1", port)
+            b = _open_sse("127.0.0.1", port)
+            a.read_some(128, 1.0)
+            b.read_some(128, 1.0)
+            time.sleep(0.3)
+            # A を強制切断 (FIN を即送る)
+            a.disconnect()
+            a = None
+            time.sleep(0.2)
+            # ファイル変更
+            with usage.open("a", encoding="utf-8") as f:
+                f.write("{}\n")
+            data_b = b.read_some(256, 2.0)
+            assert b"data: refresh" in data_b, f"B に refresh が届かなかった: {data_b!r}"
+        finally:
+            for c in (a, b):
+                if c is not None:
+                    c.disconnect()
+            server.shutdown()
+            server.server_close()
+
+    def test_no_refresh_when_file_unchanged(self, tmp_path):
+        """ファイル変更が無いときは data: refresh を送らない（ping/comment は許容）。"""
+        usage = tmp_path / "usage.jsonl"
+        usage.write_text("", encoding="utf-8")
+        mod = load_dashboard_module(usage)
+        server = mod.create_server(port=0, idle_seconds=0, poll_interval=0.1)
+        port = server.server_address[1]
+        _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            c.read_some(128, 1.0)
+            time.sleep(0.5)  # poll が複数回回るのに十分
+            extra = c.read_some(256, 0.3)
+            assert b"data: refresh" not in extra, f"変更なしで refresh が届いた: {extra!r}"
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.shutdown()
+            server.server_close()
+
+
+class TestSseIdleCounter:
+    """Phase B: SSE 接続中は idle watchdog でサーバーを終了させない。"""
+
+    def test_sse_connection_keeps_server_alive_past_idle_seconds(self, tmp_path):
+        usage = tmp_path / "usage.jsonl"
+        usage.write_text("", encoding="utf-8")
+        mod = load_dashboard_module(usage)
+        # idle_seconds を非常に短く: 0.2s。SSE 接続があれば落ちない
+        server = mod.create_server(port=0, idle_seconds=0.2, poll_interval=0.1)
+        port = server.server_address[1]
+        t = _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            c.read_some(128, 1.0)
+            # idle_seconds の 4 倍待ってもまだ alive
+            time.sleep(0.8)
+            assert t.is_alive(), "SSE 接続中なのに idle watchdog で終了した"
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2.0)
+
+    def test_sse_disconnect_lets_idle_shutdown_resume(self, tmp_path):
+        """SSE クライアントが全て切断した後は idle 経過で graceful shutdown する。
+
+        keepalive を短く (50ms) して切断検知を早める（実機 default は 15s）。
+        """
+        usage = tmp_path / "usage.jsonl"
+        usage.write_text("", encoding="utf-8")
+        mod = load_dashboard_module(usage)
+        server = mod.create_server(
+            port=0, idle_seconds=0.3, poll_interval=0.1, sse_keepalive=0.05,
+        )
+        port = server.server_address[1]
+        t = _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            c.read_some(128, 1.0)
+            time.sleep(0.2)
+            # 切断 (FIN を即送る)
+            c.disconnect()
+            c = None
+            # idle (0.3) + watchdog 周期 + keepalive 検知の余裕を見て待つ
+            t.join(timeout=3.0)
+            assert not t.is_alive(), "SSE 切断後も watchdog で終了しなかった"
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.server_close()

--- a/tests/test_dashboard_sse.py
+++ b/tests/test_dashboard_sse.py
@@ -229,6 +229,39 @@ class TestSseIdleCounter:
             server.server_close()
             t.join(timeout=2.0)
 
+    def test_sse_disconnect_detected_within_one_second_at_default_keepalive(self, tmp_path):
+        """keepalive=15s の本番デフォルトでも切断検知は ~1s 以内に動く (codex Finding 2 回帰)。
+
+        旧実装は `stop_event.wait(keepalive)` でブロックしていたため keepalive=15s だと
+        ブラウザ切断後 最大 15s 間 idle カウンタが凍結し、`DASHBOARD_IDLE_SECONDS` < 15s
+        の設定が無効化されていた。peer check を 1s 周期に分離した修正の回帰テスト。
+        """
+        usage = tmp_path / "usage.jsonl"
+        usage.write_text("", encoding="utf-8")
+        mod = load_dashboard_module(usage)
+        # keepalive は本番デフォルト相当 (15.0)。idle 0.3s で切断 → 3s 以内に exit すべき
+        server = mod.create_server(
+            port=0, idle_seconds=0.3, poll_interval=0.0, sse_keepalive=15.0,
+        )
+        port = server.server_address[1]
+        t = _start_server_in_thread(server)
+        c = None
+        try:
+            c = _open_sse("127.0.0.1", port)
+            c.read_some(128, 1.0)
+            time.sleep(0.2)
+            c.disconnect()
+            c = None
+            # peer-check 1s + idle 0.3s + watchdog 周期 余裕で 3s 以内
+            t.join(timeout=3.0)
+            assert not t.is_alive(), (
+                "keepalive=15s のとき切断検知が 3s 以内に動くべき (Finding 2 回帰)"
+            )
+        finally:
+            if c is not None:
+                c.disconnect()
+            server.server_close()
+
     def test_sse_disconnect_lets_idle_shutdown_resume(self, tmp_path):
         """SSE クライアントが全て切断した後は idle 経過で graceful shutdown する。
 

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -83,14 +83,14 @@ class TestHtmlTemplateFallback:
     def test_template_has_dynamic_fallback_fetch(self):
         """動的ダッシュボードとしても機能するよう fetch フォールバックが残っていることを確認。"""
         m = self._import()
-        assert "fetch('/api/data')" in m._HTML_TEMPLATE
+        assert "fetch('/api/data'" in m._HTML_TEMPLATE
 
     def test_template_prefers_window_data_over_fetch(self):
         """window.__DATA__ が fetch より先に参照されることを確認。"""
         m = self._import()
         tmpl = m._HTML_TEMPLATE
         window_data_pos = tmpl.index("window.__DATA__")
-        fetch_pos = tmpl.index("fetch('/api/data')")
+        fetch_pos = tmpl.index("fetch('/api/data'")
         assert window_data_pos < fetch_pos
 
 

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -93,6 +93,20 @@ class TestHtmlTemplateFallback:
         fetch_pos = tmpl.index("fetch('/api/data'")
         assert window_data_pos < fetch_pos
 
+    def test_template_uses_static_badge_for_window_data(self):
+        """codex Finding 1 回帰: 静的 export では接続バッジを 'static' state に固定する。
+
+        修正前は EventSource 結線が `window.__DATA__` 経路で丸ごとスキップされ、
+        初期 'reconnect' 表示のまま固まっていた。
+        """
+        m = self._import()
+        tmpl = m._HTML_TEMPLATE
+        # static 用 CSS が定義されている
+        assert '[data-state="static"]' in tmpl
+        # static 用ラベルと setConnStatus('static') 呼び出しが入っている
+        assert "static:" in tmpl
+        assert "setConnStatus('static')" in tmpl
+
 
 # ---------------------------------------------------------------------------
 # reports/export_html.py の main() のテスト


### PR DESCRIPTION
## Summary

Issue #14 ライブダッシュボード化の **Phase B**。Phase A (#22) で整えた `ThreadingHTTPServer + idle watchdog + /healthz` の上に SSE による push 配信を載せ、`usage.jsonl` 更新を 1 秒以内にブラウザへ反映する。

base branch は引き続き Phase A と同じ統合用 \`feature/14-live-dashboard\` を指す（stacked PR）。launch_dashboard hook (Phase C / #21) は後続 PR で。

## 実装

### サーバー

- **\`/events\` SSE エンドポイント**: \`text/event-stream\` で long-poll、初回に comment 行 (\`: connected\\n\\n\`) を flush して \`EventSource.onopen\` を即発火。\`X-Accel-Buffering: no\` で proxy バッファ抑止
- **usage.jsonl ポーリング**: \`(inode, size, mtime)\` を 1s 間隔で stat 比較。GB 級でも内容は読まない。変化検知時に全 SSE クライアントへ \`data: refresh\\n\\n\` をブロードキャスト
- **dead-reap**: 1 client が \`BrokenPipe\` で落ちても、生きている他クライアントへの broadcast は継続。\`_SseState.broadcast\` 内で死亡 client を自動 reap
- **idle watchdog 凍結**: \`_sse.count() > 0\` のとき watchdog が \`touch()\` を撃ち続け、idle カウンタの進行を止める。受け入れ条件「ブラウザ開きっぱで idle 停止しない保険」を満たす
- **peer 切断検知**: \`select + MSG_PEEK\` で non-blocking に EOF/RST を検知。\`_SSE_PEER_CHECK_INTERVAL = 1.0\` 周期で peer check するため、keepalive=15s でもブラウザ閉じてから ~1s 以内に handler が抜けて unregister → idle watchdog 再開
- **state component 分離**: \`DashboardServer\` の SSE / file-watch / idle 関連 state を \`_SseState\` / \`_FileWatcher\` / \`_IdleTracker\` に切り出し、self 代入を 5 個 (\`_stop_event\` / \`_idle\` / \`_sse\` / \`_watcher\` / \`started_at\`) に圧縮。pylint R0902 解消（10.00/10）

### クライアント

- 描画ロジックを \`async function loadAndRender()\` に切り出し、\`/events\` の \`message\` 受信で再実行
- \`EventSource\` の \`onopen / onerror\` を結線し、ヘッダーに接続状態バッジを追加:
  - 🟢 \`● 接続中\` — open
  - 🟡 \`○ 再接続中\` — error → 自動再接続中
  - 🔴 \`× 停止中\` — 30s 連続失敗
  - — \`静的レポート\` — \`window.__DATA__\` 経路（HTML export）では EventSource 不要なので固定表示
- \`fetch('/api/data', { cache: 'no-store' })\` でキャッシュ問題を回避

## codex レビュー対応

レビューで 2 件指摘されたものを fix-up commit で修正済み:

- **Finding 1 (P2)** — 静的 export 経路でバッジが「○ 接続準備中」のまま固まる UX バグ。\`window.__DATA__\` 経路で \`setConnStatus('static')\` を呼ぶよう変更し、専用 CSS state を追加
- **Finding 2 (P3)** — SSE 切断検知が \`sse_keepalive\` 周期に依存し、デフォルト 15s だと \`DASHBOARD_IDLE_SECONDS\` < 15s の設定が実装側で無効化されていたバグ。peer check を \`_SSE_PEER_CHECK_INTERVAL=1s\` に分離して independent 周期で回し、keepalive 送信は経過時間ベースに変更

## テスト

\`tests/test_dashboard_sse.py\` を新設（8 件）+ \`test_export_html.py\` に static badge 回帰 1 件 = **計 9 件追加** (288 → 290 / 11 → 12 ファイル):

### TestEventsEndpoint (2)
- \`/events\` の \`Content-Type: text/event-stream\` / \`Cache-Control: no-cache\` ヘッダー
- 初回 comment 行 (\`:\` 始まり + \`\\n\\n\` 区切り) の flush

### TestRefreshBroadcast (3)
- usage.jsonl 変更で \`data: refresh\` がクライアントに届く
- 1 client 切断時も他クライアントへの配信が継続
- ファイル変更が無いときは refresh が来ない

### TestSseIdleCounter (3)
- SSE 接続中は idle_seconds を超えてもサーバー alive
- 切断後は idle で graceful shutdown 復帰
- **回帰**: keepalive=15s（本番デフォルト）でも切断検知が ~1s で動く（Finding 2）

### TestHtmlTemplateFallback (export_html.py +1)
- **回帰**: 静的 export 経路で \`setConnStatus('static')\` と CSS が結線されている（Finding 1）

### テストヘルパ
- \`http.client.HTTPConnection.close()\` は macOS で TCP FIN 遅延でテストが flaky になるため、raw socket + \`SHUT_WR\` で確実に FIN を送る \`SseConn\` ヘルパを採用

全テストスイート **290/290 pass** ✅、pylint **10.00/10**

## 実機 smoke test

- \`/healthz\` / \`/api/data\` / \`/\` (HTML) すべて 200
- SSE 接続で \`: connected\\n\\n\` を即受信
- usage.jsonl に append → ~500ms 以内に \`data: refresh\\n\\n\` を受信
- \`SIGTERM\` → graceful shutdown / server.json 自動削除 (Phase A 互換)
- \`DASHBOARD_IDLE_SECONDS=1\` で idle 自然終了 (Phase A 互換)

## Test plan

- [x] \`python3 -m pytest tests/\` 全 pass (290 ケース)
- [x] 実機: SSE 接続 + usage.jsonl 変更で refresh が届く
- [x] 実機: ブラウザ閉じ → idle で graceful shutdown
- [x] pylint 10.00/10
- [ ] レビュー観点
  - [ ] \`_SSE_PEER_CHECK_INTERVAL\` の値選定（1s が短すぎ/長すぎないか）
  - [ ] \`_IdleTracker\` の callback design（on_idle = \`_initiate_shutdown\` で循環参照無し）
  - [ ] EventSource の自動再接続まわり（30s で 🔴 に降格する閾値）
  - [ ] static export での badge 表示 (Finding 1 の修正方針が UX として妥当か)

## Out of Scope

- \`hooks/launch_dashboard.py\` 自動起動 → Issue #21 (Phase C)
- ドキュメント反映 (CLAUDE.md / memory / commands/usage-dashboard.md) → Phase C

🤖 Generated with [Claude Code](https://claude.com/claude-code)