### PR TITLE
v0.6.1: ダッシュボード hover usability 改善 (Issue #41 + #50)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-transcript-analyzer",
   "description": "Automatically collect and visualize Claude Code Skills and Subagents usage",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "kkoichi"
   }

--- a/dashboard/template.html
+++ b/dashboard/template.html
@@ -856,6 +856,10 @@
     '</div>';
   }).join('');
   document.getElementById('projSub').textContent = projs.length + ' projects · Σ ' + fmtN(projTotal);
+
+  // dynamic re-render 後の help-pop 再配置 (Issue #41)。kpiRow を含む全 popup を
+  // walk して、右端 KPI tooltip の viewport overflow を防ぐ。
+  placeAllPops();
   } // end loadAndRender
 
   // ---- 初回描画 + EventSource (live refresh) ----
@@ -919,6 +923,18 @@
     if (!prevOpen) pop.removeAttribute('data-open');
   }
 
+  // 全 popup に対して placePop を呼んで data-place を再計算する。
+  // hover 表示は CSS `:hover` が直接 visibility を切り替えるため click 経路の
+  // placePop が呼ばれず、右端 KPI (PERMISSION GATE) の tooltip が viewport を
+  // 飛び出して横スクロールを誘発していた (Issue #41)。dynamic re-render 後と
+  // resize 後にこれを呼んで、hover 表示前に正しい data-place を確定させる。
+  function placeAllPops() {
+    document.querySelectorAll('.help-pop').forEach(pop => {
+      const btn = document.querySelector('button[data-help-id="' + pop.id + '"]');
+      if (btn) placePop(pop, btn);
+    });
+  }
+
   document.addEventListener('click', function(e) {
     const btn = e.target.closest('.help-btn');
     if (btn) {
@@ -954,12 +970,7 @@
     }
   });
 
-  window.addEventListener('resize', function() {
-    document.querySelectorAll('.help-pop[data-open="true"]').forEach(pop => {
-      const btn = document.querySelector('button[data-help-id="' + pop.id + '"]');
-      if (btn) placePop(pop, btn);
-    });
-  });
+  window.addEventListener('resize', placeAllPops);
 
   // ============================================================
   //  Data tooltip (graph data points, [data-tip] elements)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -758,3 +758,57 @@ class TestGraphDataTooltip:
         # ranking 系（既存の `title=` 付き）はスコープ外。daily / proj に aria-label を付ける
         assert "aria-label" in template
 
