### PR TITLE
TOCTOU race 解消 + CI Windows matrix 追加 (Issue #24 / PR#23 codex finding)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+      - name: Run pytest
+        run: python -m pytest tests/ -q

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -8,10 +8,68 @@ import sys
 import threading
 import time
 from collections import Counter
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, Iterator, Optional
+
+
+# ---- cross-platform 排他ロック (Issue #24 TOCTOU 解消) -----------------
+# `server.json` の write_server_json / remove_server_json を別ファイル
+# `<server.json>.lock` 経由の排他ロックで 1 critical section にする。
+# server.json 自体を lock 対象にすると Windows の `msvcrt.locking` が
+# unlink と相性が悪い (sharing violation) ため、lock とデータを分離する。
+
+if sys.platform == "win32":
+    import msvcrt  # pylint: disable=import-error
+
+    def _lock_fd(fd: int) -> None:
+        # LK_LOCK: 他プロセスが lock を握っている間、~10 秒リトライしてから OSError
+        msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+
+    def _unlock_fd(fd: int) -> None:
+        msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+else:
+    import fcntl
+
+    def _lock_fd(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+
+    def _unlock_fd(fd: int) -> None:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+
+
+@contextmanager
+def _file_lock(lock_path: Path) -> Iterator[bool]:
+    """別ファイル lock を経由する cross-platform 排他ロック。
+
+    `yield acquired:bool` パターンで取得成否を呼び出し側に伝える。lock 取得に
+    失敗 (OSError) したときは silent best-effort で続行せず False を yield し、
+    呼び出し側が安全側 (削除/書き込みを諦める) に倒す責務を持つ。
+    """
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT)
+    try:
+        try:
+            _lock_fd(fd)
+        except OSError:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            try:
+                _unlock_fd(fd)
+            except OSError:
+                pass
+    finally:
+        os.close(fd)
+
+
+def _lock_path_for(target: Path) -> Path:
+    """`<target>.lock` を返す。target の親 dir に lock ファイルを置く。"""
+    return target.with_name(target.name + ".lock")
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from subagent_metrics import aggregate_subagent_metrics, usage_invocation_events
@@ -665,12 +723,20 @@ def create_server(
 
 
 def write_server_json(path: Path, info: dict) -> None:
-    """`{pid, port, url, started_at}` を atomic に書く（tmp + os.replace）。"""
+    """`{pid, port, url, started_at}` を atomic に書く（tmp + os.replace）。
+
+    Issue #24: `_file_lock` で remove と逐次化し TOCTOU race を解消する。
+    """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
-    tmp.write_text(json.dumps(info, ensure_ascii=False), encoding="utf-8")
-    os.replace(tmp, path)
+    with _file_lock(_lock_path_for(path)):
+        # lock 取得成否に関わらず write は実行する: write は atomic (os.replace) で
+        # 単独で正しく動くため lock 失敗時の安全側退避は不要。lock があれば
+        # remove との逐次化が成立し、無くても自プロセス内では write 同士の race も無い
+        # (run() は単一プロセスから 1 度だけ呼ばれる)。
+        tmp = path.with_name(path.name + f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(info, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, path)
 
 
 def remove_server_json(path: Path, expected_pid: Optional[int] = None) -> bool:
@@ -679,28 +745,37 @@ def remove_server_json(path: Path, expected_pid: Optional[int] = None) -> bool:
     `expected_pid` を渡したときは compare-and-delete: ファイル中の `pid` が一致する場合
     のみ削除する。多重インスタンスで他プロセスが上書きしたレジストリを誤って消さないため。
     壊れた JSON / 不在ファイル / pid 不一致はいずれも `False` を返して安全側に倒す。
+
+    Issue #24: read → pid 比較 → unlink を `_file_lock` で 1 critical section に
+    閉じ込めて TOCTOU race を解消。lock 取得失敗時は削除を諦めて False を返す
+    (silent best-effort で削除に踏み切ると lock の意味が無くなる)。
     """
     path = Path(path)
-    if expected_pid is not None:
-        try:
-            content = path.read_text(encoding="utf-8")
-        except FileNotFoundError:
+    with _file_lock(_lock_path_for(path)) as acquired:
+        if expected_pid is not None and not acquired:
+            # compare-and-delete モードで lock が取れない = 他プロセスが
+            # 書き込み/削除中の可能性。安全側に倒して何もしない。
             return False
+        if expected_pid is not None:
+            try:
+                content = path.read_text(encoding="utf-8")
+            except FileNotFoundError:
+                return False
+            except OSError:
+                return False
+            try:
+                info = json.loads(content)
+            except json.JSONDecodeError:
+                return False
+            if info.get("pid") != expected_pid:
+                return False
+        try:
+            path.unlink()
+            return True
         except OSError:
+            # FileNotFoundError / PermissionError / read-only fs 等。run() の finally から
+            # 例外が漏れるとプロセス終了時のエラーログを汚すため、cleanup は best-effort 扱い。
             return False
-        try:
-            info = json.loads(content)
-        except json.JSONDecodeError:
-            return False
-        if info.get("pid") != expected_pid:
-            return False
-    try:
-        path.unlink()
-        return True
-    except OSError:
-        # FileNotFoundError / PermissionError / read-only fs 等。run() の finally から
-        # 例外が漏れるとプロセス終了時のエラーログを汚すため、cleanup は best-effort 扱い。
-        return False
 
 
 def run(

--- a/tests/test_dashboard_live.py
+++ b/tests/test_dashboard_live.py
@@ -14,6 +14,8 @@ import urllib.request
 from http.server import ThreadingHTTPServer
 from pathlib import Path
 
+import pytest
+
 from test_dashboard import load_dashboard_module  # noqa: F401  (re-exported helper)
 
 
@@ -377,3 +379,131 @@ class TestRunIntegration:
             t.join(timeout=2.0)
         # serve_forever が exit した後、server.json は削除されている
         assert not target.exists()
+
+
+class TestServerJsonCrossProcessLock:
+    """Issue #24: TOCTOU race 解消。write/remove を別ファイル lock 経由で逐次化。
+
+    現状の compare-and-delete は read → pid 比較 → unlink の 4 ステップが
+    非アトミックで、A が pid を読んだ後 B が atomic write で上書きすると、
+    A の unlink が B のレジストリ (pid 不一致) を誤削除する race が残る。
+    `_file_lock` で write/remove を 1 critical section に閉じ込めて解消する。
+    """
+
+    def test_file_lock_yields_acquired_true_on_success(self, tmp_path):
+        """通常経路: lock 取得成功時は True を yield する。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        with mod._file_lock(tmp_path / "x.lock") as acquired:
+            assert acquired is True
+
+    def test_file_lock_yields_acquired_false_when_lock_call_fails(self, tmp_path, monkeypatch):
+        """lock 取得に失敗したとき (msvcrt.locking が 10 秒待っても OSError 等)、
+        yield False で呼び出し側に伝える。silent best-effort で続行はしない
+        (race 解消保証を緩めないため、安全側に倒す責務は呼び出し側へ)。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+        def boom(_fd):
+            raise OSError("simulated lock failure")
+
+        monkeypatch.setattr(mod, "_lock_fd", boom)
+        with mod._file_lock(tmp_path / "x.lock") as acquired:
+            assert acquired is False
+
+    def test_lock_file_co_located_with_server_json(self, tmp_path):
+        """`<server.json>.lock` ファイルが同じ親 dir に作られる (cleanup は best-effort)。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        target = tmp_path / "server.json"
+        mod.write_server_json(target, {"pid": 1, "port": 1, "url": "u", "started_at": "t"})
+        # 命名規約: server.json + ".lock" suffix
+        lock = tmp_path / "server.json.lock"
+        assert lock.exists(), f"lock ファイルが存在しない (期待パス: {lock})"
+
+    def test_remove_server_json_returns_false_when_lock_unavailable(self, tmp_path, monkeypatch):
+        """lock 取得失敗時、remove は何もせず False を返してファイルを残す (安全側)。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        target = tmp_path / "server.json"
+        target.write_text(
+            json.dumps({"pid": 4242, "port": 1, "url": "u", "started_at": "t"}),
+            encoding="utf-8",
+        )
+
+        def boom(_fd):
+            raise OSError("simulated lock failure")
+
+        monkeypatch.setattr(mod, "_lock_fd", boom)
+        removed = mod.remove_server_json(target, expected_pid=4242)
+        assert removed is False
+        # ファイルは残る (削除を諦めた)
+        assert target.exists()
+
+    def test_concurrent_write_and_remove_are_serialized(self, tmp_path):
+        """write_server_json と remove_server_json を Barrier で同時起動。
+        lock があれば必ず逐次化され、最終 state は決定論的:
+          - write が後に走った → ファイル存在 + B の pid
+          - remove が後に走った → ファイル不在
+        race があると read 中の A が B の atomic write 直後の内容を「中途半端に」
+        読み取って例外を投げる、または unlink で B のファイルを誤削除する。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        target = tmp_path / "server.json"
+        target.write_text(
+            json.dumps({"pid": 1, "port": 1, "url": "u", "started_at": "t"}),
+            encoding="utf-8",
+        )
+
+        barrier = threading.Barrier(2)
+        errors: list[BaseException] = []
+
+        def remove_fn():
+            try:
+                barrier.wait(timeout=2.0)
+                mod.remove_server_json(target, expected_pid=1)
+            except BaseException as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        def write_fn():
+            try:
+                barrier.wait(timeout=2.0)
+                mod.write_server_json(
+                    target,
+                    {"pid": 2, "port": 2, "url": "u2", "started_at": "t2"},
+                )
+            except BaseException as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        t1 = threading.Thread(target=remove_fn)
+        t2 = threading.Thread(target=write_fn)
+        t1.start()
+        t2.start()
+        t1.join(timeout=3.0)
+        t2.join(timeout=3.0)
+
+        assert errors == [], f"並行実行中に例外: {errors!r}"
+        # 最終 state: 存在するなら必ず B の pid (中間状態の混在ファイル不可)
+        if target.exists():
+            info = json.loads(target.read_text(encoding="utf-8"))
+            assert info["pid"] == 2, (
+                f"race 検出: 中間状態のファイルが残っている pid={info.get('pid')}"
+            )
+
+    def test_remove_holds_lock_during_compare_and_delete(self, tmp_path, monkeypatch):
+        """compare-and-delete の read → pid 比較 → unlink が `_file_lock` 内で
+        完結している (構造テスト)。lock を取らずに read+unlink すると
+        TOCTOU race が再発するため、lock acquire 経路を必ず通ることを保証。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        target = tmp_path / "server.json"
+        target.write_text(
+            json.dumps({"pid": 4242, "port": 1, "url": "u", "started_at": "t"}),
+            encoding="utf-8",
+        )
+
+        lock_acquired_calls: list = []
+        original_lock_fd = mod._lock_fd
+
+        def spy_lock_fd(fd):
+            lock_acquired_calls.append(fd)
+            return original_lock_fd(fd)
+
+        monkeypatch.setattr(mod, "_lock_fd", spy_lock_fd)
+        removed = mod.remove_server_json(target, expected_pid=4242)
+        assert removed is True
+        assert len(lock_acquired_calls) >= 1, "remove_server_json が lock を取得していない"


### PR DESCRIPTION
## Summary

Issue #24 の MUST 3 (server.json compare-and-delete のアトミック化) と CI Windows ジョブ追加を先行マージ。Windows 互換の本体 (MUST 1, 2, 4) は別 PR で対応予定。

PR #23 で codex が指摘した P2 finding (`remove_server_json` の TOCTOU race) を解消する。

## 設計判断

### 別ファイル lock 方式
`server.json` 自体を lock 対象にすると Windows の `msvcrt.locking` が `unlink` と相性が悪い (sharing violation) ため、`<server.json>.lock` を別出しして lock とデータを分離。filelock ライブラリと同パターン。

### cross-platform (stdlib only)
`sys.platform == "win32"` で `msvcrt.locking` (LK_LOCK 10秒リトライ)、それ以外は `fcntl.flock`。外部ライブラリ依存ゼロ。

### lock 取得失敗時の挙動
`_file_lock` は `yield acquired:bool` パターン。`remove_server_json` は lock が取れない時 (compare-and-delete モード時のみ) 削除を諦めて `False` を返す。silent best-effort で続行すると lock 導入の意味が消えるため安全側に倒した。

### CI Windows ジョブ
`.github/workflows/test.yml` で ubuntu/macos/windows の matrix を追加。lock 機構の Win 実機検証を CI で完結させ、後続 PR (Windows 互換本体) のベースも作る。

## 新規テスト (6 件)

`TestServerJsonCrossProcessLock`:
- `_file_lock` の True/False yield パターン (2 件)
- lock ファイルが server.json と同 dir に作られる
- lock 取得失敗時 remove が False で安全に倒れる
- write/remove を `threading.Barrier` で並行起動 → 中間状態のファイルが残らない
- compare-and-delete が lock acquire 経路を必ず通る (構造テスト)

## Test plan

- [x] `python3 -m pytest tests/` ローカル全 335 件 pass (329 既存 + 6 新規)
- [ ] CI: ubuntu-latest pass
- [ ] CI: macos-latest pass
- [ ] **CI: windows-latest pass** ← lock 機構の Win 実機検証

## 関連

- Issue #24 (Windows 互換対応 + server.json compare-and-delete のアトミック化)
- PR #23 (Phase B / Issue #20) — codex review finding P2: 本 PR で解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)