### PR TITLE
Phase C: launch_dashboard hook で fork-and-detach 起動 (Issue #21)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,16 +29,81 @@ Claude Code の動作
   │
   │  ── 整合性チェック ─────────────────────────────
   │  Stop                             →  hooks/verify_session.py  (transcript ↔ usage 照合)
+  │
+  │  ── ダッシュボード自動起動 ───────────────────────
+  │  SessionStart                     →  hooks/launch_dashboard.py  (べき等 launcher)
+  │  UserPromptSubmit                 →  hooks/launch_dashboard.py
+  │  PostToolUse                      →  hooks/launch_dashboard.py
   ↓
 data/usage.jsonl          ← append-only イベントログ（単一ファイルに集約）
   │
   ├── reports/summary.py     →  ターミナル集計レポート
   ├── reports/export_html.py →  スタンドアロン HTML レポート
-  └── dashboard/server.py    →  ブラウザダッシュボード（http://localhost:8080）
+  └── dashboard/server.py    →  ブラウザダッシュボード（自動起動・空きポート bind）
 ```
 
 実体保存先は `~/.claude/transcript-analyzer/usage.jsonl`（プラグイン更新で消えない位置）。
 テスト用途では `USAGE_JSONL` / `HEALTH_ALERTS_JSONL` 環境変数で差し替えできる。
+
+## ライブダッシュボードの運用仕様 (v0.3, Issue #14)
+
+ダッシュボードは Claude Code セッションと一体化したライブビュー。手動コマンドは不要。
+
+### 起動条件
+
+`hooks/launch_dashboard.py` が以下の Hook で発火し、`server.json` を見て **べき等に**
+起動判定する（既起動なら何もしない、未起動なら fork-and-detach で起動）：
+
+| Hook | 役割 |
+|------|------|
+| `SessionStart` | Claude Code 起動の瞬間にダッシュボードも立ち上げる |
+| `UserPromptSubmit` | idle 後にユーザーが操作再開 → 自動復活 |
+| `PostToolUse` | 道中の死活ザイダーガード（任意のツール使用後にも復活窓を持つ） |
+
+launcher は **常に < 100ms で exit 0**（Claude Code をブロックしない）。
+
+### URL 確認方法
+
+サーバー起動時に `~/.claude/transcript-analyzer/server.json` に `{pid, port, url, started_at}`
+が atomic に書かれる。手動起動時は stderr にも `Dashboard available: http://localhost:<port>`
+を 1 行出力する。
+
+```bash
+# URL を取得
+cat ~/.claude/transcript-analyzer/server.json
+```
+
+### 停止条件
+
+- **idle 自動停止**: 最後の HTTP リクエストから `DASHBOARD_IDLE_SECONDS`（デフォルト 600 秒 = 10 分）経過で graceful shutdown
+  - SSE 接続中は idle カウンタが進まないため、ブラウザ開きっぱなしでは停止しない
+- **手動停止**: `kill <pid>`（pid は server.json から取得）。SIGTERM / SIGINT で graceful shutdown
+- 停止時に server.json は **compare-and-delete** で自動削除（多重インスタンス保護）
+
+idle 停止後にユーザーが Claude Code 操作を再開すると、UserPromptSubmit / PostToolUse
+hook が launch_dashboard を起動し直して **自動復活** する（同 or 別ポート）。
+
+### 環境変数
+
+| 変数 | デフォルト | 意味 |
+|------|-----------|------|
+| `DASHBOARD_PORT` | `0`（OS 任せ） | 具体ポート指定時はそのポートで bind |
+| `DASHBOARD_IDLE_SECONDS` | `600` | idle 停止の閾値秒。`0` で停止無効化 |
+| `DASHBOARD_POLL_INTERVAL` | `1.0` | usage.jsonl 変更検知の polling 周期 (秒)。`0` で監視無効 |
+| `DASHBOARD_SERVER_JSON` | `~/.claude/transcript-analyzer/server.json` | server.json のパス |
+
+### 手動起動・停止
+
+通常は hook 経由の自動起動で十分だが、手動でも起動可能：
+
+```bash
+# 手動起動（既起動なら多重 bind で OSError）
+python3 dashboard/server.py
+# /usage-dashboard スラッシュコマンドからも起動できる
+
+# 手動停止
+kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)
+```
 
 ## ファイル構成
 
@@ -55,7 +120,9 @@ claude-transcript-analyzer/
 │   │                         # SubagentStart / SubagentStop 処理
 │   ├── record_session.py     # SessionStart/End, PreCompact/PostCompact,
 │   │                         # Notification, InstructionsLoaded 処理
-│   └── verify_session.py     # Stop hook: transcript vs usage 照合・異常検知
+│   ├── verify_session.py     # Stop hook: transcript vs usage 照合・異常検知
+│   └── launch_dashboard.py   # SessionStart / UserPromptSubmit / PostToolUse:
+│                             # ダッシュボードを fork-and-detach でべき等起動
 ├── commands/                 # スラッシュコマンド定義
 │   ├── usage-dashboard.md
 │   ├── usage-export-html.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,13 @@ hook が launch_dashboard を起動し直して **自動復活** する（同 or
 通常は hook 経由の自動起動で十分だが、手動でも起動可能：
 
 ```bash
-# 手動起動（既起動なら多重 bind で OSError）
+# 手動起動 (launcher 経由でべき等 — 既起動なら何もしない)
+python3 ${CLAUDE_PLUGIN_ROOT}/hooks/launch_dashboard.py
+# /usage-dashboard スラッシュコマンドも同じ経路
+
+# fg debug 用に直叩きする場合は事前に既起動確認 (二重起動防止)
+cat ~/.claude/transcript-analyzer/server.json  # 既起動なら kill してから
 python3 dashboard/server.py
-# /usage-dashboard スラッシュコマンドからも起動できる
 
 # 手動停止
 kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)

--- a/commands/usage-dashboard.md
+++ b/commands/usage-dashboard.md
@@ -1,12 +1,15 @@
-Manually launch the claude-transcript-analyzer dashboard server.
+Manually launch the claude-transcript-analyzer dashboard server (idempotent).
 
 > **v0.3 以降の通常運用ではこのコマンドは不要**: `hooks/launch_dashboard.py` が
 > SessionStart / UserPromptSubmit / PostToolUse hook で**べき等に自動起動**する。
 > このスラッシュコマンドは、明示的に手動で立ち上げたい場合の併存パスとして残す。
 
 ```bash
-python3 ${CLAUDE_PLUGIN_ROOT}/dashboard/server.py
+python3 ${CLAUDE_PLUGIN_ROOT}/hooks/launch_dashboard.py
 ```
+
+Hook 経由と同じ launcher を呼ぶため **べき等**: 既起動なら何もせず、未起動なら
+fork-and-detach で起動する。多重起動・ポート競合は起きない。
 
 URL は起動時 stderr に `Dashboard available: http://localhost:<port>` として 1 行出力される。
 また `~/.claude/transcript-analyzer/server.json` の `url` フィールドからも取得できる：
@@ -25,7 +28,7 @@ cat ~/.claude/transcript-analyzer/server.json
 | `DASHBOARD_POLL_INTERVAL` | `1.0` | usage.jsonl 変更検知の polling 周期 (秒) |
 
 ```bash
-DASHBOARD_PORT=9090 python3 ${CLAUDE_PLUGIN_ROOT}/dashboard/server.py
+DASHBOARD_PORT=9090 python3 ${CLAUDE_PLUGIN_ROOT}/hooks/launch_dashboard.py
 ```
 
 ## 停止
@@ -34,4 +37,16 @@ DASHBOARD_PORT=9090 python3 ${CLAUDE_PLUGIN_ROOT}/dashboard/server.py
 - 手動停止: `kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)`
 
 idle 停止後は次の Claude Code 操作で hook 経由で **自動復活** する。
+
+## デバッグ用 fg 起動 (上級ユーザー向け)
+
+サーバーログを foreground で見たい場合は `dashboard/server.py` を直接叩ける：
+
+```bash
+python3 ${CLAUDE_PLUGIN_ROOT}/dashboard/server.py
+```
+
+⚠️ ただしこの経路は **launcher を経由しないため二重起動チェックを行わない**。
+事前に `cat ~/.claude/transcript-analyzer/server.json` で既起動を確認するか、
+既存サーバーを kill してから叩くこと。
 

--- a/commands/usage-dashboard.md
+++ b/commands/usage-dashboard.md
@@ -1,13 +1,37 @@
-Launch the claude-transcript-analyzer dashboard server.
+Manually launch the claude-transcript-analyzer dashboard server.
+
+> **v0.3 以降の通常運用ではこのコマンドは不要**: `hooks/launch_dashboard.py` が
+> SessionStart / UserPromptSubmit / PostToolUse hook で**べき等に自動起動**する。
+> このスラッシュコマンドは、明示的に手動で立ち上げたい場合の併存パスとして残す。
 
 ```bash
 python3 ${CLAUDE_PLUGIN_ROOT}/dashboard/server.py
 ```
 
-Open http://localhost:8080 in your browser to view the Skills and Subagents usage dashboard.
+URL は起動時 stderr に `Dashboard available: http://localhost:<port>` として 1 行出力される。
+また `~/.claude/transcript-analyzer/server.json` の `url` フィールドからも取得できる：
 
-You can set the `DASHBOARD_PORT` environment variable to use a different port:
+```bash
+cat ~/.claude/transcript-analyzer/server.json
+# → {"pid": ..., "port": ..., "url": "http://localhost:...", "started_at": "..."}
+```
+
+## 環境変数
+
+| 変数 | デフォルト | 意味 |
+|------|-----------|------|
+| `DASHBOARD_PORT` | `0`（OS 任せ・空きポート） | 具体ポート指定可 |
+| `DASHBOARD_IDLE_SECONDS` | `600`（10 分） | idle 自動停止の閾値秒。`0` で無効化 |
+| `DASHBOARD_POLL_INTERVAL` | `1.0` | usage.jsonl 変更検知の polling 周期 (秒) |
+
 ```bash
 DASHBOARD_PORT=9090 python3 ${CLAUDE_PLUGIN_ROOT}/dashboard/server.py
 ```
+
+## 停止
+
+- idle 自動停止: 最後の HTTP リクエストから 10 分経過で graceful shutdown
+- 手動停止: `kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)`
+
+idle 停止後は次の Claude Code 操作で hook 経由で **自動復活** する。
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -17,6 +17,14 @@
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/record_subagent.py"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/launch_dashboard.py"
+          }
+        ]
       }
     ],
     "PostToolUseFailure": [
@@ -43,6 +51,14 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/record_skill.py"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/launch_dashboard.py"
           }
         ]
       }
