### PR TITLE
[SPIKE] .py shebang direct invocation across OS

### DIFF
--- a/.github/workflows/spike-py-shebang.yml
+++ b/.github/workflows/spike-py-shebang.yml
@@ -28,15 +28,50 @@ jobs:
           '@ | Out-File -Encoding utf8 -FilePath spike.py
           Get-Content spike.py
 
-      - name: Probe A — pwsh direct .py invocation
+      - name: Diagnose — PATHEXT, launcher, python availability
         shell: pwsh
         run: |
-          $r = '{"tool_name":"Spike","tool_input":{}}' | & ".\spike.py"
-          if ($LASTEXITCODE -ne 0) { Write-Error "pwsh direct .py failed: $LASTEXITCODE"; exit 1 }
-          Write-Host "Probe A passed"
+          Write-Host "=== PATHEXT ==="
+          Write-Host $env:PATHEXT
+          Write-Host "=== Get-Command python / python3 / py ==="
+          Get-Command python  -ErrorAction SilentlyContinue | Format-List Name, Source
+          Get-Command python3 -ErrorAction SilentlyContinue | Format-List Name, Source
+          Get-Command py      -ErrorAction SilentlyContinue | Format-List Name, Source
+          Write-Host "=== where.exe (cmd-style) ==="
+          where.exe python  2>$null
+          where.exe python3 2>$null
+          where.exe py      2>$null
+          Write-Host "=== py.exe launcher --list ==="
+          py --list 2>$null
+          py -3 --version 2>$null
+
+      - name: Probe A — pwsh direct .py invocation
+        shell: pwsh
+        continue-on-error: true
+        id: probe-a
+        run: |
+          Write-Host "Attempt 1: & '.\spike.py'"
+          '{"tool_name":"Spike","tool_input":{}}' | & ".\spike.py"
+          $code1 = $LASTEXITCODE
+          Write-Host "Attempt 1 LASTEXITCODE=$code1"
+
+          Write-Host "Attempt 2: & 'spike.py' (PATHEXT lookup)"
+          '{"tool_name":"Spike","tool_input":{}}' | & "spike.py"
+          $code2 = $LASTEXITCODE
+          Write-Host "Attempt 2 LASTEXITCODE=$code2"
+
+          if ($code1 -eq 0 -or $code2 -eq 0) {
+            Write-Host "Probe A passed (at least one attempt succeeded)"
+            exit 0
+          } else {
+            Write-Host "Probe A failed (both attempts non-zero)"
+            exit 1
+          }
 
       - name: Probe B — cmd.exe direct .py invocation
         shell: cmd
+        continue-on-error: true
+        id: probe-b
         run: |
           echo {"tool_name":"Spike","tool_input":{}} | spike.py
           if errorlevel 1 (echo cmd.exe direct .py failed & exit /b 1)
@@ -44,25 +79,24 @@ jobs:
 
       - name: Probe C — bash (Git Bash) direct .py invocation
         shell: bash
+        continue-on-error: true
+        id: probe-c
         run: |
           chmod +x spike.py || true
           echo '{"tool_name":"Spike","tool_input":{}}' | ./spike.py
           if [ $? -ne 0 ]; then echo "bash direct .py failed"; exit 1; fi
           echo "Probe C passed"
 
-      - name: Probe D — py.exe launcher detection
+      - name: Probe summary
         shell: pwsh
         run: |
-          py --list
-          py -3 --version
-
-      - name: Probe E — python (no python3) availability
-        shell: pwsh
-        run: |
-          # Confirm what `python` and `python3` resolve to on Windows runner
-          Get-Command python -ErrorAction SilentlyContinue | Format-List
-          Get-Command python3 -ErrorAction SilentlyContinue | Format-List
-          Get-Command py -ErrorAction SilentlyContinue | Format-List
+          $a = "${{ steps.probe-a.outcome }}"
+          $b = "${{ steps.probe-b.outcome }}"
+          $c = "${{ steps.probe-c.outcome }}"
+          Write-Host "=== Probe outcomes ==="
+          Write-Host "  A (pwsh):    $a"
+          Write-Host "  B (cmd.exe): $b"
+          Write-Host "  C (bash):    $c"
 
   posix-control:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/spike-py-shebang.yml
