### PR TITLE
feat(health-alerts): alert を actionable にする (Issue #51)

### DIFF
--- a/hooks/_append.py
+++ b/hooks/_append.py
@@ -66,8 +66,27 @@ def _resolve_alerts_path() -> Path:
     return _DEFAULT_ALERTS_PATH
 
 
+_APPEND_DROP_HINT = (
+    "This event was lost while the archive job held an exclusive lock and "
+    "the append could not acquire its shared lock (signal-driven failure). "
+    "The full event is preserved in `event_payload` so it can be replayed: "
+    "either re-append it manually to usage.jsonl, or accept the data loss "
+    "if the same event was re-emitted by a later hook fire. "
+    "If drops persist, run `/usage-archive` while no hooks are firing to "
+    "catch up the archive cleanly."
+)
+
+
 def _record_drop_alert(event: dict) -> None:
     """archive 中で append が drop された event を health_alerts.jsonl に 1 行記録。
+
+    Issue #51: actionable な情報を追加:
+    - `kind: "append_drop"`: verify_session 由来 (`transcript_mismatch`) と区別
+    - `project`: event.project があれば転載 (発生プロジェクト即特定)
+    - `event_payload`: 失われた event 全体を保持 (lost forever 回避 / 手動復旧可)
+    - `hint`: recommended action 文
+    既存の `alert: "append_skipped_due_to_archive_lock"` は **backwards compat で維持**
+    (古いツール / dashboard 表示が依存している可能性)。
 
     記録自体の失敗は silent (元の hook を破壊しない)。
     """
@@ -75,10 +94,14 @@ def _record_drop_alert(event: dict) -> None:
         alerts_path = _resolve_alerts_path()
         alerts_path.parent.mkdir(parents=True, exist_ok=True)
         alert = {
-            "alert": "append_skipped_due_to_archive_lock",
-            "event_type": event.get("event_type", ""),
-            "session_id": event.get("session_id", ""),
+            "kind": "append_drop",
+            "alert": "append_skipped_due_to_archive_lock",  # backwards compat
             "timestamp": datetime.now(timezone.utc).isoformat(),
+            "session_id": event.get("session_id", ""),
+            "project": event.get("project", "") or "",
+            "event_type": event.get("event_type", ""),
+            "event_payload": event,
+            "hint": _APPEND_DROP_HINT,
         }
         with alerts_path.open("a", encoding="utf-8", newline="\n") as f:
             f.write(json.dumps(alert, ensure_ascii=False) + "\n")

--- a/hooks/_append.py
+++ b/hooks/_append.py
@@ -66,27 +66,18 @@ def _resolve_alerts_path() -> Path:
     return _DEFAULT_ALERTS_PATH
 
 
-_APPEND_DROP_HINT = (
-    "This event was lost while the archive job held an exclusive lock and "
-    "the append could not acquire its shared lock (signal-driven failure). "
-    "The full event is preserved in `event_payload` so it can be replayed: "
-    "either re-append it manually to usage.jsonl, or accept the data loss "
-    "if the same event was re-emitted by a later hook fire. "
-    "If drops persist, run `/usage-archive` while no hooks are firing to "
-    "catch up the archive cleanly."
-)
-
-
 def _record_drop_alert(event: dict) -> None:
     """archive 中で append が drop された event を health_alerts.jsonl に 1 行記録。
 
-    Issue #51: actionable な情報を追加:
+    Issue #51: actionable な raw data を追加:
     - `kind: "append_drop"`: verify_session 由来 (`transcript_mismatch`) と区別
+      (consumer 側 dispatch 用)
     - `project`: event.project があれば転載 (発生プロジェクト即特定)
     - `event_payload`: 失われた event 全体を保持 (lost forever 回避 / 手動復旧可)
-    - `hint`: recommended action 文
     既存の `alert: "append_skipped_due_to_archive_lock"` は **backwards compat で維持**
     (古いツール / dashboard 表示が依存している可能性)。
+    人間向けの recommended action 文は consumer 側 (dashboard / reports / docs) に
+    `kind` ベースの mapping として持たせる方針。
 
     記録自体の失敗は silent (元の hook を破壊しない)。
     """
@@ -101,7 +92,6 @@ def _record_drop_alert(event: dict) -> None:
             "project": event.get("project", "") or "",
             "event_type": event.get("event_type", ""),
             "event_payload": event,
-            "hint": _APPEND_DROP_HINT,
         }
         with alerts_path.open("a", encoding="utf-8", newline="\n") as f:
             f.write(json.dumps(alert, ensure_ascii=False) + "\n")