@@ -83,6 +99,14 @@
           {
             "type": "command",
             "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/record_session.py"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/launch_dashboard.py"
           }
         ]
       }

--- a/hooks/launch_dashboard.py
+++ b/hooks/launch_dashboard.py
@@ -6,17 +6,21 @@ Claude Code Hook (SessionStart / UserPromptSubmit / PostToolUse) から呼ばれ
 
 判定フロー:
   1. server.json を読む
-  2. pid 生存 (`os.kill(pid, 0)`) + `/healthz` 200 → 何もせず exit 0
-  3. それ以外（不在 / 壊れた JSON / pid 死亡 / healthz 失敗）→ ゾンビ pid file
-     を削除し、`subprocess.Popen([python, server.py], start_new_session=True)`
-     で fork-and-detach 起動
+  2. pid 生存 → **多重起動を発生させないため True 返却** で何もせず exit 0
+     (起動中 race window: `write_server_json()` 直後 `serve_forever()` 開始前に hook が
+     来ても healthz のリトライで吸収。リトライ後も healthz fail でも pid alive なら
+     True を返す)
+  3. server.json 不在 / 壊れた JSON / pid 死亡 → ゾンビ pid file を削除し、
+     `subprocess.Popen([python, server.py], start_new_session=True)` で fork-and-detach 起動
 
 設計上の不変条件:
 - どんな例外が起きても **silent に exit 0**（Claude Code をブロックしない）
 - 既起動検出経路は **< 100ms**（毎 hook 走るため）
-- healthz timeout は **200ms**（サーバ起動中の遅延を避ける）
+- healthz timeout は **200ms**、リトライ回数 3 / 間隔 50ms（起動中 race window 吸収）
 - start_new_session=True で親 PG/SID から切り離し、Claude Code 終了後も子は生存
 - stdin/stdout/stderr は DEVNULL でリダイレクトし親 hook の pipe を引き継がない
+- `_server_is_alive()` は **ピュア** (副作用なし)。zombie cleanup は
+  `_remove_stale_server_json()` に分離し `main()` で明示呼び出し
 
 stdin から JSON が流れてくる (Claude Code Hook 標準) が、launcher は中身を見ない。
 """
@@ -25,6 +29,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -36,12 +41,21 @@ SERVER_JSON_PATH = Path(os.environ.get("DASHBOARD_SERVER_JSON", str(_DEFAULT_SER
 # Issue #14 AC: healthz チェックのタイムアウト 200ms
 HEALTHZ_TIMEOUT_SECONDS = 0.2
 
+# Codex F2 / claude[bot] #1 対応:
+# pid alive のとき healthz が一時的に応答しない race window
+# (write_server_json 後 serve_forever 開始前) を吸収するためのリトライ。
+# 50ms × 3 = 最悪 150ms 追加だが、healthz timeout 200ms と合わせて
+# 既起動検出経路全体は alive 即時応答時 < 100ms を維持できる
+# (リトライは healthz fail 経路のみ発動)。
+HEALTHZ_RETRY_COUNT = 3
+HEALTHZ_RETRY_INTERVAL_SECONDS = 0.05
+
 # 起動対象スクリプト: hooks/ の隣の dashboard/server.py
 _SERVER_SCRIPT = Path(__file__).resolve().parent.parent / "dashboard" / "server.py"
 
 
 def _read_server_json(path: Path) -> Optional[dict]:
-    """server.json を best-effort に読む。不在 / 壊れた JSON / OSError → None。"""
+    """server.json を best-effort に読む。不在 / 壊れた JSON / 非 dict / OSError → None。"""
     try:
         content = Path(path).read_text(encoding="utf-8")
     except (FileNotFoundError, OSError):
@@ -79,11 +93,23 @@ def _healthz_ok(url: str, timeout: float = HEALTHZ_TIMEOUT_SECONDS) -> bool:
         return False
 
 
-def _server_is_alive() -> bool:
-    """server.json + pid + healthz の総合判定。
+def _healthz_ok_with_retry(url: str) -> bool:
+    """healthz を `HEALTHZ_RETRY_COUNT` 回までリトライ。1 回でも 200 なら True。"""
+    for attempt in range(HEALTHZ_RETRY_COUNT):
+        if _healthz_ok(url):
+            return True
+        if attempt < HEALTHZ_RETRY_COUNT - 1:
+            time.sleep(HEALTHZ_RETRY_INTERVAL_SECONDS)
+    return False
 
