### PR TITLE
test: _start_server_in_thread の重複定義を共通ヘルパに統合 (Issue #28)

### DIFF
--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -38,6 +38,16 @@ def write_events(path: Path, events: list[dict]) -> None:
             f.write(json.dumps(ev) + "\n")
 
 
+def start_server_in_thread(server) -> threading.Thread:
+    """サーバーをデーモンスレッドで起動する共通ヘルパ (Issue #28)。
+
+    test_dashboard_live.py / test_dashboard_sse.py から再利用する。
+    """
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return t
+
+
 class TestBuildDashboardData:
     def test_empty_events_returns_valid_structure(self, tmp_path):
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")

--- a/tests/test_dashboard_live.py
+++ b/tests/test_dashboard_live.py
@@ -19,14 +19,8 @@ from pathlib import Path
 # 切り出された。`mod._lock_fd` を monkeypatch しても `server_registry._file_lock`
 # 内の参照は変わらないため、内部実装テストは `server_registry` を直接 monkeypatch する。
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from test_dashboard import load_dashboard_module  # noqa: F401, E402  (re-exported helper)
+from test_dashboard import load_dashboard_module, start_server_in_thread  # noqa: F401, E402  (re-exported helpers)
 import server_registry  # noqa: E402
-
-
-def _start_server_in_thread(server) -> threading.Thread:
-    t = threading.Thread(target=server.serve_forever, daemon=True)
-    t.start()
-    return t
 
 
 class TestThreadingServer:
@@ -93,7 +87,7 @@ class TestThreadingServer:
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         try:
             results: list[int] = []
             errors: list[BaseException] = []
@@ -124,7 +118,7 @@ class TestHealthzEndpoint:
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         try:
             with urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz") as resp:
                 assert resp.status == 200
@@ -268,7 +262,7 @@ class TestIdleWatchdog:
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         try:
             time.sleep(0.1)
             assert server.idle_for() >= 0.09
@@ -284,7 +278,7 @@ class TestIdleWatchdog:
         """idle_seconds 経過で server がシャットダウンする。"""
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0.2)
-        t = _start_server_in_thread(server)
+        t = start_server_in_thread(server)
         try:
             t.join(timeout=3.0)
             assert not t.is_alive(), "watchdog で serve_forever が exit していない"
@@ -295,7 +289,7 @@ class TestIdleWatchdog:
         """idle_seconds=0 で watchdog は起動せず、外部 shutdown まで生き続ける。"""
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0)
-        t = _start_server_in_thread(server)
+        t = start_server_in_thread(server)
         try:
             time.sleep(0.5)
             assert t.is_alive(), "idle_seconds=0 なのに自動停止した"

--- a/tests/test_dashboard_sse.py
+++ b/tests/test_dashboard_sse.py
@@ -10,17 +10,10 @@ Phase B のスコープ:
 # pylint: disable=line-too-long
 import json
 import socket
-import threading
 import time
 from dataclasses import dataclass
 
-from test_dashboard import load_dashboard_module
-
-
-def _start_server_in_thread(server) -> threading.Thread:
-    t = threading.Thread(target=server.serve_forever, daemon=True)
-    t.start()
-    return t
+from test_dashboard import load_dashboard_module, start_server_in_thread
 
 
 def _wait_for_sse_clients(server, expected: int, timeout: float = 2.0) -> None:
@@ -95,7 +88,7 @@ class TestEventsEndpoint:
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)
@@ -119,7 +112,7 @@ class TestEventsEndpoint:
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
         server = mod.create_server(port=0, idle_seconds=0)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)
@@ -144,7 +137,7 @@ class TestRefreshBroadcast:
         # poll_interval を短くしてテストを早める
         server = mod.create_server(port=0, idle_seconds=0, poll_interval=0.1)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)
@@ -175,7 +168,7 @@ class TestRefreshBroadcast:
         mod = load_dashboard_module(usage)
         server = mod.create_server(port=0, idle_seconds=0, poll_interval=0.1)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         a = b = None
         try:
             a = _open_sse("127.0.0.1", port)
