### PR TITLE
v0.7.0 リリース前クリーンアップ + Codex P2 Findings (#71)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -582,8 +582,8 @@ def aggregate_slash_command_source_breakdown(
     """user_slash_command event を skill ごとに source 分類して expansion_rate を返す。
 
     source が "expansion" / "submit" のものだけを count に積む。それ以外
-    (旧 schema の source 欠落 / 未知 source 値) は **silent skip** (= 集計対象外
-    にするだけでエラーにはしない)。modern data 0 件の skill は出力対象外。
+    (source 不在 / 未知 source 値) は **silent skip** (= 集計対象外にするだけで
+    エラーにはしない)。modern data 0 件の skill は出力対象外。
 
     rate は 4 桁小数で丸める (`round(rate, 4)`)。
 
@@ -602,7 +602,7 @@ def aggregate_slash_command_source_breakdown(
             expansion_count[skill] += 1
         elif src == _SOURCE_SUBMIT:
             submit_count[skill] += 1
-        # 旧 schema (source 不在) / 未知 source 値は silent skip
+        # source 不在 / 未知 source 値は silent skip
     skills = set(expansion_count) | set(submit_count)
     rows = []
     for skill in skills:

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -292,8 +292,11 @@ def aggregate_hourly_heatmap(usage_events: list[dict]) -> dict:
         except (TypeError, ValueError):
             continue
         if dt.tzinfo is None:
-            # naive datetime は仕様外 (hooks は必ず +00:00 / +HH:MM 付き)。silent skip。
-            continue
+            # naive datetime は UTC として扱う (`subagent_metrics._week_start_iso`
+            # と同じ policy)。`rescan_transcripts.py --append` 経由で過去 transcript
+            # から再投入された event が naive のまま流れるケースで silent drop しない
+            # (Issue #71)。
+            dt = dt.replace(tzinfo=timezone.utc)
         hour_dt = dt.astimezone(timezone.utc).replace(minute=0, second=0, microsecond=0)
         counter[hour_dt.isoformat()] += 1
     buckets = [

--- a/dashboard/template.html
+++ b/dashboard/template.html
@@ -577,6 +577,12 @@
   /* `<section data-page="...">` は hidden 切替で常駐。 */
   .page[hidden] { display: none; }
 
+  /* Patterns / Quality / Surface タブの連続する panel 間マージン (Issue #71)。
+     Overview は `.two-up` gap + 後続 panel の inline `margin-top:14px` で既に
+     間隔が確保されている。adjacent-sibling combinator なので 1 件目の panel
+     には影響せず、`<header>` の margin-bottom が先頭間隔を決める。 */
+  .page > .panel + .panel { margin-top: 14px; }
+
   /* 後続 PR (#58〜#62) で本実装するページの placeholder。 */
   .page-placeholder {
     padding: 80px 24px;

--- a/dashboard/template.html
+++ b/dashboard/template.html
@@ -1275,7 +1275,7 @@
               <button class="help-btn" type="button" aria-label="説明を表示" aria-expanded="false" aria-describedby="hp-perm-skill" data-help-id="hp-perm-skill">?</button>
               <span class="help-pop" id="hp-perm-skill" role="tooltip" data-place="right">
                 <span class="pop-ttl">Permission per skill</span>
-                <span class="pop-body">permission notification の <strong>直前 30 秒以内 (or 実行中)</strong> に発火していた <code>skill_tool</code> に帰属。1 prompt は 1 候補にのみ帰属 (skill / subagent disjoint)。<code>permission_rate</code> = 帰属 prompt 数 / 総 skill_tool 数。<strong>1 invocation で複数回 permission を聞かれる skill</strong> は rate &gt; 1.0 になる (clamp しない)。<code>fewer-permission-prompts</code> skill / settings.json allowlist 整理のヒントとして使う。</span>
+                <span class="pop-body">permission notification の <strong>直前 30 秒以内 (or 実行中)</strong> に発火していた <code>skill_tool</code> に帰属。1 prompt は 1 候補にのみ帰属 (skill / subagent disjoint)。<code>permission_rate</code> = 帰属 prompt 数 / 総 skill_tool 数。<strong>1 invocation で複数回 permission を聞かれる skill</strong> は rate &gt; 1.0 になる (clamp しない)。settings.json の allowlist 整理 (上位の skill が頻出する Bash / MCP コマンドを <code>permissions.allow</code> に追加) のヒントとして使う。</span>
               </span>
             </span>
           </div>

--- a/docs/spec/dashboard-api.md
+++ b/docs/spec/dashboard-api.md
@@ -501,13 +501,13 @@ histogram の 0 bucket 分母を「実観測 session 数」に揃えるため。
 - sort key: `(expansion_count + submit_count)` 降順 → `skill` 昇順
 - top-N: `TOP_N_SLASH_COMMAND_BREAKDOWN = 20` で cap
 
-### 旧 schema / 未知 source 値の扱い
+### 未知 source 値の扱い
 
-`source` フィールドが `"expansion"` / `"submit"` 以外の event (旧 schema で
-`source` 欠落 / 将来追加されうる未知文字列) は **silent skip** する (= エラーに
-せず、集計に含めないだけ)。`expansion + submit == 0` の skill は output rows に
-含まれない。これは reader-side で旧 record を読み込んでもエラーにしないという
-互換性確保のためで、UI 側の表示要素にもしない。
+`source` フィールドが `"expansion"` / `"submit"` 以外の event (`source` 欠落 /
+将来追加されうる未知文字列) は **silent skip** する (= エラーにせず、集計に
+含めないだけ)。`expansion + submit == 0` の skill は output rows に含まれない。
+これは reader-side で record を読み込んでもエラーにしないという互換性確保の
+ためで、UI 側の表示要素にもしない。
 
 ## `instructions_loaded_breakdown` (Issue #62, v0.7.0〜)
 

--- a/subagent_metrics.py
+++ b/subagent_metrics.py
@@ -360,7 +360,11 @@ def _bucket_invocation_records(
     for inv, stop in _pair_invocations_with_stops(invocations, stops_sorted):
         start = inv.get("start")
         lifecycle = inv.get("lifecycle")
-        rep = start or lifecycle
+        # lifecycle.timestamp は SubagentStart hook 由来 (= 起動時刻に近い)。
+        # start.timestamp は PostToolUse(Task|Agent) 由来で invocation 完了時刻
+        # (record_subagent.py の `_now_iso()`)。週次 trend を起動週で bucket
+        # するため lifecycle 優先、無ければ start に fallback (Issue #71)。
+        rep = lifecycle or start
         ts = rep.get("timestamp", "") if rep else ""
         start_failed = bool(start) and start.get("success") is False
         stop_failed = bool(stop) and stop.get("success") is False
@@ -378,7 +382,8 @@ def invocation_records(events: list[dict]) -> list[dict]:
     `aggregate_subagent_metrics` と同じ invocation 同定 (`_bucket_events` +
     `_build_invocations` + start↔stop pairing) を使い、各 invocation の
     `failed` flag (start.success=False OR stop.success=False) を計算する。
-    timestamp は invocation の代表時刻 = `start.timestamp` 優先 / 無ければ `lifecycle.timestamp`。
+    timestamp は invocation の代表時刻 = `lifecycle.timestamp` 優先 (= 起動時刻)、
+    無ければ `start.timestamp` に fallback。
 
     用途: 週次 trend (`aggregate_subagent_failure_trend`) の入力など、invocation 単位
     時系列が必要な集計のための共通 helper (Issue #60 / B3)。

--- a/tests/test_dashboard_heatmap.py
+++ b/tests/test_dashboard_heatmap.py
@@ -139,6 +139,24 @@ class TestAggregateHourlyHeatmap:
             {"hour_utc": "2026-04-28T10:00:00+00:00", "count": 1},
         ]
 
+    def test_naive_timestamp_treated_as_utc(self, tmp_path):
+        """Issue #71 Finding 2: naive datetime は UTC として扱う。
+
+        `subagent_metrics._week_start_iso` と同じ policy。`rescan_transcripts.py
+        --append` 経由で過去 transcript から再投入された event が naive のまま
+        流れるケースで、heatmap だけ silent drop されると集計の整合性が崩れる。
+        """
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        usage_events = [
+            # naive timestamp (TZ 情報なし) → UTC として 10:00 bucket に入るべき
+            {"event_type": "skill_tool", "skill": "a", "project": "p", "session_id": "s",
+             "timestamp": "2026-04-28T10:30:00"},
+        ]
+        result = mod.aggregate_hourly_heatmap(usage_events)
+        assert result["buckets"] == [
+            {"hour_utc": "2026-04-28T10:00:00+00:00", "count": 1},
+        ]
+
     def test_week_boundary_separate_buckets(self, tmp_path):
         """日曜 23:00 と月曜 00:00 が別 bucket (時刻 truncate 確認)。"""
         mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")

--- a/tests/test_quality_template.py
+++ b/tests/test_quality_template.py
@@ -177,3 +177,26 @@ class TestQualityPageDOM:
         head_idx = section.index('panel-head', idx - 200)
         head_chunk = section[head_idx:head_idx + 100]
         assert 'c-mint' in head_chunk, "trend panel uses c-mint missing"
+
+
+# ============================================================
+#  TestPagePanelSpacing — Issue #71: Patterns/Quality/Surface タブの
+#  panel 間マージンを CSS で確保する (Overview 以外の 3 ページが
+#  対象。Overview は inline style + .two-up gap で既に間隔がある)。
+# ============================================================
+
+class TestPagePanelSpacing:
+    def test_page_panel_adjacent_sibling_has_margin_top(self):
+        """`.page > .panel + .panel { margin-top: ... }` 相当の rule が存在する。
+
+        Patterns / Quality / Surface 各ページで連続する .panel 要素間にマージンを
+        入れるための CSS rule。selector 形式は `.page > .panel + .panel` か
+        同等の adjacent-sibling combinator を含めばよい。
+        """
+        template = _load_template()
+        # CSS ブロックだけを切り出して selector を検索
+        style_start = template.index('<style>')
+        style_end = template.index('</style>', style_start)
+        css = template[style_start:style_end]
+        assert '.page > .panel + .panel' in css, \
+            "Patterns/Quality/Surface ページの .panel 間マージン CSS rule が未定義 (Issue #71)"

--- a/tests/test_subagent_quality.py
+++ b/tests/test_subagent_quality.py
@@ -345,19 +345,41 @@ class TestInvocationRecords:
         assert len(recs) == 1
         assert recs[0]["failed"] is False
 
-    def test_timestamp_uses_start_when_present(self):
+    def test_timestamp_uses_lifecycle_when_present(self):
+        # Issue #71 Finding 1: lifecycle.timestamp は SubagentStart hook で記録される
+        # = 起動時刻に近い。一方 start.timestamp は PostToolUse(Task|Agent) 由来で
+        # invocation 完了時刻 (record_subagent.py の `_now_iso()`)。週次 trend を
+        # 起動週で bucket するため lifecycle を優先採用、無ければ start に fallback。
         events = [
-            _start("Explore", "s", "2026-04-21T00:00:00+00:00"),
-            _lifecycle("Explore", "s", "2026-04-21T00:00:00.500+00:00"),  # 0.5s 後 → 同一 invocation
+            _lifecycle("Explore", "s", "2026-04-21T00:00:00+00:00"),
+            _start("Explore", "s", "2026-04-21T00:00:00.500+00:00"),  # 0.5s 後 → 同一 invocation
         ]
         recs = subagent_metrics.invocation_records(events)
         assert len(recs) == 1
         assert recs[0]["timestamp"] == "2026-04-21T00:00:00+00:00"
 
-    def test_timestamp_falls_back_to_lifecycle(self):
-        events = [_lifecycle("Explore", "s", "2026-04-21T00:00:00+00:00")]
+    def test_timestamp_falls_back_to_start(self):
+        # lifecycle が無いとき (= SubagentStart hook が発火しなかった invocation) は
+        # start.timestamp に fallback。
+        events = [_start("Explore", "s", "2026-04-21T00:00:00+00:00")]
         recs = subagent_metrics.invocation_records(events)
         assert recs[0]["timestamp"] == "2026-04-21T00:00:00+00:00"
+
+    def test_failure_trend_buckets_by_lifecycle_week_not_completion_week(self):
+        # Issue #71 Finding 1: 週境界を跨ぐ invocation を起動週にバケットする。
+        # 2026-04-26 (Sun 23:59:59.500) lifecycle → 起動週 = 2026-04-20 (Mon)
+        # 2026-04-27 (Mon 00:00:00.000) start    → 完了週 = 2026-04-27 (Mon)
+        # 0.5s 差で同一 invocation。lifecycle 優先採用なので 04-20 週が正解。
+        events = [
+            _lifecycle("Explore", "s", "2026-04-26T23:59:59.500+00:00"),
+            _start("Explore", "s", "2026-04-27T00:00:00+00:00", success=False),
+            _stop("Explore", "s", "2026-04-27T00:00:05+00:00", success=False),
+        ]
+        result = subagent_metrics.aggregate_subagent_failure_trend(events)
+        assert len(result) == 1
+        assert result[0]["week_start"] == "2026-04-20"
+        assert result[0]["subagent_type"] == "Explore"
+        assert result[0]["failure_count"] == 1
 
     def test_invocation_count_matches_metrics_count(self):
         """invocation_records と aggregate_subagent_metrics の type 別 count が一致。"""


### PR DESCRIPTION
## Summary

Issue #71 の v0.7.0 リリース前クリーンアップ。本文 3 タスク + Codex Round 2 で検出された P2 correctness 2 件を 1 PR にまとめて対応。

## Changes (5 commits)

### 🛠 Codex P2 correctness fixes
- **fix(subagent-metrics)**: `_bucket_invocation_records` で `lifecycle.timestamp` を優先採用 (起動時刻に近い)。`start.timestamp` は PostToolUse 由来で完了時刻なので、週境界跨ぎの subagent invocation が完了週ではなく起動週に bucket されるよう修正。
- **fix(dashboard)**: `aggregate_hourly_heatmap` の naive timestamp を silent skip ではなく UTC として扱うよう修正。`subagent_metrics._week_start_iso` と policy 統一。`rescan_transcripts.py --append` 経由で再投入された event の集計整合性が崩れない。

### ✨ UI / docs cleanup
- **refactor(dashboard)**: 旧 schema 表記を `dashboard/server.py` のコメントと `docs/spec/dashboard-api.md` の見出しから削除。「未知 source 値の扱い」に統一 (silent skip 動作はそのまま)。
- **refactor(dashboard)**: Permission per skill help-pop の `fewer-permission-prompts` skill 直接名指しを汎用表現 (settings.json allowlist 整理) に置換。
- **style(dashboard)**: Patterns / Quality / Surface タブの panel 間マージン CSS rule (`.page > .panel + .panel { margin-top: 14px; }`) を追加。Overview は既存の inline `margin-top:14px` + `.two-up` gap で影響なし。

### Tests
- 新規 4 件 (Finding 1 timestamp 優先 / Finding 1 週境界跨ぎ / Finding 2 naive UTC / margin CSS rule pin)
- 既存 1 件のリネーム + flip (`test_timestamp_uses_start_when_present` → `test_timestamp_uses_lifecycle_when_present`)
- 全 835 passed ✅

## Test plan
- [x] `python3 -m pytest tests/` → 835 passed, 1 skipped
- [x] `python3 reports/export_html.py` で static HTML 生成 → ブラウザで Patterns / Quality / Surface 3 ページ実視認 (panel 間マージン OK / 旧スキーマ表記・env-specific skill 名は全消失)
- [x] `grep -E "fewer-permission-prompts|legacy_count|旧 schema|旧スキーマ|観測待ち" /tmp/issue-71-smoke.html` → 0 matches

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)