-    pid が死んでいたら **副作用として** ゾンビ server.json を削除する
-    (Issue #14 AC「ゾンビ pid file を削除」)。
+
+def _server_is_alive() -> bool:
+    """server.json + pid + healthz の総合判定。**ピュア (副作用なし)**。
+
+    Codex F2 / claude[bot] #1 対応: pid alive + healthz fail (リトライ後も) でも
+    **True 返却** で多重起動を防ぐ。サーバー起動中 race window や一時的なデッドロックで
+    `_spawn_server()` が呼ばれて 2 つ目のサーバーが立つことを避けるため。
+    pid が完全停止 (デッドロック) している場合は ops 介入 (kill) で復旧する想定。
     """
     info = _read_server_json(SERVER_JSON_PATH)
     if info is None:
@@ -93,15 +119,36 @@ def _server_is_alive() -> bool:
     if not isinstance(pid, int) or not isinstance(url, str) or not url:
         return False
     if not _is_pid_alive(pid):
-        # ゾンビ削除: best-effort (失敗しても次回 launch で対処)
-        try:
-            SERVER_JSON_PATH.unlink()
-        except OSError:
-            pass
-        return False
-    if not _healthz_ok(url):
-        return False
+        return False  # 副作用なし: 削除は _remove_stale_server_json() / main() で行う
+    # pid alive 確定。healthz をリトライしてみるが、結果に関わらず True 返却
+    # (race window 吸収 + 二重起動防止)。
+    _healthz_ok_with_retry(url)
     return True
+
+
+def _remove_stale_server_json() -> bool:
+    """**dead pid** のときだけ server.json を削除する。返り値は実際に削除したか。
+
+    `_server_is_alive` から副作用を分離した zombie cleanup (claude[bot] #5 対応)。
+    `main()` から `_server_is_alive()` が False を返した直後に明示的に呼ばれる。
+
+    - alive pid → 何もしない (False)
+    - dead pid → 削除 (True)
+    - 不在 / 壊れた JSON / 非 dict → 何もしない (False)。spawn 後の atomic replace に任せる
+    """
+    info = _read_server_json(SERVER_JSON_PATH)
+    if info is None:
+        return False
+    pid = info.get("pid")
+    if not isinstance(pid, int):
+        return False
+    if _is_pid_alive(pid):
+        return False
+    try:
+        SERVER_JSON_PATH.unlink()
+        return True
+    except OSError:
+        return False
 
 
 def _spawn_server() -> None:
@@ -130,13 +177,16 @@ def _spawn_server() -> None:
 def main() -> int:
     """launcher のエントリポイント。常に 0 を返す（silent fail）。
 
-    stdin に Hook 標準の JSON が流れてくるが launcher は読まない（性能優先）。
-    Claude Code は stdin に書ききれない pipe があれば SIGPIPE で続行するため、
-    launcher が即 exit してもブロックしない。
+    フロー:
+        if _server_is_alive():     # ピュア判定 (副作用なし)
+            return 0
+        _remove_stale_server_json()  # 明示的な zombie cleanup
+        _spawn_server()              # fork-and-detach
     """
     try:
         if _server_is_alive():
             return 0
+        _remove_stale_server_json()
         _spawn_server()
     except Exception:
         # どんな想定外例外でも Claude Code をブロックしない (Issue #14 AC)

--- a/hooks/launch_dashboard.py
+++ b/hooks/launch_dashboard.py
@@ -1,0 +1,148 @@
+"""hooks/launch_dashboard.py — Issue #21 Phase C: ダッシュボードの自動起動 launcher
+
+Claude Code Hook (SessionStart / UserPromptSubmit / PostToolUse) から呼ばれ、
+`dashboard/server.py` が既に動いていれば何もせず、未起動なら fork-and-detach で
+起動する **べき等な薄い launcher**。
+
+判定フロー:
+  1. server.json を読む
+  2. pid 生存 (`os.kill(pid, 0)`) + `/healthz` 200 → 何もせず exit 0
+  3. それ以外（不在 / 壊れた JSON / pid 死亡 / healthz 失敗）→ ゾンビ pid file
+     を削除し、`subprocess.Popen([python, server.py], start_new_session=True)`
+     で fork-and-detach 起動
+
+設計上の不変条件:
+- どんな例外が起きても **silent に exit 0**（Claude Code をブロックしない）
+- 既起動検出経路は **< 100ms**（毎 hook 走るため）
+- healthz timeout は **200ms**（サーバ起動中の遅延を避ける）
+- start_new_session=True で親 PG/SID から切り離し、Claude Code 終了後も子は生存
+- stdin/stdout/stderr は DEVNULL でリダイレクトし親 hook の pipe を引き継がない
+
+stdin から JSON が流れてくる (Claude Code Hook 標準) が、launcher は中身を見ない。
+"""
+# pylint: disable=broad-except
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+_DEFAULT_SERVER_JSON_PATH = Path.home() / ".claude" / "transcript-analyzer" / "server.json"
+SERVER_JSON_PATH = Path(os.environ.get("DASHBOARD_SERVER_JSON", str(_DEFAULT_SERVER_JSON_PATH)))
+
+# Issue #14 AC: healthz チェックのタイムアウト 200ms
+HEALTHZ_TIMEOUT_SECONDS = 0.2
+
+# 起動対象スクリプト: hooks/ の隣の dashboard/server.py
+_SERVER_SCRIPT = Path(__file__).resolve().parent.parent / "dashboard" / "server.py"
+
+
+def _read_server_json(path: Path) -> Optional[dict]:
+    """server.json を best-effort に読む。不在 / 壊れた JSON / OSError → None。"""
+    try:
+        content = Path(path).read_text(encoding="utf-8")
+    except (FileNotFoundError, OSError):
+        return None
+    try:
+        info = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(info, dict):
+        return None
+    return info
+
+
+def _is_pid_alive(pid: int) -> bool:
+    """`os.kill(pid, 0)` で存在確認。ESRCH (No such process) → False。
+    EPERM (permission denied = 別ユーザのプロセスは存在する) → True。"""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # 他ユーザの pid が偶然 collision したケース。「別プロセスが存在する」の意味で True
+        return True
+    except OSError:
+        return False
+
+
+def _healthz_ok(url: str, timeout: float = HEALTHZ_TIMEOUT_SECONDS) -> bool:
+    """`{url}/healthz` が 200 を返すか。接続失敗 / timeout / 非 200 → False。"""
+    try:
+        with urllib.request.urlopen(f"{url}/healthz", timeout=timeout) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, OSError, TimeoutError):
+        return False
+
+
+def _server_is_alive() -> bool:
+    """server.json + pid + healthz の総合判定。
+
+    pid が死んでいたら **副作用として** ゾンビ server.json を削除する
+    (Issue #14 AC「ゾンビ pid file を削除」)。
+    """
+    info = _read_server_json(SERVER_JSON_PATH)
+    if info is None:
+        return False
+    pid = info.get("pid")
+    url = info.get("url")
+    if not isinstance(pid, int) or not isinstance(url, str) or not url:
+        return False
+    if not _is_pid_alive(pid):
+        # ゾンビ削除: best-effort (失敗しても次回 launch で対処)
+        try:
+            SERVER_JSON_PATH.unlink()
+        except OSError:
+            pass
+        return False
+    if not _healthz_ok(url):
+        return False
+    return True
+
+
+def _spawn_server() -> None:
+    """`python3 dashboard/server.py` を fork-and-detach で起動。silent。
+
+    - `start_new_session=True`: 親 PG/SID から切り離し、Claude Code 終了後も生存
+    - `stdin/stdout/stderr=DEVNULL`: 親 hook の pipe を引き継がない
+    - `close_fds=True`: 余計な fd を継承しない（POSIX デフォルトだが明示）
+    """
+    if not _SERVER_SCRIPT.exists():
+        return
+    try:
+        subprocess.Popen(  # pylint: disable=consider-using-with
+            [sys.executable, str(_SERVER_SCRIPT)],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except OSError:
+        # PermissionError / FileNotFoundError / fork limit 等。silent fail。
+        return
+
+
+def main() -> int:
+    """launcher のエントリポイント。常に 0 を返す（silent fail）。
+
+    stdin に Hook 標準の JSON が流れてくるが launcher は読まない（性能優先）。
+    Claude Code は stdin に書ききれない pipe があれば SIGPIPE で続行するため、
+    launcher が即 exit してもブロックしない。
+    """
+    try:
+        if _server_is_alive():
+            return 0
+        _spawn_server()
+    except Exception:
+        # どんな想定外例外でも Claude Code をブロックしない (Issue #14 AC)
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_launch_dashboard.py
+++ b/tests/test_launch_dashboard.py
@@ -1,0 +1,406 @@
+"""tests/test_launch_dashboard.py — Issue #21 Phase C: launch_dashboard.py のテスト
+
+`hooks/launch_dashboard.py` は SessionStart / UserPromptSubmit / PostToolUse hook で発火し、
+server.json を見て (1) 既起動なら何もせず exit 0、(2) 未起動 / pid 死亡 / healthz 失敗 なら
+fork-and-detach で `dashboard/server.py` を起動して exit 0 する、べき等な薄い launcher。
+
+テスト戦略:
+- 関数単位ユニットテスト: `_read_server_json` / `_is_pid_alive` / `_healthz_ok` /
+  `_server_is_alive` / `main` を、subprocess.Popen と urllib.request を patch して検証
+- 結合スモークテスト: 実スクリプトを subprocess.run で起動し、server.py が fork-and-detach
+  で起動されて server.json が現れることを確認（ベタ）
+
+Issue #14 AC のテスト要件「server.json 不在/alive/dead/healthz失敗 の 4 ケース」をカバー。
+"""
+# pylint: disable=line-too-long
+import importlib.util
+import json
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+_LAUNCH_PATH = Path(__file__).parent.parent / "hooks" / "launch_dashboard.py"
+_SERVER_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
+
+
+def load_launch_module(server_json: Path):
+    """DASHBOARD_SERVER_JSON をパッチした状態で launch_dashboard モジュールを読み込む。"""
+    os.environ["DASHBOARD_SERVER_JSON"] = str(server_json)
+    try:
+        spec = importlib.util.spec_from_file_location("launch_dashboard", _LAUNCH_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        del os.environ["DASHBOARD_SERVER_JSON"]
+    return mod
+
+
+# ----------------------------------------------------------------------------
+# _read_server_json
+# ----------------------------------------------------------------------------
+
+class TestReadServerJson:
+    def test_missing_file_returns_none(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        assert mod._read_server_json(tmp_path / "nonexistent.json") is None
+
+    def test_invalid_json_returns_none(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        path = tmp_path / "broken.json"
+        path.write_text("not json {{{", encoding="utf-8")
+        assert mod._read_server_json(path) is None
+
+    def test_valid_json_returns_dict(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        path = tmp_path / "ok.json"
+        path.write_text(json.dumps({"pid": 1234, "port": 8080, "url": "http://localhost:8080"}), encoding="utf-8")
+        info = mod._read_server_json(path)
+        assert info == {"pid": 1234, "port": 8080, "url": "http://localhost:8080"}
+
+
+# ----------------------------------------------------------------------------
+# _is_pid_alive
+# ----------------------------------------------------------------------------
+
+class TestIsPidAlive:
+    def test_self_pid_is_alive(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        assert mod._is_pid_alive(os.getpid()) is True
+
+    def test_dead_pid_returns_false(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        # 確実に存在しない pid を選ぶ: 子を spawn して回収後の pid を使う
+        with subprocess.Popen([sys.executable, "-c", "pass"]) as proc:
+            proc.wait()
+        # 回収済み pid なので os.kill(pid, 0) は ESRCH
+        assert mod._is_pid_alive(proc.pid) is False
+
+
+# ----------------------------------------------------------------------------
+# _healthz_ok
+# ----------------------------------------------------------------------------
+
+class _HealthzHandler(BaseHTTPRequestHandler):
+    """テスト用の最小 healthz サーバー。各テストで status を切り替える。"""
+    status_code = 200
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/healthz":
+            self.send_response(self.status_code)
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *_args, **_kwargs):
+        pass
+
+
+class TestHealthzOk:
+    def test_returns_true_for_200(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        _HealthzHandler.status_code = 200
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthzHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        try:
+            assert mod._healthz_ok(f"http://127.0.0.1:{port}") is True
+        finally:
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2)
+
+    def test_returns_false_for_500(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        _HealthzHandler.status_code = 500
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthzHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        try:
+            assert mod._healthz_ok(f"http://127.0.0.1:{port}") is False
+        finally:
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2)
+
+    def test_returns_false_for_connection_refused(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        # 空きポートを選んで即解放、そこに繋いで refused
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            free_port = s.getsockname()[1]
+        assert mod._healthz_ok(f"http://127.0.0.1:{free_port}") is False
+
+    def test_timeout_under_300ms(self, tmp_path):
+        """healthz timeout は 200ms が AC。実測で 300ms 以内に False を返すこと。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        # accept はしないが listen だけする → connect は通るが応答が無い → read timeout
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        port = listener.getsockname()[1]
+        try:
+            t0 = time.perf_counter()
+            assert mod._healthz_ok(f"http://127.0.0.1:{port}") is False
+            elapsed = time.perf_counter() - t0
+            assert elapsed < 0.3, f"healthz が timeout に 300ms 以上 ({elapsed:.3f}s) かかっている"
+        finally:
+            listener.close()
+
+
+# ----------------------------------------------------------------------------
+# _server_is_alive (server.json + pid + healthz の総合判定)
+# ----------------------------------------------------------------------------
+
+class TestServerIsAlive:
+    def test_no_server_json_returns_false(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        assert mod._server_is_alive() is False
+
+    def test_broken_server_json_returns_false(self, tmp_path):
+        path = tmp_path / "server.json"
+        path.write_text("garbage{{{", encoding="utf-8")
+        mod = load_launch_module(path)
+        assert mod._server_is_alive() is False
+
+    def test_dead_pid_removes_stale_server_json_and_returns_false(self, tmp_path):
+        """ゾンビ pid file は launch_dashboard が削除する（AC: ゾンビ pid file を削除）。"""
+        path = tmp_path / "server.json"
+        # 死んだ pid を埋め込む
+        with subprocess.Popen([sys.executable, "-c", "pass"]) as proc:
+            proc.wait()
+        path.write_text(json.dumps({"pid": proc.pid, "port": 9999, "url": "http://127.0.0.1:9999"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        assert mod._server_is_alive() is False
+        assert not path.exists(), "ゾンビ server.json が削除されていない"
+
+    def test_alive_pid_but_healthz_fails_returns_false(self, tmp_path):
+        """pid は生きてるが healthz が無応答 → 復帰のために False を返す。"""
+        path = tmp_path / "server.json"
+        # 自プロセス pid + 接続不可 url
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            free_port = s.getsockname()[1]
+        path.write_text(json.dumps({"pid": os.getpid(), "port": free_port, "url": f"http://127.0.0.1:{free_port}"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        assert mod._server_is_alive() is False
+
+    def test_alive_pid_and_healthz_ok_returns_true(self, tmp_path):
+        """pid 生存 + healthz 200 → True (re-launch 不要)。"""
+        path = tmp_path / "server.json"
+        _HealthzHandler.status_code = 200
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthzHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        try:
+            path.write_text(json.dumps({"pid": os.getpid(), "port": port, "url": f"http://127.0.0.1:{port}"}), encoding="utf-8")
+            mod = load_launch_module(path)
+            assert mod._server_is_alive() is True
+        finally:
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2)
+
+
+# ----------------------------------------------------------------------------
+# main() — 全体フロー (Popen mock)
+# ----------------------------------------------------------------------------
+
+class TestMainSpawnDecision:
+    def test_alive_does_not_spawn(self, tmp_path):
+        path = tmp_path / "server.json"
+        _HealthzHandler.status_code = 200
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthzHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        try:
+            path.write_text(json.dumps({"pid": os.getpid(), "port": port, "url": f"http://127.0.0.1:{port}"}), encoding="utf-8")
+            mod = load_launch_module(path)
+            with mock.patch.object(mod.subprocess, "Popen") as popen:
+                rc = mod.main()
+            assert rc == 0
+            popen.assert_not_called()
+        finally:
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2)
+
+    def test_no_server_json_spawns(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            rc = mod.main()
+        assert rc == 0
+        popen.assert_called_once()
+
+    def test_dead_pid_spawns(self, tmp_path):
+        path = tmp_path / "server.json"
+        with subprocess.Popen([sys.executable, "-c", "pass"]) as proc:
+            proc.wait()
+        path.write_text(json.dumps({"pid": proc.pid, "port": 9999, "url": "http://127.0.0.1:9999"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            rc = mod.main()
+        assert rc == 0
+        popen.assert_called_once()
+
+    def test_healthz_failure_spawns(self, tmp_path):
+        path = tmp_path / "server.json"
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            free_port = s.getsockname()[1]
+        path.write_text(json.dumps({"pid": os.getpid(), "port": free_port, "url": f"http://127.0.0.1:{free_port}"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            rc = mod.main()
+        assert rc == 0
+        popen.assert_called_once()
+
+    def test_spawn_oserror_silent_exit_zero(self, tmp_path):
+        """Popen が OSError → exit 0 (Claude Code をブロックしない)。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        with mock.patch.object(mod.subprocess, "Popen", side_effect=OSError("denied")):
+            rc = mod.main()
+        assert rc == 0
+
+    def test_unexpected_exception_silent_exit_zero(self, tmp_path):
+        """想定外の例外でも exit 0 (Claude Code をブロックしない)。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        with mock.patch.object(mod, "_server_is_alive", side_effect=RuntimeError("boom")):
+            rc = mod.main()
+        assert rc == 0
+
+
+# ----------------------------------------------------------------------------
+# Popen 引数（fork-and-detach のための呼び出し形）
+# ----------------------------------------------------------------------------
+
+class TestSpawnArguments:
+    def test_popen_uses_start_new_session(self, tmp_path):
+        """fork-and-detach: start_new_session=True で親 PG/SID から切り離す。
+        親プロセス（hook 経由 = Claude Code）終了後も子サーバー生存のため必須。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            rc = mod.main()
+        assert rc == 0
+        kwargs = popen.call_args.kwargs
+        assert kwargs.get("start_new_session") is True
+
+    def test_popen_redirects_stdio_to_devnull(self, tmp_path):
+        """親 hook の pipe を引き継がない。Claude Code の stdout/stderr を汚さない。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            mod.main()
+        kwargs = popen.call_args.kwargs
+        assert kwargs.get("stdin") == subprocess.DEVNULL
+        assert kwargs.get("stdout") == subprocess.DEVNULL
+        assert kwargs.get("stderr") == subprocess.DEVNULL
+
+    def test_popen_target_is_dashboard_server_py(self, tmp_path):
+        mod = load_launch_module(tmp_path / "server.json")
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            mod.main()
+        args = popen.call_args.args[0]
+        # [python, dashboard/server.py]
+        assert len(args) == 2
+        assert Path(args[1]).name == "server.py"
+        assert Path(args[1]).parent.name == "dashboard"
+
+
+# ----------------------------------------------------------------------------
+# Performance — alive 判定経路で 100ms 以内
+# ----------------------------------------------------------------------------
+
+class TestPerformance:
+    def test_alive_path_under_100ms(self, tmp_path):
+        """既起動検出経路は毎 hook 走るため AC: < 100ms。"""
+        path = tmp_path / "server.json"
+        _HealthzHandler.status_code = 200
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthzHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        try:
+            path.write_text(json.dumps({"pid": os.getpid(), "port": port, "url": f"http://127.0.0.1:{port}"}), encoding="utf-8")
+            mod = load_launch_module(path)
+            t0 = time.perf_counter()
+            mod.main()
+            elapsed = time.perf_counter() - t0
+            assert elapsed < 0.1, f"alive 検出経路が 100ms 超過: {elapsed:.3f}s"
+        finally:
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2)
+
+
+# ----------------------------------------------------------------------------
+# 結合スモーク — 実スクリプトを subprocess で起動し fork-and-detach を検証
+# ----------------------------------------------------------------------------
+
+class TestEndToEndLaunch:
+    def test_script_spawns_real_dashboard_server(self, tmp_path):
+        """実スクリプト起動: server.json 不在 → fork-and-detach で dashboard/server.py が起動し、
+        server.json が現れる。子サーバーは cleanup でちゃんと止める。"""
+        server_json = tmp_path / "server.json"
+        usage_jsonl = tmp_path / "usage.jsonl"
+        env = os.environ.copy()
+        env["DASHBOARD_SERVER_JSON"] = str(server_json)
+        env["USAGE_JSONL"] = str(usage_jsonl)
+        env["DASHBOARD_PORT"] = "0"  # 空きポート
+        env["DASHBOARD_IDLE_SECONDS"] = "5"  # テスト後に自動消滅
+        # 子サーバーが起動準備に時間がかかる場合があるので poll_interval は長めでも可
+        result = subprocess.run(
+            [sys.executable, str(_LAUNCH_PATH)],
+            input="",
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"launcher exit code: {result.returncode}, stderr: {result.stderr}"
+
+        # 子サーバーが server.json を書くまで待つ
+        deadline = time.time() + 5.0
+        while time.time() < deadline:
+            if server_json.exists():
+                try:
+                    info = json.loads(server_json.read_text(encoding="utf-8"))
+                    if "pid" in info and "url" in info:
+                        break
+                except json.JSONDecodeError:
+                    pass
+            time.sleep(0.05)
+        assert server_json.exists(), "子サーバーが server.json を書いていない"
+        info = json.loads(server_json.read_text(encoding="utf-8"))
+        spawned_pid = info["pid"]
+
+        try:
+            # healthz が応答することを確認（実 server.py が動いている証拠）
+            req = urllib.request.Request(f"{info['url']}/healthz")
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                assert resp.status == 200
+        finally:
+            # 子サーバーを cleanup
+            try:
+                os.kill(spawned_pid, 15)  # SIGTERM
+            except (OSError, ProcessLookupError):
+                pass
+            # 終了待ち（DASHBOARD_IDLE_SECONDS=5 で勝手にも消えるが念のため）
+            deadline = time.time() + 5.0
+            while time.time() < deadline:
+                try:
+                    os.kill(spawned_pid, 0)
+                except (OSError, ProcessLookupError):
+                    break
+                time.sleep(0.05)

--- a/tests/test_launch_dashboard.py
+++ b/tests/test_launch_dashboard.py
@@ -6,11 +6,19 @@ fork-and-detach で `dashboard/server.py` を起動して exit 0 する、べき
 
 テスト戦略:
 - 関数単位ユニットテスト: `_read_server_json` / `_is_pid_alive` / `_healthz_ok` /
-  `_server_is_alive` / `main` を、subprocess.Popen と urllib.request を patch して検証
-- 結合スモークテスト: 実スクリプトを subprocess.run で起動し、server.py が fork-and-detach
+  `_server_is_alive` / `_remove_stale_server_json` / `main` を、subprocess.Popen と
+  urllib.request を patch して検証
+- 結合スモークテスト: 実スクリプトを subprocess.run で起動し、server.py が fix-and-detach
   で起動されて server.json が現れることを確認（ベタ）
 
 Issue #14 AC のテスト要件「server.json 不在/alive/dead/healthz失敗 の 4 ケース」をカバー。
+
+PR #25 レビュー対応 (Codex F1/F2 + claude[bot] #1〜#5) で以下が変更された:
+- `_server_is_alive` は **ピュア化** (副作用 unlink を抜き、`_remove_stale_server_json`
+  に分離。`main()` で明示呼び出し)
+- `_server_is_alive` は **pid alive のとき healthz をリトライ** (50ms × 3)。
+  リトライ後も fail でも **True 返却** (起動中 race window で多重起動を発生させないため)
+- `_HealthzHandler.status_code` は autouse fixture で test 終了時に default に戻す
 """
 # pylint: disable=line-too-long
 import importlib.util
@@ -26,6 +34,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 _LAUNCH_PATH = Path(__file__).parent.parent / "hooks" / "launch_dashboard.py"
 _SERVER_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 
@@ -40,6 +50,40 @@ def load_launch_module(server_json: Path):
     finally:
         del os.environ["DASHBOARD_SERVER_JSON"]
     return mod
+
+
+# ----------------------------------------------------------------------------
+# テスト用 healthz handler — 全テストで共有するため state leak 対策が必要
+# ----------------------------------------------------------------------------
+
+class _HealthzHandler(BaseHTTPRequestHandler):
+    """テスト用の最小 healthz サーバー。各テストで status を切り替える。
+
+    `status_code` はクラス変数で共有される。test_*_500 のような mutate 後に
+    他テストへ leak すると並列実行 (pytest-xdist) で flaky になるため、
+    `_reset_healthz_handler_state` autouse fixture で各テスト終了時に 200 へ戻す
+    (claude[bot] #3 review 対応)。
+    """
+    status_code = 200
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/healthz":
+            self.send_response(self.status_code)
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *_args, **_kwargs):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_healthz_handler_state():
+    """各テスト後に `_HealthzHandler.status_code` を 200 に復元 (state leak 対策)。"""
+    yield
+    _HealthzHandler.status_code = 200
 
 
 # ----------------------------------------------------------------------------
@@ -64,6 +108,16 @@ class TestReadServerJson:
         info = mod._read_server_json(path)
         assert info == {"pid": 1234, "port": 8080, "url": "http://localhost:8080"}
 
+    def test_non_dict_json_returns_none(self, tmp_path):
+        """list / string / number 等 dict でない JSON → None (claude[bot] #4a 対応)。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        for content in ('[1,2,3]', '"string"', '42', 'null'):
+            path = tmp_path / "non_dict.json"
+            path.write_text(content, encoding="utf-8")
+            assert mod._read_server_json(path) is None, (
+                f"non-dict JSON ({content!r}) が None 返却していない"
+            )
+
 
 # ----------------------------------------------------------------------------
 # _is_pid_alive
@@ -86,23 +140,6 @@ class TestIsPidAlive:
 # ----------------------------------------------------------------------------
 # _healthz_ok
 # ----------------------------------------------------------------------------
-
-class _HealthzHandler(BaseHTTPRequestHandler):
-    """テスト用の最小 healthz サーバー。各テストで status を切り替える。"""
-    status_code = 200
-
-    def do_GET(self):  # noqa: N802
-        if self.path == "/healthz":
-            self.send_response(self.status_code)
-            self.end_headers()
-            self.wfile.write(b'{"status":"ok"}')
-        else:
-            self.send_response(404)
-            self.end_headers()
-
-    def log_message(self, *_args, **_kwargs):
-        pass
-
 
 class TestHealthzOk:
     def test_returns_true_for_200(self, tmp_path):
@@ -159,7 +196,7 @@ class TestHealthzOk:
 
 
 # ----------------------------------------------------------------------------
-# _server_is_alive (server.json + pid + healthz の総合判定)
+# _server_is_alive — ピュア化版 (副作用なし、pid alive 時は healthz fail でも True)
 # ----------------------------------------------------------------------------
 
 class TestServerIsAlive:
@@ -173,30 +210,68 @@ class TestServerIsAlive:
         mod = load_launch_module(path)
         assert mod._server_is_alive() is False
 
-    def test_dead_pid_removes_stale_server_json_and_returns_false(self, tmp_path):
-        """ゾンビ pid file は launch_dashboard が削除する（AC: ゾンビ pid file を削除）。"""
+    def test_dead_pid_returns_false_without_side_effects(self, tmp_path):
+        """ピュア化 (claude[bot] #5): `_server_is_alive` は副作用を持たない。
+        ゾンビ削除は `_remove_stale_server_json` / `main()` に移譲。"""
         path = tmp_path / "server.json"
-        # 死んだ pid を埋め込む
         with subprocess.Popen([sys.executable, "-c", "pass"]) as proc:
             proc.wait()
         path.write_text(json.dumps({"pid": proc.pid, "port": 9999, "url": "http://127.0.0.1:9999"}), encoding="utf-8")
         mod = load_launch_module(path)
         assert mod._server_is_alive() is False
-        assert not path.exists(), "ゾンビ server.json が削除されていない"
+        assert path.exists(), "_server_is_alive が副作用 (unlink) を持っている — ピュア化原則に違反"
 
-    def test_alive_pid_but_healthz_fails_returns_false(self, tmp_path):
-        """pid は生きてるが healthz が無応答 → 復帰のために False を返す。"""
+    def test_alive_pid_with_persistent_healthz_failure_returns_true(self, tmp_path):
+        """Codex F2 / claude[bot] #1: pid alive + healthz 永久失敗 → **True** 返却 (spawn 抑止)。
+        サーバー起動中の race window で `write_server_json()` 後 `serve_forever()` 開始前に hook が
+        発火するケースで、pid alive だけ見て True を返すことで二重起動を防ぐ。デッドロック中サーバー
+        は ops 介入 (kill) で復旧する想定。"""
         path = tmp_path / "server.json"
-        # 自プロセス pid + 接続不可 url
+        # 自プロセス pid + 接続不可 url (healthz は絶対 fail)
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
             free_port = s.getsockname()[1]
         path.write_text(json.dumps({"pid": os.getpid(), "port": free_port, "url": f"http://127.0.0.1:{free_port}"}), encoding="utf-8")
         mod = load_launch_module(path)
-        assert mod._server_is_alive() is False
+        # 絶対 fail の healthz だがリトライ後も True 返却 (pid alive 経由)
+        assert mod._server_is_alive() is True
+
+    def test_alive_pid_with_eventual_healthz_success_returns_true(self, tmp_path):
+        """healthz リトライ動作確認: 1 回目 fail + 2 回目以降 success → True 返却。"""
+        path = tmp_path / "server.json"
+
+        class _CountingHealthzHandler(BaseHTTPRequestHandler):
+            attempts = 0
+
+            def do_GET(self):  # noqa: N802
+                _CountingHealthzHandler.attempts += 1
+                if _CountingHealthzHandler.attempts < 2:
+                    self.send_response(503)
+                else:
+                    self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{}')
+
+            def log_message(self, *_args, **_kwargs):
+                pass
+
+        _CountingHealthzHandler.attempts = 0
+        server = ThreadingHTTPServer(("127.0.0.1", 0), _CountingHealthzHandler)
+        port = server.server_address[1]
+        t = threading.Thread(target=server.serve_forever, daemon=True)
+        t.start()
+        try:
+            path.write_text(json.dumps({"pid": os.getpid(), "port": port, "url": f"http://127.0.0.1:{port}"}), encoding="utf-8")
+            mod = load_launch_module(path)
+            assert mod._server_is_alive() is True
+            assert _CountingHealthzHandler.attempts >= 2, "healthz リトライが効いていない"
+        finally:
+            server.shutdown()
+            server.server_close()
+            t.join(timeout=2)
 
     def test_alive_pid_and_healthz_ok_returns_true(self, tmp_path):
-        """pid 生存 + healthz 200 → True (re-launch 不要)。"""
+        """pid 生存 + healthz 200 → True (re-launch 不要)。リトライ無しで即時。"""
         path = tmp_path / "server.json"
         _HealthzHandler.status_code = 200
         server = ThreadingHTTPServer(("127.0.0.1", 0), _HealthzHandler)
@@ -211,6 +286,42 @@ class TestServerIsAlive:
             server.shutdown()
             server.server_close()
             t.join(timeout=2)
+
+
+# ----------------------------------------------------------------------------
+# _remove_stale_server_json — 切り出された zombie cleanup (claude[bot] #5 対応)
+# ----------------------------------------------------------------------------
+
+class TestRemoveStaleServerJson:
+    def test_dead_pid_unlinks_and_returns_true(self, tmp_path):
+        path = tmp_path / "server.json"
+        with subprocess.Popen([sys.executable, "-c", "pass"]) as proc:
+            proc.wait()
+        path.write_text(json.dumps({"pid": proc.pid, "port": 9999, "url": "http://x"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        assert mod._remove_stale_server_json() is True
+        assert not path.exists()
+
+    def test_alive_pid_keeps_file(self, tmp_path):
+        """alive pid は誤って削除しない (server.json は信頼できる状態)。"""
+        path = tmp_path / "server.json"
+        path.write_text(json.dumps({"pid": os.getpid(), "port": 9999, "url": "http://x"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        assert mod._remove_stale_server_json() is False
+        assert path.exists(), "alive pid のファイルを誤って削除してしまった"
+
+    def test_missing_file_is_noop(self, tmp_path):
+        """不在ファイル → 何もしない (False, 例外も投げない)。"""
+        mod = load_launch_module(tmp_path / "server.json")
+        assert mod._remove_stale_server_json() is False
+
+    def test_broken_json_is_noop(self, tmp_path):
+        """壊れた JSON は削除せず spawn 後の atomic replace に任せる (race 回避)。"""
+        path = tmp_path / "server.json"
+        path.write_text("{broken", encoding="utf-8")
+        mod = load_launch_module(path)
+        assert mod._remove_stale_server_json() is False
+        assert path.exists()
 
 
 # ----------------------------------------------------------------------------
@@ -255,7 +366,8 @@ class TestMainSpawnDecision:
         assert rc == 0
         popen.assert_called_once()
 
-    def test_healthz_failure_spawns(self, tmp_path):
+    def test_healthz_failure_does_not_spawn_when_pid_alive(self, tmp_path):
+        """Codex F2 / claude[bot] #1: pid alive + healthz fail → spawn しない (二重起動防止)。"""
         path = tmp_path / "server.json"
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
@@ -265,7 +377,7 @@ class TestMainSpawnDecision:
         with mock.patch.object(mod.subprocess, "Popen") as popen:
             rc = mod.main()
         assert rc == 0
-        popen.assert_called_once()
+        popen.assert_not_called()
 
     def test_spawn_oserror_silent_exit_zero(self, tmp_path):
         """Popen が OSError → exit 0 (Claude Code をブロックしない)。"""
@@ -280,6 +392,23 @@ class TestMainSpawnDecision:
         with mock.patch.object(mod, "_server_is_alive", side_effect=RuntimeError("boom")):
             rc = mod.main()
         assert rc == 0
+
+
+class TestMainSweepsZombieBeforeSpawn:
+    """main() は dead pid 経路で `_remove_stale_server_json` を呼んでから spawn する
+    (claude[bot] #5: 副作用を main() に集約)。"""
+
+    def test_dead_pid_path_unlinks_before_spawn(self, tmp_path):
+        path = tmp_path / "server.json"
+        with subprocess.Popen([sys.executable, "-c", "pass"]) as proc:
+            proc.wait()
+        path.write_text(json.dumps({"pid": proc.pid, "port": 9999, "url": "http://127.0.0.1:9999"}), encoding="utf-8")
+        mod = load_launch_module(path)
+        with mock.patch.object(mod.subprocess, "Popen") as popen:
+            rc = mod.main()
+        assert rc == 0
+        popen.assert_called_once()
+        assert not path.exists(), "main() が dead pid 経路で server.json を削除していない"
 
 
 # ----------------------------------------------------------------------------
@@ -397,10 +526,20 @@ class TestEndToEndLaunch:
             except (OSError, ProcessLookupError):
                 pass
             # 終了待ち（DASHBOARD_IDLE_SECONDS=5 で勝手にも消えるが念のため）
-            deadline = time.time() + 5.0
+            deadline = time.time() + 3.0
             while time.time() < deadline:
                 try:
                     os.kill(spawned_pid, 0)
                 except (OSError, ProcessLookupError):
                     break
                 time.sleep(0.05)
+            # SIGTERM を無視するプロセスへの fallback (claude[bot] #4b 対応)
+            try:
+                os.kill(spawned_pid, 0)
+            except (OSError, ProcessLookupError):
+                pass  # 既に死亡済み
+            else:
+                try:
+                    os.kill(spawned_pid, 9)  # SIGKILL
+                except (OSError, ProcessLookupError):
+                    pass


### PR DESCRIPTION
## Summary

Issue #14 ライブダッシュボード化の **Phase C 完結編**。Phase A (#22) のサーバー基盤と Phase B (#23) の SSE push 配信の上に、Claude Code Hook 連動の **自動起動 launcher** を載せて「セッションとダッシュボードが一体化した体験」を実現する。

base branch は引き続き統合用 `feature/14-live-dashboard` を指す（stacked PR）。これで Issue #14 の全 Acceptance Criteria が達成されるため、merge 後は `feature/14-live-dashboard` を main にマージする想定。

## 実装

### `hooks/launch_dashboard.py`

`SessionStart` / `UserPromptSubmit` / `PostToolUse` の各 hook で発火する **べき等な薄い launcher**。usage.jsonl には書き出さず、副作用は `dashboard/server.py` の fork-and-detach 起動のみ。

判定フロー:
1. `server.json` を読む（不在 / 壊れた JSON → False）
2. pid 生存 (`os.kill(pid, 0)`) + `/healthz` 200 → 何もせず **exit 0**
3. それ以外 → ゾンビ pid file を削除し `subprocess.Popen([python, server.py], start_new_session=True, stdin=stdout=stderr=DEVNULL)` で起動

不変条件:
- どんな例外でも **silent exit 0**（Claude Code をブロックしない）
- 既起動検出経路は **< 100ms**（毎 hook 走るため。`test_alive_path_under_100ms` で保証）
- healthz timeout は **200ms**
- `start_new_session=True` で親 PG/SID から切り離し → Claude Code 終了後も子は生存
- stdin/stdout/stderr は DEVNULL でリダイレクト → 親 hook の pipe を引き継がない
- `DASHBOARD_SERVER_JSON` で server.json パスを差し替え可能（テスト用 + dashboard/server.py と一致）

### `hooks/hooks.json`

`SessionStart` / `UserPromptSubmit` / `PostToolUse` の 3 イベントに `launch_dashboard.py` を **既存 hook と並列で** 追加。`${CLAUDE_PLUGIN_ROOT}` 参照を踏襲。

| Hook | 既存 | 追加 |
|------|------|------|
| `SessionStart` | record_session | **+ launch_dashboard** |
| `UserPromptSubmit` | record_skill | **+ launch_dashboard** |
| `PostToolUse` | record_skill / record_subagent | **+ launch_dashboard** |

### ドキュメント

- **`CLAUDE.md`**: データフロー図に「ダッシュボード自動起動」レーンを追加。ファイル構成にも launch_dashboard.py を追記。新セクション「ライブダッシュボードの運用仕様 (v0.3, Issue #14)」で起動条件 / URL 確認方法 / 停止条件 / 環境変数 / 手動起動・停止を整理
- **`commands/usage-dashboard.md`**: 「v0.3 以降の通常運用ではこのコマンドは不要、明示手動起動の併存パスとして残す」と書き直し、環境変数表 + 停止方法 + 自動復活仕様を追記

## テスト

`tests/test_launch_dashboard.py` を新設（**25 件追加**, 290 → 315 / 12 → 13 ファイル）：

### TestReadServerJson (3)
- 不在 → None / 壊れた JSON → None / 正常 → dict

### TestIsPidAlive (2)
- 自プロセス pid → True / 回収済み pid → False（subprocess で生成して即 wait → 確実に消えた pid を使う）

### TestHealthzOk (4)
- 200 → True / 500 → False / connection refused → False / **timeout < 300ms**（実 socket listener で accept しないシナリオ）

### TestServerIsAlive (5)
- server.json 不在 → False / 壊れた JSON → False / **dead pid → ゾンビ削除を assert** / healthz NG → False / alive → True

### TestMainSpawnDecision (6)
- alive → spawn 呼ばれない / 不在 → spawn / dead → spawn / healthz失敗 → spawn / **OSError → silent exit 0** / 想定外例外 → silent exit 0

### TestSpawnArguments (3)
- `start_new_session=True` / stdin/stdout/stderr=DEVNULL / target が `dashboard/server.py`

### TestPerformance (1)
- alive 検出経路 **< 100ms** (perf_counter)

### TestEndToEndLaunch (1)
- 結合スモーク: 実スクリプトを subprocess.run → fork-and-detach で実 server.py 起動 → server.json 出現 → healthz 200 → cleanup

全テストスイート **315/315 pass** ✅、pylint **10.00/10**

## 実機 smoke test

隔離パス (`DASHBOARD_SERVER_JSON=/tmp/...`, `DASHBOARD_PORT=0`) で:

| Test | 結果 |
|------|------|
| 1. cold start (server.json 不在) | ✅ launcher exit 0 → server.py spawn → server.json + healthz 200 |
| 2. 既起動 (べき等) | ✅ PID 不変、`ps aux \| grep dashboard/server.py` で 1 プロセスのみ |
| 3. dead pid → ゾンビ削除 + 再起動 | ✅ 新 PID で再起動 + healthz 200 |
| 4. fork-and-detach | ✅ launcher exit 後も子サーバー生存 |

⚠️ launcher 実測 wall time は **~350ms**（python interpreter 起動 ~250ms + import + 内部処理）。AC「< 100ms」は launcher 内部処理として `test_alive_path_under_100ms` で保証している（interpreter 起動分は OS 共通要因で、Hook 経由の任意の python script に共通する）。問題視するならレビューで指摘してほしい。

## Issue #14 AC 達成

Phase A/B でカバー済の項目を除き、本 PR で：

- [x] `hooks/launch_dashboard.py` を新設
- [x] `hooks/hooks.json` の SessionStart / UserPromptSubmit / PostToolUse で launch_dashboard を発火
- [x] べき等動作 (server.json 不在 / pid 死亡 / healthz 失敗 → 起動)
- [x] 親プロセス終了後も子サーバーが生存（fork-and-detach）
- [x] 起動成功時 stderr に `Dashboard available: ...`（server.py 側で実装済、launcher は経由しない）
- [x] healthz チェックのタイムアウト 200ms
- [x] 起動失敗時は silent exit 0
- [x] CLAUDE.md / memory / commands/usage-dashboard.md 更新

⚠️ 「launch_dashboard.py の所要時間 < 100ms」は **launcher 内部処理** として保証。wall time は interpreter 起動を含めて ~350ms（上記実機 smoke test 参照）。

## Test plan

- [x] `python3 -m pytest tests/` 全 pass (315 ケース)
- [x] pylint 10.00/10
- [x] 実機: cold start / 既起動 / ゾンビ削除 / fork-and-detach の 4 シナリオ
- [ ] レビュー観点
  - [ ] healthz timeout 200ms の妥当性（短すぎ → 起動直後の遅い応答で再起動してしまう / 長すぎ → 毎 hook で 200ms ブロックしうる）
  - [ ] launcher wall time ~350ms (python interpreter 起動含む) を許容するか、それとも shell script や C 実装でさらに圧縮するか
  - [ ] dead pid 検出時の **副作用としての** server.json 削除（`_server_is_alive` 関数内で `unlink()` する設計）が surprising でないか
  - [ ] PostToolUse の 3 ハンドラ並列発火の負荷感（Phase A/B でも同等）

## Out of Scope

- ブラウザ自動 open（Issue #14 で確定済み: 採用しない）
- launch_dashboard.py 自身が usage.jsonl に書き込み記録する仕組み（launcher は副作用ゼロが設計）
- `feature/14-live-dashboard` → main マージ（本 PR 後のフォローアップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)