@@ -207,7 +200,7 @@ class TestRefreshBroadcast:
         mod = load_dashboard_module(usage)
         server = mod.create_server(port=0, idle_seconds=0, poll_interval=0.1)
         port = server.server_address[1]
-        _start_server_in_thread(server)
+        start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)
@@ -232,7 +225,7 @@ class TestSseIdleCounter:
         # idle_seconds を非常に短く: 0.2s。SSE 接続があれば落ちない
         server = mod.create_server(port=0, idle_seconds=0.2, poll_interval=0.1)
         port = server.server_address[1]
-        t = _start_server_in_thread(server)
+        t = start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)
@@ -262,7 +255,7 @@ class TestSseIdleCounter:
             port=0, idle_seconds=0.3, poll_interval=0.0, sse_keepalive=15.0,
         )
         port = server.server_address[1]
-        t = _start_server_in_thread(server)
+        t = start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)
@@ -292,7 +285,7 @@ class TestSseIdleCounter:
             port=0, idle_seconds=0.3, poll_interval=0.1, sse_keepalive=0.05,
         )
         port = server.server_address[1]
-        t = _start_server_in_thread(server)
+        t = start_server_in_thread(server)
         c = None
         try:
             c = _open_sse("127.0.0.1", port)


### PR DESCRIPTION
## Summary

- PR #27 の claude[bot] レビュー指摘 #3 (cleanup task) への対応
- `tests/test_dashboard_live.py` と `tests/test_dashboard_sse.py` で完全に同一だった `_start_server_in_thread` を、既存の `load_dashboard_module` パターン (cross-import from `test_dashboard`) に合わせて集約
- v0.6.0 リリース向けの 3 つ目の PR (base: \`v0.6.0\` ブランチ)

Closes #28

## ビフォー

\`\`\`python
# tests/test_dashboard_live.py:26-29
def _start_server_in_thread(server) -> threading.Thread:
    t = threading.Thread(target=server.serve_forever, daemon=True)
    t.start()
    return t

# tests/test_dashboard_sse.py:20-23  (完全に同じ定義)
def _start_server_in_thread(server) -> threading.Thread:
    t = threading.Thread(target=server.serve_forever, daemon=True)
    t.start()
    return t
\`\`\`

## アフター

\`\`\`python
# tests/test_dashboard.py に集約 (Issue #19 の load_dashboard_module パターン踏襲)
def start_server_in_thread(server) -> threading.Thread:
    t = threading.Thread(target=server.serve_forever, daemon=True)
    t.start()
    return t

# tests/test_dashboard_live.py / test_dashboard_sse.py
from test_dashboard import load_dashboard_module, start_server_in_thread
\`\`\`

## 変更詳細

| ファイル | 変更 |
|---------|------|
| \`tests/test_dashboard.py\` | \`start_server_in_thread\` を共通ヘルパとして追加 (リーディングアンダースコア無し = shared helper として明示) |
| \`tests/test_dashboard_live.py\` | 重複定義削除 + import 追加 + call site 5 箇所を新名へ置換 |
| \`tests/test_dashboard_sse.py\` | 同上 (call site 9 箇所) + 不要になった \`import threading\` も整理 |

## 設計判断

- **既存の \`load_dashboard_module\` cross-import パターンに合わせる** (conftest.py の fixture 化ではなく)。理由: 既に dashboard 系テストの helper は \`test_dashboard\` から re-export する慣習があり、新しい慣習を増やさない方が discoverability が高い
- **アンダースコア外し** (\`_start_server_in_thread\` → \`start_server_in_thread\`)。理由: 「module-private」の意図が「shared helper」に変わるため

## Test plan

- [x] \`python3 -m pytest tests/test_dashboard.py tests/test_dashboard_live.py tests/test_dashboard_sse.py\` → **92 passed, 1 skipped** (該当 3 ファイル)
- [x] \`python3 -m pytest tests/\` → **383 passed, 1 skipped** (フルスイート、回帰なし)
- [x] \`grep -n "_start_server_in_thread"\` で旧名の残留なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)