--- a/hooks/verify_session.py
+++ b/hooks/verify_session.py
@@ -99,16 +99,6 @@ def _existing_fingerprints(alerts_file: Path) -> set[str]:
     return fps
 
 
-_TRANSCRIPT_MISMATCH_HINT = (
-    "Inspect transcript_path to identify the missed events. "
-    "User slash commands are observed via UserPromptExpansion (primary) and "
-    "UserPromptSubmit (fallback); skill / subagent events via PostToolUse. "
-    "A missing entry usually indicates a hook execution failure — check "
-    "~/.claude/log/ for hook errors, then re-run "
-    "`scripts/rescan_transcripts.py --append` if the gap needs to be backfilled."
-)
-
-
 def _project_from_cwd(cwd: str) -> str:
     """cwd の basename を project 名として返す (空 cwd は空文字)。"""
     if not cwd:
@@ -177,12 +167,13 @@ def handle_stop(
     if fingerprint in _existing_fingerprints(alerts_file):
         return
 
-    # Issue #51: alert に actionable な情報を追加する。
-    # - kind: 種別 enum (drop alert と区別)
+    # Issue #51: alert に actionable な raw data を載せる。
+    # - kind: 種別 enum (drop alert と区別 / consumer 側 dispatch 用)
     # - project / cwd: どこで起きたか即座に分かる
     # - transcript_path: 直接該当トランスクリプトを開ける
     # - missing_samples: 欠損 type ごとの transcript vs usage 件数比較
-    # - hint: recommended action 文
+    # 人間向けの hint 文は **consumer 側 (dashboard / reports / docs)** に
+    # `kind` ベースの mapping として持たせる方針。jsonl は raw data に徹する。
     alert = {
         "kind": "transcript_mismatch",
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -195,7 +186,6 @@ def handle_stop(
         "missing_samples": _build_missing_samples(
             transcript_counter, usage_counter, missing_types
         ),
-        "hint": _TRANSCRIPT_MISMATCH_HINT,
     }
     # newline="\n" 固定で Windows text mode の \r\n 変換を抑止 (Issue #24)。
     alerts_file.parent.mkdir(parents=True, exist_ok=True)

--- a/hooks/verify_session.py
+++ b/hooks/verify_session.py
@@ -99,6 +99,46 @@ def _existing_fingerprints(alerts_file: Path) -> set[str]:
     return fps
 
 
+_TRANSCRIPT_MISMATCH_HINT = (
+    "Inspect transcript_path to identify the missed events. "
+    "User slash commands are observed via UserPromptExpansion (primary) and "
+    "UserPromptSubmit (fallback); skill / subagent events via PostToolUse. "
+    "A missing entry usually indicates a hook execution failure — check "
+    "~/.claude/log/ for hook errors, then re-run "
+    "`scripts/rescan_transcripts.py --append` if the gap needs to be backfilled."
+)
+
+
+def _project_from_cwd(cwd: str) -> str:
+    """cwd の basename を project 名として返す (空 cwd は空文字)。"""
+    if not cwd:
+        return ""
+    return Path(cwd).name
+
+
+def _build_missing_samples(
+    transcript_counter: Counter,
+    usage_counter: Counter,
+    missing_types: list[str],
+) -> list[dict]:
+    """欠損 type ごとに transcript_count / usage_count / delta を返す。
+
+    Issue #51: 「skill_tool が 1 件欠けた」だけでなく「transcript には 3 件あったが
+    usage には 2 件しかない」と分かるようにする。
+    """
+    samples: list[dict] = []
+    for et in missing_types:
+        t = transcript_counter.get(et, 0)
+        u = usage_counter.get(et, 0)
+        samples.append({
+            "event_type": et,
+            "transcript_count": t,
+            "usage_count": u,
+            "delta": t - u,
+        })
+    return samples
+
+
 def handle_stop(
     session_id: str,
     cwd: str,
@@ -137,11 +177,25 @@ def handle_stop(
     if fingerprint in _existing_fingerprints(alerts_file):
         return
 
+    # Issue #51: alert に actionable な情報を追加する。
+    # - kind: 種別 enum (drop alert と区別)
+    # - project / cwd: どこで起きたか即座に分かる
+    # - transcript_path: 直接該当トランスクリプトを開ける
+    # - missing_samples: 欠損 type ごとの transcript vs usage 件数比較
+    # - hint: recommended action 文
     alert = {
+        "kind": "transcript_mismatch",
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "session_id": session_id,
+        "project": _project_from_cwd(cwd),
+        "cwd": cwd,
+        "transcript_path": str(transcript_path),
         "missing_count": missing_count,
         "missing_types": missing_types,
+        "missing_samples": _build_missing_samples(
+            transcript_counter, usage_counter, missing_types
+        ),
+        "hint": _TRANSCRIPT_MISMATCH_HINT,
     }
     # newline="\n" 固定で Windows text mode の \r\n 変換を抑止 (Issue #24)。
     alerts_file.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_hooks_append_lock.py
+++ b/tests/test_hooks_append_lock.py
@@ -317,11 +317,10 @@ class TestEnvOverride:
 class TestDropAlertSchema:
     """Issue #51: drop alert はもとから情報量が少なく、復旧が難しかった。
 
-    新スキーマ:
-    - `kind: "append_drop"` で種別を明示 (verify_session 由来と区別)
+    新スキーマ (raw data のみ。人間向け hint 文は consumer 側に分離):
+    - `kind: "append_drop"` で種別を明示 (verify_session 由来と区別 / dispatch 用)
     - `project` で発生プロジェクトが分かる
     - `event_payload` で失われた event 全体を保持 (lost forever 回避 / 手動復旧可)
-    - `hint` で recommended action を示す
     - 既存の `alert: "append_skipped_due_to_archive_lock"` は backwards compat で維持
     """
 
@@ -369,17 +368,6 @@ class TestDropAlertSchema:
         assert len(records) == 1
         assert records[0]["project"] == ""
 
-    def test_drop_alert_includes_hint(self, tmp_path, fresh_append_module):
-        """hint で recommended action を示す。"""
-        alerts_path = tmp_path / "health_alerts.jsonl"
-        event = {"event_type": "skill_tool", "session_id": "sess-drop-4"}
-        fresh_append_module._record_drop_alert(event)
-        records = _read_lines(alerts_path)
-        assert len(records) == 1
-        hint = records[0]["hint"]
-        assert isinstance(hint, str) and hint  # non-empty
-        # event_payload に言及して復旧経路を示す
-        assert "event_payload" in hint or "archive" in hint.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hooks_append_lock.py
+++ b/tests/test_hooks_append_lock.py
@@ -310,6 +310,79 @@ class TestEnvOverride:
 
 
 # ---------------------------------------------------------------------------
+# TestDropAlertSchema: Issue #51 — drop alert に actionable な情報を載せる
+# ---------------------------------------------------------------------------
+
+
+class TestDropAlertSchema:
+    """Issue #51: drop alert はもとから情報量が少なく、復旧が難しかった。
+
+    新スキーマ:
+    - `kind: "append_drop"` で種別を明示 (verify_session 由来と区別)
+    - `project` で発生プロジェクトが分かる
+    - `event_payload` で失われた event 全体を保持 (lost forever 回避 / 手動復旧可)
+    - `hint` で recommended action を示す
+    - 既存の `alert: "append_skipped_due_to_archive_lock"` は backwards compat で維持
+    """
+
+    def test_drop_alert_includes_kind_and_event_payload(self, tmp_path, fresh_append_module):
+        alerts_path = tmp_path / "health_alerts.jsonl"
+        # fresh_append_module fixture が HEALTH_ALERTS_JSONL を tmp_path に向けている
+        event = {
+            "event_type": "skill_tool",
+            "skill": "user-story-creation",
+            "args": "6",
+            "project": "myapp",
+            "session_id": "sess-drop-1",
+            "timestamp": "2026-04-28T10:00:00+00:00",
+        }
+        fresh_append_module._record_drop_alert(event)
+        records = _read_lines(alerts_path)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["kind"] == "append_drop"
+        assert rec["alert"] == "append_skipped_due_to_archive_lock"  # backwards compat
+        assert rec["session_id"] == "sess-drop-1"
+        assert rec["event_type"] == "skill_tool"
+        # event_payload で失われた event 全体を保持 (recovery 用)
+        assert rec["event_payload"] == event
+
+    def test_drop_alert_includes_project_when_present(self, tmp_path, fresh_append_module):
+        alerts_path = tmp_path / "health_alerts.jsonl"
+        event = {
+            "event_type": "subagent_start",
+            "subagent_type": "Explore",
+            "project": "chirper",
+            "session_id": "sess-drop-2",
+        }
+        fresh_append_module._record_drop_alert(event)
+        records = _read_lines(alerts_path)
+        assert len(records) == 1
+        assert records[0]["project"] == "chirper"
+
+    def test_drop_alert_handles_missing_project(self, tmp_path, fresh_append_module):
+        """project field が event に無くても落ちない (空文字 fallback)。"""
+        alerts_path = tmp_path / "health_alerts.jsonl"
+        event = {"event_type": "skill_tool", "session_id": "sess-drop-3"}
+        fresh_append_module._record_drop_alert(event)
+        records = _read_lines(alerts_path)
+        assert len(records) == 1
+        assert records[0]["project"] == ""
+
+    def test_drop_alert_includes_hint(self, tmp_path, fresh_append_module):
+        """hint で recommended action を示す。"""
+        alerts_path = tmp_path / "health_alerts.jsonl"
+        event = {"event_type": "skill_tool", "session_id": "sess-drop-4"}
+        fresh_append_module._record_drop_alert(event)
+        records = _read_lines(alerts_path)
+        assert len(records) == 1
+        hint = records[0]["hint"]
+        assert isinstance(hint, str) and hint  # non-empty
+        # event_payload に言及して復旧経路を示す
+        assert "event_payload" in hint or "archive" in hint.lower()
+
+
+# ---------------------------------------------------------------------------
 # TestNonContentionPerformance: 非競合 hot path の budget 確認
 # ---------------------------------------------------------------------------
 

--- a/tests/test_verify_session.py
+++ b/tests/test_verify_session.py
@@ -237,6 +237,125 @@ class TestHandleStop:
         assert "missing_types" in alert
         assert isinstance(alert["missing_types"], list)
 
+    # ---- Issue #51: actionable fields ----
+
+    def test_alert_includes_kind_and_project_and_cwd(self, tmp_path):
+        """Issue #51: kind / project / cwd が記録され「どこで起きたか」即座に分かる。"""
+        session_id = "sess-issue51-kind"
+        cwd = "/Users/foo/myapp"
+
+        alerts = self._run(
+            tmp_path, session_id, cwd,
+            transcript_rows=[
+                make_transcript_row("assistant", session_id, cwd, [make_task_block("Plan")]),
+            ],
+            usage_events=[],
+        )
+        assert len(alerts) == 1
+        a = alerts[0]
+        assert a["kind"] == "transcript_mismatch"
+        assert a["project"] == "myapp"  # basename of cwd
+        assert a["cwd"] == cwd
+
+    def test_alert_includes_transcript_path(self, tmp_path):
+        """Issue #51: 該当トランスクリプトのフルパスが記録される (= 直接開ける)。"""
+        session_id = "sess-issue51-path"
+        cwd = "/Users/foo/myapp"
+
+        alerts = self._run(
+            tmp_path, session_id, cwd,
+            transcript_rows=[
+                make_transcript_row("assistant", session_id, cwd, [make_task_block("Plan")]),
+            ],
+            usage_events=[],
+        )
+        assert len(alerts) == 1
+        # transcript_path は claude_home (= tmp_path) 配下の実パス
+        expected = tmp_path / "projects" / "-Users-foo-myapp" / f"{session_id}.jsonl"
+        assert alerts[0]["transcript_path"] == str(expected)
+
+    def test_alert_includes_missing_samples_per_type(self, tmp_path):
+        """Issue #51: 欠損 type ごとに transcript_count / usage_count / delta が分かる。
+
+        actionability: 「skill_tool が 1 件欠けた」だけでなく
+        「transcript には 3 件あったが usage には 2 件しかない」と即座に分かる。
+        """
+        session_id = "sess-issue51-samples"
+        cwd = "/Users/foo/myapp"
+
+        alerts = self._run(
+            tmp_path, session_id, cwd,
+            transcript_rows=[
+                # transcript: skill_tool 3 件 + subagent_start 2 件
+                make_transcript_row("assistant", session_id, cwd,
+                                    [make_skill_block("commit")] * 3),
+                make_transcript_row("assistant", session_id, cwd,
+                                    [make_task_block("Explore")] * 2),
+            ],
+            usage_events=[
+                # usage: skill_tool 2 件 (1 件不足) + subagent_start 0 件 (2 件不足)
+                make_usage_event("skill_tool", session_id, skill="commit", args=""),
+                make_usage_event("skill_tool", session_id, skill="commit", args=""),
+            ],
+        )
+        assert len(alerts) == 1
+        samples = alerts[0]["missing_samples"]
+        assert isinstance(samples, list)
+        # samples は missing_types と同じ集合
+        sample_types = {s["event_type"] for s in samples}
+        assert sample_types == {"skill_tool", "subagent_start"}
+        # 各 sample に delta が入る
+        skill_sample = next(s for s in samples if s["event_type"] == "skill_tool")
+        assert skill_sample["transcript_count"] == 3
+        assert skill_sample["usage_count"] == 2
+        assert skill_sample["delta"] == 1
+        sub_sample = next(s for s in samples if s["event_type"] == "subagent_start")
+        assert sub_sample["transcript_count"] == 2
+        assert sub_sample["usage_count"] == 0
+        assert sub_sample["delta"] == 2
+
+    def test_alert_includes_hint_text(self, tmp_path):
+        """Issue #51: hint で recommended action を示す (空文字列ではない)。"""
+        session_id = "sess-issue51-hint"
+        cwd = "/Users/foo/myapp"
+
+        alerts = self._run(
+            tmp_path, session_id, cwd,
+            transcript_rows=[
+                make_transcript_row("assistant", session_id, cwd, [make_task_block("Plan")]),
+            ],
+            usage_events=[],
+        )
+        assert len(alerts) == 1
+        hint = alerts[0]["hint"]
+        assert isinstance(hint, str)
+        assert hint  # non-empty
+        # hint は具体的アクションへの誘導を含む (透明性: transcript_path に言及)
+        assert "transcript" in hint.lower()
+
+    def test_project_falls_back_when_cwd_is_empty(self, tmp_path):
+        """cwd が空のときも project は空文字 / kind は付く (堅牢性)。"""
+        session_id = "sess-issue51-emptycwd"
+        cwd = ""  # 空 cwd
+        cwd_encoded = vs._encode_cwd(cwd)
+        transcript_dir = tmp_path / "projects" / cwd_encoded
+        transcript_dir.mkdir(parents=True, exist_ok=True)
+        write_jsonl(transcript_dir / f"{session_id}.jsonl", [
+            make_transcript_row("assistant", session_id, cwd, [make_task_block("Plan")]),
+        ])
+        usage_file = tmp_path / "usage.jsonl"
+        write_jsonl(usage_file, [])
+        alerts_file = tmp_path / "health_alerts.jsonl"
+        vs.handle_stop(
+            session_id=session_id, cwd=cwd, claude_home=tmp_path,
+            usage_file=usage_file, alerts_file=alerts_file,
+        )
+        alerts = read_jsonl(alerts_file)
+        assert len(alerts) == 1
+        assert alerts[0]["kind"] == "transcript_mismatch"
+        # project は空文字でも構わない (落ちないことが大事)
+        assert alerts[0]["project"] == ""
+
     def test_cwd_encoding_keeps_leading_dash(self, tmp_path):
         """cwd エンコードで先頭の '-' が保持されること"""
         session_id = "sess-enc"

--- a/tests/test_verify_session.py
+++ b/tests/test_verify_session.py
@@ -314,25 +314,6 @@ class TestHandleStop:
         assert sub_sample["usage_count"] == 0
         assert sub_sample["delta"] == 2
 
-    def test_alert_includes_hint_text(self, tmp_path):
-        """Issue #51: hint で recommended action を示す (空文字列ではない)。"""
-        session_id = "sess-issue51-hint"
-        cwd = "/Users/foo/myapp"
-
-        alerts = self._run(
-            tmp_path, session_id, cwd,
-            transcript_rows=[
-                make_transcript_row("assistant", session_id, cwd, [make_task_block("Plan")]),
-            ],
-            usage_events=[],
-        )
-        assert len(alerts) == 1
-        hint = alerts[0]["hint"]
-        assert isinstance(hint, str)
-        assert hint  # non-empty
-        # hint は具体的アクションへの誘導を含む (透明性: transcript_path に言及)
-        assert "transcript" in hint.lower()
-
     def test_project_falls_back_when_cwd_is_empty(self, tmp_path):
         """cwd が空のときも project は空文字 / kind は付く (堅牢性)。"""
         session_id = "sess-issue51-emptycwd"


### PR DESCRIPTION
## Summary

- 旧 health_alerts.jsonl は session_id / missing_count / missing_types だけ書いており、「どのプロジェクトで起きたか」「該当トランスクリプトはどこか」「失われた event の中身は何か」を別途調べないと具体的アクションに繋げられなかった (Issue #51)
- `verify_session.py` (transcript_mismatch) と `_append.py` (append_drop) の両方に **kind / project / cwd / transcript_path / event_payload** などの actionable な **raw data** フィールドを追加
- 既存 dashboard の `load_health_alerts` は dict として読むだけ (schema validate なし) なので、新旧フォーマットの混在は問題なし

## Before / After

**Before** (実データから):
\`\`\`json
{"timestamp": "2026-04-26T13:11:12...", "session_id": "30e63862-0fb7-...",
 "missing_count": 1, "missing_types": ["user_slash_command"]}
\`\`\`

**After**:
\`\`\`json
{"kind": "transcript_mismatch", "timestamp": "...", "session_id": "...",
 "project": "myapp", "cwd": "/Users/foo/myapp",
 "transcript_path": "/Users/.../projects/-Users-foo-myapp/<sid>.jsonl",
 "missing_count": 1, "missing_types": ["skill_tool"],
 "missing_samples": [{"event_type": "skill_tool", "transcript_count": 3,
                      "usage_count": 2, "delta": 1}]}
\`\`\`

## 受け入れ条件

- [x] `transcript_mismatch` alert に kind / project / cwd / transcript_path / missing_samples が記録される
- [x] `append_drop` alert に kind / project / event_payload (失われた event 全体) が記録される
- [x] 既存の `alert: "append_skipped_due_to_archive_lock"` は backwards compat で維持
- [x] 既存テストの重複抑止 / 1セッション1アラート設計は変えない
- [x] cwd が空文字でも落ちない

## 設計判断

### kind enum を 2 つに分けた理由

旧フォーマットでは drop alert だけが `alert: "append_skipped_due_to_archive_lock"` を持ち、verify_session 由来は何も持たなかった。**フィルタ・dashboard 表示・将来の集計** で種別を区別する必要があるため、両者に統一して `kind` を入れる。

### `event_payload` を append_drop に入れた理由

archive lock 取得失敗で event が usage.jsonl から失われると **二度と復旧できない**。将来 `health_alerts.jsonl` から失われた event を replay できるよう、event 全体を保持する。プライバシーリスクは元々の event payload と同じレベルで増加なし。

### `transcript_path` を絶対パスで保存

ユーザーは即座に \`cat <transcript_path>\` で確認できる必要があるため、絶対パスで記録 (~/$HOME 展開はしない)。

### hint フィールドを **載せない** 理由 (レビュー対応)

初版で各 alert に prose な `hint` 文を載せたが「jsonl は raw data の場所では？」というレビュー指摘で削除（コミット 8e4284c）。

- 同じ ~300 字文字列が同種 alert ごとに複製されデータが冗長 / 視認性低下
- 将来 dashboard / reports で表示要件が出たら **`kind` ベースで consumer 側 dispatch** すれば同じ value で DRY (jsonl 書き換え不要 / コード一箇所で更新 / i18n 余地もある)
- jsonl 直読みする pro user 向けには `docs/transcript-format.md` の kind 表で対応する経路が自然

## Test plan

- [x] \`python3 -m pytest tests/\` グリーン (527 passed, +7 this PR)
- [x] \`ruff check\` clean
- [x] 手動 dry-run で新フォーマットの実出力を確認

## Out of scope

- dashboard 側で health_alerts を UI 表示する: 現状 `/api/data` には含まれているが template.html 側に rendering なし。ユーザー体感のあるフィードバックを得てから設計したいので別 issue
- dashboard / reports に `kind → 説明文` の lookup を実装する: 上記が立った時点で同時に対応する
- 既存 health_alerts.jsonl の migration: backwards compat で混在 OK なので不要

Closes #51