+
+class TestHelpPopupOverflow:
+    """Issue #41: 右端 KPI (PERMISSION GATE) の help-pop が data-place="right"
+    のまま viewport 外に飛び出して横スクロールを誘発するバグへの対策。
+
+    旧仕様では placePop の auto-flip (`data-place="left"` への切替) は **click 時のみ**
+    呼ばれていた。hover 表示は CSS `:hover` で発火するため flip されず、初期描画 /
+    SSE refresh / resize 後に右端 popup が overflow したままになっていた。
+
+    修正方針:
+      1. `placeAllPops()` 共通 helper で全 popup を walk して placePop を呼ぶ
+      2. loadAndRender 末尾で呼ぶ（kpiRow dynamic re-render に追従）
+      3. resize handler を `data-open="true"` フィルタ無しの全 popup 対象に変更
+    """
+
+    def test_template_defines_place_all_pops_helper(self, tmp_path):
+        """placeAllPops() helper が定義されている。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        assert "function placeAllPops()" in template
+
+    def test_resize_handler_replaces_all_popups(self, tmp_path):
+        """resize handler は全 popup を再配置する（旧 data-open="true" フィルタを撤廃）。
+
+        旧仕様では hover 経由で表示される popup は data-open 属性を持たないため
+        resize 時に flip されず、viewport 縮小で右端 popup が overflow したままだった。
+        """
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        resize_marker = "addEventListener('resize'"
+        idx = template.find(resize_marker)
+        assert idx > 0, "resize handler が見つからない"
+        # resize handler の body は短いので 400 char で十分カバーできる
+        snippet = template[idx:idx + 400]
+        assert "placeAllPops" in snippet, "resize handler から placeAllPops が呼ばれていない"
+        # 旧フィルタが残っていないこと
+        assert ".help-pop[data-open=\"true\"]" not in snippet, (
+            "resize handler 内に旧 data-open フィルタが残存している"
+        )
+
+    def test_initial_render_invokes_place_all_pops(self, tmp_path):
+        """kpiRow render 後・loadAndRender 末尾までに placeAllPops が呼ばれる
+        （dynamic re-render 後の再配置）。"""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        template = mod._HTML_TEMPLATE
+        kpi_idx = template.find("getElementById('kpiRow').innerHTML")
+        assert kpi_idx > 0, "kpiRow render 箇所が見つからない"
+        end_marker = template.find("// end loadAndRender", kpi_idx)
+        assert end_marker > kpi_idx, "loadAndRender 末尾マーカーが見つからない"
+        body = template[kpi_idx:end_marker]
+        assert "placeAllPops()" in body, (
+            "kpiRow render 後 / loadAndRender 末尾までに placeAllPops() の呼び出しがない"
+        )
+


### PR DESCRIPTION
Closes #41
Closes #50

v0.6.1 patch release。ダッシュボードの hover 周りバグ修正と usability 改善を 2 件まとめている。

## Issue #41 — help-pop の auto-flip を hover / 初期描画でも効かせる

`PERMISSION GATE` などの右端 KPI tooltip が `data-place="right"` のまま viewport を飛び出して横スクロールを誘発していた。原因は `placePop` の auto-flip が **click 経路のみ** で発火し、CSS `:hover` 経由の表示や初期描画 / SSE refresh / resize 後に flip されないこと。

**Fix**: `placeAllPops()` 共通 helper を追加し、`loadAndRender` 末尾と `resize` handler で全 popup の `data-place` を再計算。hover 表示前に正しい配置が確定する。

| 状況 | 修正前 | 修正後 |
|------|-------|-------|
| 右端 KPI tooltip | viewport 外 → 横スクロール必須 | 自動で左 flip → 収まる |
| 自動 flip 経路 | click のみ | click / hover / 初期描画 / resize |

## Issue #50 — hover 領域拡張 + 0 件の日 / ランキング行にも tooltip

3 つの hover usability 改善をまとめて。

### a) Sparkline の hit area を全高 band に
旧 `.dot-hit` 円 (`r=6` / 直径 12px) を撤廃し、各日について全高 `.day-band` rect (~150px tall) を `data-tip="daily"` 付きで配置。判定領域が 100x 以上に拡張され、マウス精度負荷が消える。

### b) 0 件の日でも tooltip 表示
旧 dots 生成は `if (d.count <= 0) return ''` で完全スキップ → tooltip 出現せず。新 bands は count に関係なく全日 emit するため、「この日は 0 件」を hover で確実に確認できる。可視 dot は count>0 のみ維持（0 を打つと視覚ノイズ）。

### c) ランキング行の hover tooltip
旧 `.rn` の native `title=` のみ → グラフバー / 順位 / 値部分は hover で何も出なかった。`.rank-row` 全体に `data-tip="rank"` + data-name / data-c / data-kind / data-fail / data-avg を付与し、`dtipBuild` に rank 分岐追加。
- skill → mint accent stripe
- subagent → coral accent stripe
- failure 数 / 比率 / avg duration もリッチ表示
- native `title=` は floating tooltip と二重表示になるため削除

## ブラウザ実機検証
| 検証項目 | 結果 |
|----------|------|
| 1280x900 / 800x900 で全 12 help-pop overflow 無し | ✅ |
| PERMISSION GATE → `data-place="left"`, TOTAL EVENTS → `right` | ✅ |
| 0 件の日 (2026-04-23) の band hover → `events 0` tooltip 表示 | ✅ |
| bar-skill 行 hover → `uses 8 / fail 1 (13%)` (mint accent) | ✅ |
| Explore subagent 行 hover → `invocations 3 / avg 2.0s` (coral) | ✅ |
| band サイズ 156×148px (旧 12×12 円) | ✅ |

## Test plan
- [x] `python3 -m pytest tests/` → **520 passed / 1 skipped** (Issue #50 で +9 / Issue #41 で +3)
- [x] 新規テストクラス
  - `TestHelpPopupOverflow` (3): helper 定義 / resize handler 全 popup 対象 / loadAndRender 呼び出し
  - `TestSparklineWiderHoverBand` (5): band class / 0 件 emit / full-height / data-tip 属性 / 可視 dot は count>0
  - `TestRankingRowHover` (4): data-tip="rank" / data-name 等 / rank kind 分岐 / native title 削除
- [x] static-export (`reports/export_html.py`) で生成した HTML をブラウザで表示・hover 動作確認
- [x] `.claude-plugin/plugin.json` を 0.6.0 → 0.6.1 に bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)