+++ b/.github/workflows/spike-py-shebang.yml
@@ -1,0 +1,93 @@
+name: Spike — Python shebang direct invocation
+on:
+  workflow_dispatch:
+  push:
+    branches: [spike/python-shebang-windows]
+
+jobs:
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Prepare shebang .py file
+        shell: pwsh
+        run: |
+          @'
+          #!/usr/bin/env python3
+          import sys, json
+          try:
+              data = json.load(sys.stdin)
+          except Exception as e:
+              data = {"_stdin_error": str(e)}
+          sys.stderr.write(f"OK shebang invoked: tool={data.get('tool_name','?')}, py={sys.executable}, platform={sys.platform}\n")
+          sys.exit(0)
+          '@ | Out-File -Encoding utf8 -FilePath spike.py
+          Get-Content spike.py
+
+      - name: Probe A — pwsh direct .py invocation
+        shell: pwsh
+        run: |
+          $r = '{"tool_name":"Spike","tool_input":{}}' | & ".\spike.py"
+          if ($LASTEXITCODE -ne 0) { Write-Error "pwsh direct .py failed: $LASTEXITCODE"; exit 1 }
+          Write-Host "Probe A passed"
+
+      - name: Probe B — cmd.exe direct .py invocation
+        shell: cmd
+        run: |
+          echo {"tool_name":"Spike","tool_input":{}} | spike.py
+          if errorlevel 1 (echo cmd.exe direct .py failed & exit /b 1)
+          echo Probe B passed
+
+      - name: Probe C — bash (Git Bash) direct .py invocation
+        shell: bash
+        run: |
+          chmod +x spike.py || true
+          echo '{"tool_name":"Spike","tool_input":{}}' | ./spike.py
+          if [ $? -ne 0 ]; then echo "bash direct .py failed"; exit 1; fi
+          echo "Probe C passed"
+
+      - name: Probe D — py.exe launcher detection
+        shell: pwsh
+        run: |
+          py --list
+          py -3 --version
+
+      - name: Probe E — python (no python3) availability
+        shell: pwsh
+        run: |
+          # Confirm what `python` and `python3` resolve to on Windows runner
+          Get-Command python -ErrorAction SilentlyContinue | Format-List
+          Get-Command python3 -ErrorAction SilentlyContinue | Format-List
+          Get-Command py -ErrorAction SilentlyContinue | Format-List
+
+  posix-control:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Prepare and probe
+        shell: bash
+        run: |
+          cat > spike.py <<'EOF'
+          #!/usr/bin/env python3
+          import sys, json
+          try:
+              data = json.load(sys.stdin)
+          except Exception as e:
+              data = {"_stdin_error": str(e)}
+          sys.stderr.write(f"OK shebang: py={sys.executable}, platform={sys.platform}\n")
+          sys.exit(0)
+          EOF
+          chmod +x spike.py
+          echo '{"tool_name":"Spike"}' | ./spike.py


### PR DESCRIPTION
## Summary

Verify whether `.py` files can be invoked directly as hook commands (no `python` / `python3` prefix) across Windows, Linux, and macOS — relying on `#!/usr/bin/env python3` shebang + Windows `.py` association via `py.exe` launcher.

This is a **throwaway spike** for case G in `plans/d-virtual-wand.md`. To be closed and branch deleted after a single workflow run regardless of result.

## Background

`hooks/hooks.json` currently uses `python ${CLAUDE_PLUGIN_ROOT}/hooks/foo.py` as the launch command. This breaks for macOS Homebrew users who have only `python3`. PR #31 picked `python` over `python3` for Windows compat. Cross-survey of Anthropic-official + 22 third-party plugins shows no precedent for OS-aware launcher resolution.

Case G: drop the launcher entirely and rely on shebang + OS association:

```diff
- "command": "python ${CLAUDE_PLUGIN_ROOT}/hooks/record_skill.py"
+ "command": "${CLAUDE_PLUGIN_ROOT}/hooks/record_skill.py"
```

## What this PR does

Adds `.github/workflows/spike-py-shebang.yml` with 5 probes on `windows-latest`:
- A: pwsh direct `.\spike.py` invocation
- B: cmd.exe direct `spike.py` invocation
- C: Git Bash direct `./spike.py` invocation
- D: `py --list` / `py -3 --version` availability
- E: `Get-Command python | python3 | py` resolution

Plus POSIX control jobs on ubuntu-latest and macos-latest.

## Decision rule

- All 3 Windows probes (A, B, C) pass → case G is physically viable on Windows. Proceed to spike 2 (real plugin install).
- Any probe fails → record which surface fails, demote to case E (per-OS parallel entries) or case H (`shell: "bash"` everywhere).

## Cleanup

After the run completes and the result is recorded back into `plans/d-virtual-wand.md`, this PR will be closed and the branch deleted.