### PR TITLE
docs: AGENTS.md を CLAUDE.md ポインタ化 + 共通規約に圧縮 (Issue #37)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,80 +1,39 @@
 # claude-transcript-analyzer
 
-## プロジェクトの目的
+> このリポジトリの正規 AI エージェント向けガイドは **[CLAUDE.md](CLAUDE.md)** です。
+> AGENTS.md は CLAUDE.md と内容を重複させないために、全エージェントに適用される
+> 最低限の規約のみを保持します。データフロー / event_type 一覧 / ファイル構成 /
+> Hook 配置などの詳細仕様は CLAUDE.md を参照してください。
 
-Claude Code のトランスクリプト（`.jsonl`）を解析し、**Skills と Subagents の使用状況を自動収集・集計・可視化する**ツール。
+## プロジェクトの目的（要約）
 
-Claude Code Hooks を使ってリアルタイムにイベントを収集し、`data/usage.jsonl` に蓄積する。
-それをブラウザダッシュボードで見やすく表示する。
+Claude Code の Skills と Subagents の使用状況を Hooks で自動収集・可視化するツール。
+イベントログは `~/.claude/transcript-analyzer/usage.jsonl`（テスト時のみ
+プロジェクト内 `data/usage.jsonl`）に append-only で蓄積され、
+ダッシュボード / ターミナルレポート / HTML エクスポートで参照する。
 
-## データフロー
-
-```
-Claude Code の動作
-  │  PostToolUse(Skill)         →  hooks/record_skill.py
-  │  UserPromptSubmit           →  hooks/record_skill.py
-  │  PostToolUse(Task)          →  hooks/record_subagent.py
-  │  SessionStart / UserPromptExpansion / UserPromptSubmit / PostToolUse
-  │                             →  hooks/launch_dashboard.py  (べき等 launcher)
-  ↓
-data/usage.jsonl          ← append-only イベントログ（単一ファイルに集約）
-  │
-  ├── reports/summary.py  →  ターミナル集計レポート
-  └── dashboard/server.py →  ブラウザダッシュボード（自動起動・空きポート bind）
-```
-
-## ファイル構成
-
-```
-claude-transcript-analyzer/
-├── hooks/
-│   ├── record_skill.py       # PostToolUse(Skill) + UserPromptSubmit 処理
-│   └── record_subagent.py    # PostToolUse(Task) 処理
-├── dashboard/
-│   └── server.py             # ローカル HTTP ダッシュボードサーバー
-├── data/
-│   └── usage.jsonl           # append-only イベントログ（自動生成）
-├── install/
-│   └── merge_settings.py     # settings.json マージスクリプト（べき等）
-├── reports/
-│   └── summary.py            # 集計レポート表示
-├── tests/
-├── install.sh                # セットアップスクリプト
-├── docs/
-│   ├── transcript-format.md  # トランスクリプトファイルの場所と構造
-│   └── specs/                # 仕様
-```
-
-## data/usage.jsonl のイベント形式
-
-3種類のイベントが1ファイルに混在する（JSONL 形式）。
-
-```jsonc
-// Skill ツール呼び出し
-{"event_type": "skill_tool", "skill": "user-story-creation", "args": "6", "project": "chirper", "session_id": "...", "timestamp": "2026-02-28T10:00:00+00:00"}
-
-// ユーザーの slash コマンド
-{"event_type": "user_slash_command", "skill": "/insights", "args": "", "project": "chirper", "session_id": "...", "timestamp": "2026-02-28T10:05:00+00:00"}
-
-// Subagent 起動
-{"event_type": "subagent_start", "subagent_type": "Explore", "project": "chirper", "session_id": "...", "timestamp": "2026-02-28T10:06:00+00:00"}
-```
-
-## 開発規約
+## 全 AI エージェント共通の規約
 
 - **TDD** で実装する（テストを先に書く）
 - **外部ライブラリ不使用**（stdlib のみ）
-- テスト隔離: `USAGE_JSONL` 環境変数で `DATA_FILE` をオーバーライドする
+- テスト隔離:
+  - `USAGE_JSONL` で `DATA_FILE` をオーバーライド
+  - `HEALTH_ALERTS_JSONL` で `verify_session.py` の `ALERTS_FILE` をオーバーライド
 - 組み込みコマンドは記録しない: `/exit /clear /help /compact /mcp /config /model /resume /context /skills /hooks /fast`
 
 ## よく使うコマンド
 
 ```bash
-# テスト実行
 python3 -m pytest tests/
 ```
 
-## トランスクリプトのソースファイル
+## さらに詳しく
 
-処理元となる Claude Code のトランスクリプトは `~/.claude/projects/` 以下にある。
-詳細は `docs/transcript-format.md` を参照。
+| 知りたいこと | 参照先 |
+|------------|-------|
+| プロジェクト全体仕様（データフロー / 観測対象 Hook / event_type） | [`CLAUDE.md`](CLAUDE.md) |
+| トランスクリプト形式 + Hook 入力 JSON スキーマ | [`docs/transcript-format.md`](docs/transcript-format.md) |
+| 仕様書 / 実装計画 | `docs/specs/` / `docs/plans/` |
+| レビューメモ | `docs/review/` |
+
+処理元の Claude Code トランスクリプト（`.jsonl`）は `~/.claude/projects/` 以下に保存される。


### PR DESCRIPTION
## Summary

- v0.1 当時の記述のまま 3 メジャーバージョン分 drift していた AGENTS.md を、CLAUDE.md からの薄いポインタ + 全 AI エージェント共通の最低限の規約に圧縮
- Issue #37 で言及された **「DRY 観点の薄いポインタ案」** を採用。AGENTS.md と CLAUDE.md の重複は drift の構造的温床なので、単一情報源化で将来の drift を防ぐ
- v0.6.0 リリース向けの 2 つ目の PR (base: \`v0.6.0\` ブランチ)

Closes #37

## ビフォー (drift)

- データフロー図が v0.1 の 3 events のみ (実態は 13 イベント / 14 hook)
- ファイル構成図に \`install/\` + \`install.sh\` が残存 (Issue #11 で削除済み)
- イベント形式の例が 3 種のみ (実態は \`subagent_stop\` / \`subagent_lifecycle_start\` / \`session_*\` / \`compact_*\` / \`notification\` / \`instructions_loaded\` まで存在)
- 開発規約に \`HEALTH_ALERTS_JSONL\` の言及なし

## アフター (DRY 単一情報源)

- プロジェクト全体仕様は CLAUDE.md を canonical として参照
- AGENTS.md は全 AI エージェント共通の最低限の規約のみ保持 (TDD / stdlib only / テスト隔離 env vars / 組み込みコマンド除外)
- \`HEALTH_ALERTS_JSONL\` を「テスト隔離」セクションに inline 追加
- 「さらに詳しく」表で詳細リソースへのナビゲーション提供 (discoverability 確保)

## Issue #37 受入基準のマッピング

| 基準 | 対応 |
|------|------|
| データフロー図が v0.5.2 の hook 全件をカバー | ✅ CLAUDE.md ポインタ (criteria の "or" 条項適用) |
| ファイル構成図が現リポジトリ構造と一致 | ✅ 同上 |
| イベント形式の例が代表的な event_type を網羅 | ✅ 同上 (criteria 内で明示的に「or 詳細は CLAUDE.md 参照のポインタ」を許容) |
| 開発規約に \`HEALTH_ALERTS_JSONL\` を追記 | ✅ inline で追加 |

## 行数

81 → **39** (-52%)

## Test plan

- [x] \`python3 -m pytest tests/\` → **383 passed, 1 skipped** (コード変更なしだが回帰確認)
- [x] \`grep -n "install" AGENTS.md\` で残留なしを確認
- [x] \`grep -n "HEALTH_ALERTS_JSONL" AGENTS.md\` で追加確認
- [ ] PR マージ後、AGENTS.md を読む別 AI エージェント (Codex 等) で実機確認 (将来的)

🤖 Generated with [Claude Code](https://claude.com/claude-code)