### PR TITLE
feat(dashboard): live update highlight + toast (Issue #69)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -945,6 +945,7 @@ _CSS_FILES = (
 _MAIN_JS_FILES = (
     "10_helpers.js",              # esc / fmtN / pad / STATUS_LABEL / setConnStatus
     "20_load_and_render.js",      # async loadAndRender (KPI / ranking / sparkline / projects)
+    "25_live_diff.js",            # live mode 差分 highlight + toast (Issue #69)
     "30_renderers_patterns.js",   # heatmap / cooccurrence / project×skill matrix renderers
     "40_renderers_quality.js",    # subagent percentile / failure / permission / compact renderers
     "50_renderers_surface.js",    # Surface invocation / lifecycle / hibernating + fmtDur

--- a/dashboard/template/scripts/20_load_and_render.js
+++ b/dashboard/template/scripts/20_load_and_render.js
@@ -262,5 +262,20 @@
   // dynamic re-render 後の help-pop 再配置 (Issue #41)。kpiRow を含む全 popup を
   // walk して、右端 KPI tooltip の viewport overflow を防ぐ。
   placeAllPops();
+
+  // Issue #69: live mode のときだけ差分 highlight + 更新概要 toast を発火。
+  // static export (window.__DATA__) 経路では prevSnapshot の比較相手が無く、
+  // diff が UX 上 noise なので skip する。__livePrev は 25_live_diff.js 側に
+  // closure-private に置かれていて、ここからは read-only 参照 + commit helper
+  // 経由でのみ更新する (catch 経路で commit を呼ばない契約を構造保証)。
+  if (typeof window === 'undefined' || typeof window.__DATA__ === 'undefined') {
+    const __liveNext = buildLiveSnapshot(data);
+    if (__livePrev !== null) {
+      const __liveDiff = diffLiveSnapshot(__livePrev, __liveNext);
+      applyHighlights(__liveDiff);
+      showLiveToast(formatToastSummary(__liveDiff));
+    }
+    commitLiveSnapshot(__liveNext);
+  }
   } // end loadAndRender
 

--- a/dashboard/template/scripts/20_load_and_render.js
+++ b/dashboard/template/scripts/20_load_and_render.js
@@ -46,7 +46,7 @@
 
   document.getElementById('kpiRow').innerHTML = kpis.map(g => {
     const popId = 'hp-' + g.id;
-    return '<div class="kpi ' + g.cls + (g.warn?' warn':'') + '">' +
+    return '<div class="kpi ' + g.cls + (g.warn?' warn':'') + '" id="' + g.id + '">' +
       '<div class="k-row">' +
         '<span class="k">' + esc(g.k) + '</span>' +
         '<span class="help-host">' +

--- a/dashboard/template/scripts/25_live_diff.js
+++ b/dashboard/template/scripts/25_live_diff.js
@@ -11,7 +11,7 @@
   //   するため、per-element timer state は WeakMap (NOT Map) で持つ。
   let __livePrev = null;
   let __toastTimer = null;       // display 期間終了 → fade-out 開始 timer
-  let __toastFadeTimer = null;   // fade-out transition 終了 → hidden = true timer
+  let __toastFadeTimer = null;   // fade-out animation 終了 → hidden = true timer
   const __highlightTimers = new WeakMap();
 
   // KPI / lede / ranking row のラベル定義。toast 対象 (LABEL テーブル) と
@@ -28,7 +28,7 @@
   ];
   const __TOAST_MAX_SEGMENTS = 4;
   const __HIGHLIGHT_MS = 1500;
-  const __TOAST_MS = 6000;
+  const __TOAST_MS = 4000;
   // CSS の `.toast { transition: opacity 240ms ease, transform 240ms ease }` と同期。
   // `.show` を remove したあと `__TOAST_FADE_MS` 経過してから `hidden = true` にする
   // ことで fade-out transition を見える状態で完走させる (display: none で transition
@@ -187,23 +187,33 @@
       el.hidden = true;
       el.textContent = '';
       el.classList.remove('show');
+      el.classList.remove('fading');
       return;
     }
     el.textContent = msg;
     el.hidden = false;
+    // 「上書きされた」signal を確実に出すため CSS animation (@keyframes toast-in)
+    // を毎回再起動する。CSS transition (前後値の差分判定) ではなく CSS animation
+    // (class が付いた瞬間に再生) を使うことで、表示中の toast に re-trigger が
+    // 来ても reflow trick (`.remove + offsetWidth + .add`) で確実に slide-in が
+    // 再生される (CSS transition 方式だと Browser が同フレーム内の連続 style 変更を
+    // collapse して transition を skip する問題があり、実機検証で動かないことを確認済)。
+    //
+    // prefers-reduced-motion 環境では CSS 側で animation を無効化し opacity の
+    // transition のみ残す (10_components.css 参照)。
     el.classList.remove('show');
+    el.classList.remove('fading');
     void el.offsetWidth;
     el.classList.add('show');
     __toastTimer = setTimeout(() => {
-      // fade-out transition を発火。`.show` を remove することで CSS の
-      // `opacity: 1 → 0` / `transform: translate(-50%, 0) → translate(-50%, -6px)`
-      // が走り出す。display: none を即座に当てると transition が打ち切られるため、
-      // __TOAST_FADE_MS 後に `hidden = true` にする (順序が逆だと fade-out が
-      // 視覚的に見えない)。
+      // fade-out animation (@keyframes toast-out) を発火。display: none を即座に
+      // 当てると animation が打ち切られるため、__TOAST_FADE_MS 後に hidden = true。
       el.classList.remove('show');
+      el.classList.add('fading');
       __toastTimer = null;
       __toastFadeTimer = setTimeout(() => {
         el.hidden = true;
+        el.classList.remove('fading');
         __toastFadeTimer = null;
       }, __TOAST_FADE_MS);
     }, __TOAST_MS);

--- a/dashboard/template/scripts/25_live_diff.js
+++ b/dashboard/template/scripts/25_live_diff.js
@@ -13,6 +13,16 @@
   let __toastTimer = null;       // display 期間終了 → fade-out 開始 timer
   let __toastFadeTimer = null;   // fade-out animation 終了 → hidden = true timer
   const __highlightTimers = new WeakMap();
+  // SSE refresh / hashchange からの loadAndRender 並行発火による stale-snapshot
+  // race を直列化で防ぐための state。
+  //   __activeRender    : 現在 in-flight の loadAndRender 結果 promise (なければ null)
+  //   __pendingRefresh  : in-flight 中に追加 schedule された場合の coalesce フラグ
+  // race の具体例: fetch1 / fetch2 が overlap し fetch2 が先に return → DOM が
+  // 古い fetch1 の data で上書きされ commitLiveSnapshot で __livePrev が snap1 に
+  // 巻き戻る → 次の refresh diff が「snap1 → 現在」の累積 delta を toast に
+  // 出してしまう。serialization で fetch を必ず順番に流すことで構造的に防ぐ。
+  let __activeRender = null;
+  let __pendingRefresh = false;
 
   // KPI / lede / ranking row のラベル定義。toast 対象 (LABEL テーブル) と
   // highlight のみの key を分離する。順序固定 = priority order を兼ねる
@@ -223,6 +233,39 @@
     __livePrev = next;
   }
 
+  // loadAndRender の overlap を直列化する wrapper。
+  //
+  // 70_init_eventsource.js の SSE message handler / 60_hashchange_listener.js
+  // から fire-and-forget で呼ばれる経路を経由させ、in-flight 中の追加要求は
+  // __pendingRefresh = true で coalesce し、現 render 完了後に 1 回だけ追加 fire
+  // する。これにより:
+  //   - DOM (kpiRow / skillBody / sparkline 等) が古い data の遅延 return で上書き
+  //     されるのを防ぐ
+  //   - commitLiveSnapshot の writer も常に 1 つに絞られるため __livePrev の
+  //     stale snapshot 巻き戻りを構造的に防ぐ
+  //   - burst 中に queue が肥大しない (常に最大 1 件 pending)
+  //
+  // Promise.resolve().then(...) で loadAndRender 呼出を 1 microtask 遅延させて
+  // いるのは、`scheduleLoadAndRender()` の戻り値で `__activeRender` を見せた
+  // 直後に同期的に loadAndRender を呼ばないためで、テスト時の microtask flush
+  // 観測を簡単にする副次効果もある。
+  function scheduleLoadAndRender() {
+    if (__activeRender) {
+      __pendingRefresh = true;
+      return __activeRender;
+    }
+    __activeRender = Promise.resolve()
+      .then(function () { return loadAndRender(); })
+      .finally(function () {
+        __activeRender = null;
+        if (__pendingRefresh) {
+          __pendingRefresh = false;
+          scheduleLoadAndRender();
+        }
+      });
+    return __activeRender;
+  }
+
   // test fixture / dev probe からの read-only access。production 経路では使わない
   // (20 番からは diffLiveSnapshot の第一引数として渡す path のみ)。
   if (typeof window !== 'undefined') {
@@ -231,6 +274,7 @@
       diffLiveSnapshot,
       formatToastSummary,
       commitLiveSnapshot,
+      scheduleLoadAndRender,
       getLivePrev: function () { return __livePrev; },
     };
   }

--- a/dashboard/template/scripts/25_live_diff.js
+++ b/dashboard/template/scripts/25_live_diff.js
@@ -1,0 +1,208 @@
+  // Issue #69: live ダッシュボードの差分ハイライト + 更新概要 toast。
+  //
+  // ・closure-private state は 25 番ファイル冒頭 (= 全 main_js を wrap する単一
+  //   IIFE 直下) に置く。20 番の loadAndRender が呼ばれる時点で評価済になるため
+  //   TDZ ReferenceError は構造的に発生しない。
+  // ・`commitLiveSnapshot(next)` を `__livePrev` への唯一の writer とし、
+  //   20_load_and_render.js からの直接代入を禁止 (literal pin で grep 可能)。
+  //   catch 経路で commit を呼ばないことで、fetch 失敗を跨いで snap1→snap3 の
+  //   累積 delta が toast に出る (= 「失敗中も裏で動いていた」signal)。
+  // ・rank row は loadAndRender ごとに innerHTML 完全置換で element 参照が detach
+  //   するため、per-element timer state は WeakMap (NOT Map) で持つ。
+  let __livePrev = null;
+  let __toastTimer = null;
+  const __highlightTimers = new WeakMap();
+
+  // KPI / lede / ranking row のラベル定義。toast 対象 (LABEL テーブル) と
+  // highlight のみの key を分離する。順序固定 = priority order を兼ねる
+  // (5 種以上同時 delta 時に先頭 4 セグメントが残る)。
+  const __TOAST_LABELS = [
+    { id: 'kpi-total',   sing: 'event',                plur: 'events' },
+    { id: 'kpi-skills',  sing: 'skill',                plur: 'skills' },
+    { id: 'kpi-subs',    sing: 'subagent invocation',  plur: 'subagent invocations' },
+    { id: 'kpi-sess',    sing: 'session',              plur: 'sessions' },
+    { id: 'kpi-projs',   sing: 'project',              plur: 'projects' },
+    { id: 'kpi-compact', sing: 'compaction',           plur: 'compactions' },
+    { id: 'kpi-perm',    sing: 'permission',           plur: 'permissions' },
+  ];
+  const __TOAST_MAX_SEGMENTS = 4;
+  const __HIGHLIGHT_MS = 1500;
+  const __TOAST_MS = 4000;
+
+  function buildLiveSnapshot(data) {
+    const d = (data && typeof data === 'object') ? data : {};
+    const ss = (d.session_stats && typeof d.session_stats === 'object') ? d.session_stats : {};
+    const skillRanking = Array.isArray(d.skill_ranking) ? d.skill_ranking : [];
+    const subRanking = Array.isArray(d.subagent_ranking) ? d.subagent_ranking : [];
+    const projects = Array.isArray(d.project_breakdown) ? d.project_breakdown : [];
+    const buckets = (d.hourly_heatmap && Array.isArray(d.hourly_heatmap.buckets))
+      ? d.hourly_heatmap.buckets : [];
+    const localDays = localDailyFromHourly(buckets);
+
+    const kpi = {
+      'kpi-total':   Number(d.total_events) || 0,
+      'kpi-skills':  skillRanking.length,
+      'kpi-subs':    subRanking.length,
+      'kpi-projs':   projects.length,
+      'kpi-sess':    Number(ss.total_sessions) || 0,
+      'kpi-resume':  Number(ss.resume_rate) || 0,
+      'kpi-compact': Number(ss.compact_count) || 0,
+      'kpi-perm':    Number(ss.permission_prompt_count) || 0,
+    };
+    const lede = {
+      ledeEvents:   Number(d.total_events) || 0,
+      ledeDays:     localDays.length,
+      ledeProjects: projects.length,
+    };
+    const rankSkill = new Map();
+    for (const it of skillRanking) {
+      if (it && typeof it.name === 'string' && it.name) {
+        rankSkill.set(it.name, Number(it.count) || 0);
+      }
+    }
+    const rankSub = new Map();
+    for (const it of subRanking) {
+      if (it && typeof it.name === 'string' && it.name) {
+        rankSub.set(it.name, Number(it.count) || 0);
+      }
+    }
+    return { kpi, lede, rankSkill, rankSub };
+  }
+
+  function diffLiveSnapshot(prev, next) {
+    const empty = { kpi: [], lede: [], rankSkill: [], rankSub: [] };
+    if (prev === null || prev === undefined || !next) return empty;
+    const kpi = [];
+    for (const id of Object.keys(next.kpi || {})) {
+      const cur = Number(next.kpi[id]) || 0;
+      const old = Number((prev.kpi || {})[id]) || 0;
+      const delta = cur - old;
+      if (delta > 0) kpi.push({ id, delta });
+    }
+    const lede = [];
+    for (const id of Object.keys(next.lede || {})) {
+      const cur = Number(next.lede[id]) || 0;
+      const old = Number((prev.lede || {})[id]) || 0;
+      const delta = cur - old;
+      if (delta > 0) lede.push({ id, delta });
+    }
+    const rankSkill = __diffRankMap(prev.rankSkill, next.rankSkill);
+    const rankSub = __diffRankMap(prev.rankSub, next.rankSub);
+    return { kpi, lede, rankSkill, rankSub };
+  }
+
+  function __diffRankMap(prevMap, nextMap) {
+    const out = [];
+    if (!nextMap || typeof nextMap.forEach !== 'function') return out;
+    nextMap.forEach((cur, name) => {
+      const old = (prevMap && typeof prevMap.get === 'function' && prevMap.has(name))
+        ? Number(prevMap.get(name)) || 0
+        : 0;
+      const delta = (Number(cur) || 0) - old;
+      if (delta > 0) out.push({ name, delta });
+    });
+    return out;
+  }
+
+  function formatToastSummary(diff) {
+    if (!diff || !Array.isArray(diff.kpi)) return '';
+    const byId = new Map(diff.kpi.map(e => [e.id, e.delta]));
+    const segments = [];
+    for (const lab of __TOAST_LABELS) {
+      const delta = byId.get(lab.id);
+      if (typeof delta !== 'number' || delta <= 0) continue;
+      const label = (delta === 1) ? lab.sing : lab.plur;
+      segments.push('+' + delta + ' ' + label);
+      if (segments.length >= __TOAST_MAX_SEGMENTS) break;
+    }
+    return segments.join(' · ');
+  }
+
+  function applyHighlights(diff) {
+    if (!diff || typeof document === 'undefined') return;
+    if (Array.isArray(diff.kpi)) {
+      for (const e of diff.kpi) __bumpById(e.id);
+    }
+    if (Array.isArray(diff.lede)) {
+      for (const e of diff.lede) __bumpById(e.id);
+    }
+    if (Array.isArray(diff.rankSkill)) {
+      for (const e of diff.rankSkill) __bumpRankRow(e.name, 'skill');
+    }
+    if (Array.isArray(diff.rankSub)) {
+      for (const e of diff.rankSub) __bumpRankRow(e.name, 'subagent');
+    }
+  }
+
+  function __bumpById(id) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    __bumpElement(el);
+  }
+
+  function __bumpRankRow(name, kind) {
+    const root = document.getElementById(kind === 'subagent' ? 'subBody' : 'skillBody');
+    if (!root) return;
+    // CSS attribute selector に流す前にエスケープ。"\\" の literal で 1 個の
+    // バックスラッシュを送る (attribute value 内の特殊文字 quoting)。
+    const safeName = String(name).replace(/(["\\])/g, '\\$1');
+    const el = root.querySelector('.rank-row[data-name="' + safeName + '"]');
+    if (!el) return;
+    __bumpElement(el);
+  }
+
+  function __bumpElement(el) {
+    const prevTimer = __highlightTimers.get(el);
+    if (prevTimer) {
+      clearTimeout(prevTimer);
+      el.classList.remove('bumped');
+      // animation 再起動 (reflow) — 同 element の連続 bump で先頭 frame からやり直す
+      void el.offsetWidth;
+    }
+    el.classList.add('bumped');
+    const t = setTimeout(() => {
+      el.classList.remove('bumped');
+      __highlightTimers.delete(el);
+    }, __HIGHLIGHT_MS);
+    __highlightTimers.set(el, t);
+  }
+
+  function showLiveToast(msg) {
+    if (typeof document === 'undefined') return;
+    const el = document.getElementById('liveToast');
+    if (!el) return;
+    if (!msg) {
+      el.hidden = true;
+      el.textContent = '';
+      if (__toastTimer) { clearTimeout(__toastTimer); __toastTimer = null; }
+      return;
+    }
+    el.textContent = msg;
+    el.hidden = false;
+    el.classList.remove('show');
+    void el.offsetWidth;
+    el.classList.add('show');
+    if (__toastTimer) clearTimeout(__toastTimer);
+    __toastTimer = setTimeout(() => {
+      el.hidden = true;
+      el.classList.remove('show');
+      __toastTimer = null;
+    }, __TOAST_MS);
+  }
+
+  function commitLiveSnapshot(next) {
+    __livePrev = next;
+  }
+
+  // test fixture / dev probe からの read-only access。production 経路では使わない
+  // (20 番からは diffLiveSnapshot の第一引数として渡す path のみ)。
+  if (typeof window !== 'undefined') {
+    window.__liveDiff = {
+      buildLiveSnapshot,
+      diffLiveSnapshot,
+      formatToastSummary,
+      commitLiveSnapshot,
+      getLivePrev: function () { return __livePrev; },
+    };
+  }
+

--- a/dashboard/template/scripts/25_live_diff.js
+++ b/dashboard/template/scripts/25_live_diff.js
@@ -10,7 +10,8 @@
   // ・rank row は loadAndRender ごとに innerHTML 完全置換で element 参照が detach
   //   するため、per-element timer state は WeakMap (NOT Map) で持つ。
   let __livePrev = null;
-  let __toastTimer = null;
+  let __toastTimer = null;       // display 期間終了 → fade-out 開始 timer
+  let __toastFadeTimer = null;   // fade-out transition 終了 → hidden = true timer
   const __highlightTimers = new WeakMap();
 
   // KPI / lede / ranking row のラベル定義。toast 対象 (LABEL テーブル) と
@@ -27,7 +28,14 @@
   ];
   const __TOAST_MAX_SEGMENTS = 4;
   const __HIGHLIGHT_MS = 1500;
-  const __TOAST_MS = 4000;
+  const __TOAST_MS = 6000;
+  // CSS の `.toast { transition: opacity 240ms ease, transform 240ms ease }` と同期。
+  // `.show` を remove したあと `__TOAST_FADE_MS` 経過してから `hidden = true` にする
+  // ことで fade-out transition を見える状態で完走させる (display: none で transition
+  // を打ち切らない)。CSS 側を変えたらこの定数も同期して変えること。
+  // prefers-reduced-motion 環境では CSS transition が 200ms に短縮されるが、240ms
+  // 待つことでフェード完了後の hidden 化を構造的に保証する。
+  const __TOAST_FADE_MS = 240;
 
   function buildLiveSnapshot(data) {
     const d = (data && typeof data === 'object') ? data : {};
@@ -171,10 +179,14 @@
     if (typeof document === 'undefined') return;
     const el = document.getElementById('liveToast');
     if (!el) return;
+    // 連続 refresh で複数 toast が来たら、前回の display end / fade-out end の
+    // どちらの timer も取り消して新 toast の lifecycle を 0 から始める。
+    if (__toastTimer) { clearTimeout(__toastTimer); __toastTimer = null; }
+    if (__toastFadeTimer) { clearTimeout(__toastFadeTimer); __toastFadeTimer = null; }
     if (!msg) {
       el.hidden = true;
       el.textContent = '';
-      if (__toastTimer) { clearTimeout(__toastTimer); __toastTimer = null; }
+      el.classList.remove('show');
       return;
     }
     el.textContent = msg;
@@ -182,11 +194,18 @@
     el.classList.remove('show');
     void el.offsetWidth;
     el.classList.add('show');
-    if (__toastTimer) clearTimeout(__toastTimer);
     __toastTimer = setTimeout(() => {
-      el.hidden = true;
+      // fade-out transition を発火。`.show` を remove することで CSS の
+      // `opacity: 1 → 0` / `transform: translate(-50%, 0) → translate(-50%, -6px)`
+      // が走り出す。display: none を即座に当てると transition が打ち切られるため、
+      // __TOAST_FADE_MS 後に `hidden = true` にする (順序が逆だと fade-out が
+      // 視覚的に見えない)。
       el.classList.remove('show');
       __toastTimer = null;
+      __toastFadeTimer = setTimeout(() => {
+        el.hidden = true;
+        __toastFadeTimer = null;
+      }, __TOAST_FADE_MS);
     }, __TOAST_MS);
   }
 

--- a/dashboard/template/scripts/60_hashchange_listener.js
+++ b/dashboard/template/scripts/60_hashchange_listener.js
@@ -1,7 +1,9 @@
   // hashchange → loadAndRender 再実行 (Issue #58 Q2)。router IIFE が先に
   // body.dataset.activePage を更新し、main IIFE の本リスナーが loadAndRender を
   // 呼び直すことで、page navigate 直後の page-scoped widget が即時描画される。
+  // scheduleLoadAndRender 経由で SSE refresh と並行発火しても直列化される
+  // (stale-snapshot race 対策 / 25_live_diff.js を参照)。
   window.addEventListener('hashchange', () => {
-    loadAndRender().catch((err) => console.error('route change render 失敗', err));
+    scheduleLoadAndRender().catch((err) => console.error('route change render 失敗', err));
   });
 

--- a/dashboard/template/scripts/70_init_eventsource.js
+++ b/dashboard/template/scripts/70_init_eventsource.js
@@ -1,5 +1,7 @@
   // ---- 初回描画 + EventSource (live refresh) ----
-  await loadAndRender();
+  // 初回描画も scheduleLoadAndRender 経由で統一。Init 中に hashchange が割り込んでも
+  // serialization wrapper が coalesce してくれる (25_live_diff.js を参照)。
+  await scheduleLoadAndRender();
   if (typeof window.__DATA__ !== 'undefined') {
     // 静的 export 経路では EventSource を起動せず、バッジを「静的レポート」表示に固定
     setConnStatus('static');
@@ -28,9 +30,11 @@
       }
     });
     es.addEventListener('message', (ev) => {
-      // payload は "refresh" のみだが拡張余地として弁別
+      // payload は "refresh" のみだが拡張余地として弁別。
+      // scheduleLoadAndRender 経由で並行 refresh を直列化する
+      // (stale-snapshot race 対策 / 25_live_diff.js を参照)。
       if (typeof ev.data === 'string' && ev.data.indexOf('refresh') !== -1) {
-        loadAndRender().catch(err => console.error('refresh 失敗', err));
+        scheduleLoadAndRender().catch(err => console.error('refresh 失敗', err));
       }
     });
   }

--- a/dashboard/template/shell.html
+++ b/dashboard/template/shell.html
@@ -475,6 +475,10 @@ __INCLUDE_STYLES__
 
   <div class="data-tip" id="dataTooltip" role="tooltip" aria-hidden="true"></div>
 
+  <!-- Live update toast (Issue #69) — live mode の差分概要を 1 行で短時間表示。
+       static export 経路では JS が show しないので hidden のまま。 -->
+  <div class="toast" id="liveToast" role="status" aria-live="polite" aria-atomic="true" hidden></div>
+
 <script>
 __INCLUDE_ROUTER_JS__
 </script>

--- a/dashboard/template/styles/10_components.css
+++ b/dashboard/template/styles/10_components.css
@@ -326,3 +326,63 @@
   }
   footer .accent { color: var(--mint); }
 
+  /* ---------- live diff highlight + toast (Issue #69) ---------- */
+  /* 数字が伸びた KPI / lede / ranking row に bumped class が 1.5s だけ載る。
+     box-shadow inset の単一プロパティアニメで layout-safe (隣 KPI を押しのけない)。 */
+  @keyframes pulse-bg {
+    0%   { box-shadow: inset 0 0 0 9999px rgba(111,227,200, 0.18); }
+    100% { box-shadow: inset 0 0 0 9999px rgba(111,227,200, 0); }
+  }
+  .kpi.bumped,
+  .lede .num.bumped,
+  .rank-row.bumped {
+    animation: pulse-bg 1.5s ease-out;
+  }
+  /* lede 数字は inline element で box-shadow が effective でない場合もあるので
+     念のため background-color の transition でも視認性を補う。 */
+  .lede .num.bumped {
+    border-radius: 3px;
+  }
+
+  .toast {
+    position: fixed;
+    top: 14px;
+    right: 14px;
+    z-index: 1000;
+    padding: 8px 14px;
+    border-radius: var(--r-pill);
+    background: var(--bg-panel);
+    border: 1px solid var(--mint-soft);
+    color: var(--ink);
+    font-family: var(--ff-mono);
+    font-size: 12px;
+    box-shadow: 0 4px 18px rgba(0,0,0,0.18);
+    opacity: 0;
+    transform: translateY(-6px);
+    pointer-events: none;
+    transition: opacity 240ms ease, transform 240ms ease;
+  }
+  .toast.show {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    /* pulse keyframe を切って静止 outline のみで「変化があった」signal を残す。
+       toast の slide-in も opacity fade のみに簡略化。 */
+    .kpi.bumped,
+    .lede .num.bumped,
+    .rank-row.bumped {
+      animation: none !important;
+      outline: 1px solid var(--mint);
+      outline-offset: 1px;
+    }
+    .toast {
+      transition: opacity 200ms ease;
+      transform: none;
+    }
+    .toast.show {
+      transform: none;
+    }
+  }
+

--- a/dashboard/template/styles/10_components.css
+++ b/dashboard/template/styles/10_components.css
@@ -345,11 +345,12 @@
   }
 
   /* Toast — 横方向中央寄せ + coral 系 attention color。
-     transform: translateX(-50%) は center 配置のため常に必要。slide-in 用の
-     translateY は show class の有無で 0 / -6px に切り替える (translate 関数で
-     X/Y 同時指定)。reduced-motion 環境では translateX(-50%) のみ残し translateY
-     を 0 固定にすることで "static center" を保つ (CSS で translate を完全 unset
-     すると左寄せに戻ってしまうため)。 */
+     transform: translateX(-50%) は center 配置のため常に必要 (translate 関数で
+     X/Y 同時指定)。slide-in / fade-out は CSS @keyframes で実装。CSS transition
+     方式だと表示中の上書き re-trigger 時に Browser が同フレーム内の連続 style 変更を
+     collapse して transition を skip する問題がある (実機検証で確認)。CSS animation
+     は class の remove → reflow → add で確実に再起動する classic pattern を取れる
+     ため、「上書きされた」signal を毎回確実に見せられる。 */
   .toast {
     position: fixed;
     top: 14px;
@@ -366,16 +367,30 @@
     opacity: 0;
     transform: translate(-50%, -6px);
     pointer-events: none;
-    transition: opacity 240ms ease, transform 240ms ease;
+  }
+  @keyframes toast-in {
+    from { opacity: 0; transform: translate(-50%, -6px); }
+    to   { opacity: 1; transform: translate(-50%, 0); }
+  }
+  @keyframes toast-out {
+    from { opacity: 1; transform: translate(-50%, 0); }
+    to   { opacity: 0; transform: translate(-50%, -6px); }
   }
   .toast.show {
     opacity: 1;
     transform: translate(-50%, 0);
+    animation: toast-in 240ms ease both;
+  }
+  .toast.fading {
+    opacity: 0;
+    transform: translate(-50%, -6px);
+    animation: toast-out 240ms ease forwards;
   }
 
   @media (prefers-reduced-motion: reduce) {
     /* pulse keyframe を切って静止 outline のみで「変化があった」signal を残す。
-       toast の slide-in も opacity fade のみに簡略化。 */
+       toast の slide も止めて opacity fade のみに簡略化 (translate(-50%, 0) は
+       center 配置のため必須なので keep)。 */
     .kpi.bumped,
     .lede .num.bumped,
     .rank-row.bumped {
@@ -384,11 +399,15 @@
       outline-offset: 1px;
     }
     .toast {
+      transform: translate(-50%, 0);
+    }
+    .toast.show,
+    .toast.fading {
+      animation: none !important;
+      transform: translate(-50%, 0);
       transition: opacity 200ms ease;
-      transform: translate(-50%, 0);
     }
-    .toast.show {
-      transform: translate(-50%, 0);
-    }
+    .toast.show { opacity: 1; }
+    .toast.fading { opacity: 0; }
   }
 

--- a/dashboard/template/styles/10_components.css
+++ b/dashboard/template/styles/10_components.css
@@ -344,27 +344,33 @@
     border-radius: 3px;
   }
 
+  /* Toast — 横方向中央寄せ + coral 系 attention color。
+     transform: translateX(-50%) は center 配置のため常に必要。slide-in 用の
+     translateY は show class の有無で 0 / -6px に切り替える (translate 関数で
+     X/Y 同時指定)。reduced-motion 環境では translateX(-50%) のみ残し translateY
+     を 0 固定にすることで "static center" を保つ (CSS で translate を完全 unset
+     すると左寄せに戻ってしまうため)。 */
   .toast {
     position: fixed;
     top: 14px;
-    right: 14px;
+    left: 50%;
     z-index: 1000;
     padding: 8px 14px;
     border-radius: var(--r-pill);
     background: var(--bg-panel);
-    border: 1px solid var(--mint-soft);
-    color: var(--ink);
+    border: 1px solid var(--coral-soft);
+    color: var(--coral);
     font-family: var(--ff-mono);
     font-size: 12px;
-    box-shadow: 0 4px 18px rgba(0,0,0,0.18);
+    box-shadow: 0 4px 18px rgba(255,138,118, 0.22);
     opacity: 0;
-    transform: translateY(-6px);
+    transform: translate(-50%, -6px);
     pointer-events: none;
     transition: opacity 240ms ease, transform 240ms ease;
   }
   .toast.show {
     opacity: 1;
-    transform: translateY(0);
+    transform: translate(-50%, 0);
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -379,10 +385,10 @@
     }
     .toast {
       transition: opacity 200ms ease;
-      transform: none;
+      transform: translate(-50%, 0);
     }
     .toast.show {
-      transform: none;
+      transform: translate(-50%, 0);
     }
   }
 

--- a/docs/plans/69-live-update-highlight.md
+++ b/docs/plans/69-live-update-highlight.md
@@ -1,0 +1,343 @@
+# Issue #69 — Live ダッシュボード差分ハイライト + 更新概要 toast
+
+## 🎯 Goal & Scope
+
+Issue 本文（Light variant）の 2 intent:
+
+1. ライブ更新時、**変化した数字（KPI tile / lede / ranking row count）を視覚的に目立たせる**
+2. **更新概要を toast** で短時間表示する
+
+→ ユーザーが画面を見ているときに「いま何が伸びたか」が一瞥でわかり、長いセッション中の「いつの間にか数字が動いていた」状態を解消する。
+
+### Scope
+
+- **対象数字**: Overview ページのみ。具体的には KPI tiles 8 種 (`kpi-total` / `kpi-skills` / `kpi-subs` / `kpi-projs` / `kpi-sess` / `kpi-resume` / `kpi-compact` / `kpi-perm`) + lede 数字 3 種 (`ledeEvents` / `ledeDays` / `ledeProjects`) + ranking rows の name 単位 count (skill_ranking / subagent_ranking)
+- **動作経路**: live mode (`EventSource` 経由 `/events` refresh) のみ。静的 export (`window.__DATA__` 経由) では highlight も toast も発火しない（diff 比較相手が無い + UX 上 noise）
+- **Toast 内容**: 1 行 aggregate (`+5 events · +1 skill · +2 subagent invocations`)。複数 SSE refresh が連発したときは最新 toast で置換 (queue しない)
+- **First-render**: 初回 `loadAndRender()` は `prevSnapshot === null` の状態を構造的に保ち、highlight も toast も**出さない**
+
+### Out of scope (本 PR の境界)
+
+- Patterns / Quality / Surface タブの数字 highlight（タブ非表示で highlight しても見えず、見える化された toast に「裏で +10 events」と書いても scope が膨れて UX 検証が難しい）
+- Toast の click-to-dismiss / hover で持続 / 履歴 / 通知音
+- Sparkline / hourly heatmap / cooccurrence / failure trend / compact density / percentile / permission breakdown / surface 3 panel の cell-level 強調（まずは「視野 1 で見える数字」に focus し、視覚 noise を最小化）
+- **減少**の強調（KPI 数値が減るケースは retention や archive 化のタイミング以外ほぼ無く、本番 UX ノイズになる）。`delta > 0` のみ highlight。delta=0 (= 不変) も highlight しない
+- 静的 export での再現
+
+## 📐 設計概要 — 主要設計判断
+
+### D1. Diff の単位 — 「key → 前回値」 Map を closure 内に保持
+
+選択: **closure 内の `prevSnapshot` Map** を `loadAndRender()` の外側に置き、毎回の render 末尾で「次回比較用の next snapshot」に置き換える。
+
+理由: render 関数は副作用 (DOM 完全置換) を持つ既存設計。**diff を render 内に閉じ込める**設計だと「render → DOM 置換 → diff 取り → highlight class 付与」を同期で書ける。「前回値を返す flow」設計より既存コードへの侵襲が小さい。`window.__DATA__` 経由 (static export) では `prevSnapshot` を初期化しない or 常に `null` にし、highlight 経路に入らない。
+
+snapshot schema (内部 JS object):
+```js
+{
+  kpi: { 'kpi-total': 1234, 'kpi-skills': 8, ... },   // 8 entries
+  lede: { ledeEvents: 1234, ledeDays: 12, ledeProjects: 3 },
+  rankSkill:  Map<name, count>,    // skill_ranking name 単位
+  rankSub:    Map<name, count>,    // subagent_ranking name 単位
+}
+```
+
+#### concat 順序 / TDZ 安全性根拠
+
+shell.html は全 main_js を `(async function(){ __INCLUDE_MAIN_JS__ })();` で wrap している (= **単一の async IIFE**)。ES module ではないため hoisting/TDZ は **同一 IIFE 内の lexical scoping** に基づく。
+
+`_MAIN_JS_FILES` 並びは `00 → 10 → 20 → 25 → 30 → ...`。`let __livePrev = null` は **25 番ファイル冒頭 (IIFE 直下)** に置き、20 番ファイル内の `loadAndRender()` の **関数 body** からのみ参照する。
+
+- 20 番の IIFE 直下 (関数定義の外側) には `__livePrev` の **宣言文 (`let / var / const __livePrev`) を置かない** (declaration-only check で grep 可能)
+- `loadAndRender()` は async 関数で実行時に呼ばれるため、その時点では 25 番の `let` は評価済み → ReferenceError は構造的に発生しない
+- Phase 1-a の literal pin で 2 つを保証:
+  - `test_load_render_does_not_redeclare_liveprev` — 20 番に `let __livePrev` / `var __livePrev` / `const __livePrev` の **宣言文が無い** (grep で簡潔に確認可能 — JS parser 不要)
+  - `test_25_declares_liveprev_at_iife_top` — 25 番冒頭 (関数定義より前) に `let __livePrev` 宣言が存在
+
+### D2. Highlight 表現 — 背景色 pulse (1.5s, ease-out, fade)
+
+選択: **CSS `@keyframes pulse-bg`** で 1.5 秒で fade out する mint-tinted 背景パルス。ranking row は同 keyframe を `.rank-row.bumped` で適用、KPI tile は `.kpi.bumped`、lede 数字は `.num.bumped`。
+
+理由:
+- border flash は KPI tile の `::before` (top accent line) と競合して見にくい
+- scale bump (transform) は隣接 KPI を押しのけて layout shift を生む。dashboard の 8-col grid は密で許容できない
+- 背景 pulse は `box-shadow: inset 0 0 0 transparent → mint @ 0.18 → transparent` の単一プロパティアニメで layout-safe
+- **`prefers-reduced-motion: reduce`** では keyframe を無効化し、代わりに 1.5s 後に消える静的 outline のみ残す（toast の slide-in も同条件で無効化）
+
+class 付与 → 1500ms 後に `classList.remove('bumped')` する `setTimeout`。複数連続の SSE refresh で同要素が再 bump するときは `void el.offsetWidth` で animation を再起動する。
+
+### D3. Toast 表現 — 1 行 aggregate / top-right / 4s 自動消滅
+
+選択: **画面右上に固定 (position: fixed; top: 14px; right: 14px)** な単一 toast 要素。SSE refresh ごとに**置換** (queue しない)。
+
+形式（例）:
+```
++12 events · +1 skill · +2 subagent · +3 sessions
+```
+
+ルール:
+- delta > 0 のフィールドだけ列挙、最大 4 セグメント
+- 順序固定: events → skills → subagent → sessions → projects → compact → permission（KPI 並び順から `kpi-resume` を除外し、後述 LABEL テーブルで toast 対象を絞る）。**この順序が priority order を兼ねる** — 5 種以上 delta が同時発火したときは先頭 4 セグメントが残る (Phase 1-b の `test_format_toast_summary_caps_at_four_segments` が LABEL テーブル順を前提に pin)
+- 全 delta = 0 のときは toast を出さない（無音 refresh = ファイル mtime touch だけ等）
+- `prefers-reduced-motion: reduce` のときは slide-in を opacity fade のみに簡略化
+- `aria-live="polite"` + `role="status"` でスクリーンリーダーにも届ける（ただし日本語化は既存 dashboard の慣習に従い formatter で英語アグリゲートのまま提示）
+
+要素は shell.html に **`<div class="toast" id="liveToast" role="status" aria-live="polite" aria-atomic="true" hidden></div>`** を追加（footer の直前に置き z-order top）。
+
+#### Toast LABEL テーブル — 唯一の真実源
+
+各 KPI に対する toast セグメントの**ラベル文言（singular / plural）**、**delta 単位**、**toast 対象に含めるか**を pin する。実装と test の唯一の真実源。
+
+| KPI id | label (singular / plural) | delta 単位 | toast 対象? | 備考 |
+|---|---|---|---|---|
+| `kpi-total` | event / events | int | ○ | events 増分 |
+| `kpi-skills` | skill / skills | int | ○ | skill kind 数の増分 (新登場 skill 観測時のみ立つ) |
+| `kpi-subs` | subagent invocation / subagent invocations | int | ○ | 新 subagent kind 数の増分 |
+| `kpi-sess` | session / sessions | int | ○ | session 数の増分 |
+| `kpi-projs` | project / projects | int | ○ | project (cwd 単位) 数の増分 |
+| `kpi-resume` | — | ratio | × | ratio 値で加算 delta が UX 上意味不明 → toast 除外 (highlight のみ) |
+| `kpi-compact` | compaction / compactions | int | ○ | PreCompact 増分 |
+| `kpi-perm` | permission / permissions | int | ○ | permission prompt 増分 |
+
+ranking row (`rankSkill` / `rankSub`) と lede (`ledeEvents` / `ledeDays` / `ledeProjects`) は**toast には載せず highlight のみ**（toast に「+5 lede events」「+1 codex-review use」を入れると KPI 数値と二重カウントで読みにくい）。
+
+`prefers-reduced-motion` 配慮や aria 属性は toast 表示の有無にかかわらず適用。LABEL テーブルから外れた KPI (`kpi-resume`) も**highlight 経路は走る** (= 数字が動いたらパルスは出る)。
+
+### D4. Diff 比較 scope — Overview のみ（minimal 推奨）
+
+選択: KPI 8 + lede 3 + ranking rows (skill / subagent) のみ。
+
+理由:
+- Patterns / Quality / Surface はタブ非アクティブ時に `hidden` で見えない。highlight 付与しても無意味
+- Toast に「+1 hourly bucket」「+2 cooccurrence pairs」を入れても understanding が伴わず UX noise
+- 後続 Issue で「Patterns タブにいるときは Patterns の数字も拾う」拡張は active page 検知で素直に追加可能（`document.querySelector('section.page:not([hidden])').dataset.page`）。今回は構造を「key → value Map」設計にして将来拡張余地だけ残す
+
+### D5. First-render / reconnect 直後の扱い
+
+選択: `prevSnapshot = null` のときは highlight / toast 経路を完全 skip。`loadAndRender()` の末尾で `prevSnapshot = computeNextSnapshot(data)` を必ず実行することで、**初回 render が「次回の prev」になる**。
+
+reconnect (SSE 再接続) は EventSource の自動再接続で `loadAndRender()` 自体が呼ばれないため特別扱い不要。ユーザーが page reload したときは module 評価から始まるので `prevSnapshot = null` に自然に戻り、reload 直後の SSE refresh 1 発目は diff 無し（= toast 無し）になる。これは「ユーザーが意図的に reload した直後の noise」を構造的に防ぐ。
+
+#### Fetch 失敗時の `__livePrev` 取扱いポリシー
+
+現行 `loadAndRender()` は `data` 取得失敗時 `console.error` + early-return する catch 経路を持つ。本機能は **catch 経路で `__livePrev` を更新しない** (= 前回成功時の baseline を保持)。
+
+意図:
+- 「初回成功 (snapshot1 保存) → 2 回目失敗 (catch return / prev は snapshot1 のまま) → 3 回目成功」のとき、3 回目で `snapshot3 vs snapshot1` の **2 回分累積 delta** が toast に出る
+- これは「fetch が間欠的に失敗していた間も裏で何か動いていた」signal として **意図的**。逆に catch で `__livePrev = null` にリセットすると 3 回目の toast が出なくなり、「失敗をまたいだ」観測が抜ける
+
+**構造的強制 — `commitLiveSnapshot(next)` helper の導入**:
+
+`__livePrev` への代入を `25_live_diff.js` の `commitLiveSnapshot(next)` helper に**閉じ込める**。`20_load_and_render.js` 側は `commitLiveSnapshot(__liveNext)` を success path の末尾でだけ呼ぶ。これにより:
+- 20 番から `__livePrev = ...` の直接代入を**禁止**できる (literal pin で grep 可能)
+- catch 経路で `commitLiveSnapshot()` を呼ばない契約を構造的に保証
+- `commitLiveSnapshot` 単体は pure (引数を `__livePrev` に代入し読み出すだけ) なので Node round-trip でも pin 可能
+
+Phase 1 で pin する 2 本セット:
+- Phase 1-a literal pin: `test_load_render_does_not_directly_assign_liveprev` — `20_load_and_render.js` 内に `__livePrev =` (代入) が**存在しない** (commit helper 経由のみであることを構造的に保証)
+- Phase 1-b Node round-trip: `test_commit_live_snapshot_then_diff_accumulates_across_skipped_commit` — `commitLiveSnapshot(snap1)` → `diffLiveSnapshot(__livePrev, snap3)` で snap1 vs snap3 の累積 delta が出ることを直接 pin (catch 経路の擬似化 = 「commit を呼ばない」シナリオ)
+
+### D6. Ranking row の identity = name
+
+選択: rank index ではなく **name 単位**で前回 count を保持。
+
+理由: 同じ rank position でも name が入れ替わるケース (e.g. skill A 11→12 で skill B 10→11 を抜き 1 位浮上) は実機で頻発。rank index で diff を取ると「動いていない skill」も highlight されてしまう。name 単位 Map で diff し、新登場の skill (前回 Map に key 無し) も `delta = current - 0 > 0` で highlight する。
+
+### D7. 高頻度 SSE refresh への対処
+
+`server.py` の polling は default 1.0s。連発する SSE refresh で:
+- highlight: `bumped` class を再適用するときに animation 再起動 (`void el.offsetWidth` reflow trick)
+- highlight の **per-element timer cleanup**: `applyHighlights()` は要素ごとに「remove `bumped` する setTimeout id」を **`WeakMap<Element, number>`** で保持し、再 bump 時に `clearTimeout(prev)` してから新 timer を貼る。これにより「最初の bump 1500ms 後の `setTimeout` が **2 回目 animation の真ん中**で `classList.remove('bumped')` を実行してしまう race」を構造的に防ぐ
+- **WeakMap 必須**: rank row は `loadAndRender()` ごとに `#skillBody` / `#subBody` の innerHTML 完全置換で element 参照が detach する。`Map` だと detach 済 DOM を pin して slow leak になるため、必ず `WeakMap` を使う。Phase 1-a に `test_apply_highlights_uses_weakmap_for_timer_state` (`new WeakMap(` の存在 + `new Map(` を timer 用途で使っていないこと) を pin する
+- toast: 同要素の textContent 置換 + `void el.offsetWidth` で slide-in 再起動。前 toast の dismiss timer (`toastTimer`) は `clearTimeout` してから新規 timer を貼る
+
+debounce は**入れない**。Issue は「更新があったら知らせて」が intent で、debounce はその逆方向。
+
+## 📁 Critical files for Implementation
+
+新規 + 既存:
+
+- `dashboard/template/scripts/25_live_diff.js` — **新規**。`buildLiveSnapshot(data)` / `diffLiveSnapshot(prev, next)` / `applyHighlights(diff)` / `formatToastSummary(diff)` / `showLiveToast(msg)` の 5 関数。closure-private state も 25 番に置く（router/helpers が 00/10、本体 render が 20、その直後 25 で diff を「render の隣接シビング」として扱う）
+- `dashboard/template/scripts/20_load_and_render.js` — **改修**。`loadAndRender()` 末尾で `const next = buildLiveSnapshot(data); if (prev) { applyHighlights(diffLiveSnapshot(prev, next)); showLiveToast(formatToastSummary(...)); } prev = next;` を追加。`prev` は 25_live_diff.js の closure-private (export せず top-level let で IIFE 内に保持)
+- `dashboard/template/styles/10_components.css` — **改修**。`@keyframes pulse-bg` + `.bumped` 修飾 + `.toast` block + `prefers-reduced-motion` メディアクエリを追加。新ファイルを切らないのは「現状 7 ファイル運用 / 70_live_pulse.css を増やすほどの量ではない」判断
+- `dashboard/template/shell.html` — **改修**。footer 直前に `<div class="toast" id="liveToast" ...>` を追加。kpi tile span に `data-kpi-id` (既存 id を持っているので追加不要かも → 既存 `kpi-*` id をそのまま data ref に使う) / lede `<span class="num">` には既存 id がある。ranking row には `data-name` 既存 (rank renderer 出力済) があるので利用
+- `dashboard/server.py` — **改修**。`_MAIN_JS_FILES` tuple に `25_live_diff.js` を追加（`20_load_and_render.js` と `30_renderers_patterns.js` の間）。`test_dashboard_template_split.py` の `EXPECTED_TEMPLATE_SHA256` を更新（plan-reviewer に意図的更新だと示すため、コミットメッセージに sha 履歴を追加）
+- `tests/test_dashboard_live_diff.py` — **新規**。Node round-trip + static-export grep + sha256 整合の混合
+- `scripts/build_live_diff_fixture.py` — **新規** (オプショナル)。手動視覚スモーク用。2 段階の usage.jsonl を切り替えて diff 発火を再現する fixture
+
+## 🛠 Step-by-step 実装 (TDD ordering)
+
+> Phase 0 prep / Phase 1 RED (helper 単位) / Phase 2 GREEN / Phase 3 RED (renderer 統合) / Phase 4 GREEN / Phase 5 sha256 + visual smoke。各 Phase は独立 commit。
+
+### Phase 0 — preparation (commit 1)
+
+- 0.1 `tests/test_dashboard_template_split.py::EXPECTED_TEMPLATE_SHA256` の運用ルール再確認（コメントの「履歴」リストに今回 entry を追加する余地を確保）
+- 0.2 既存 dashboard JS / CSS への侵襲箇所を読んで、`prefers-reduced-motion` 判定 helper が無いことを確認 (新規導入しても既存 CSS と衝突しない)
+
+### Phase 1 — RED (helper 単位の失敗テストを書く / commit 2)
+
+新規 `tests/test_dashboard_live_diff.py` に **literal pin + Node round-trip** で以下を失敗化する。
+
+#### 1-a. literal pin (静的解析)
+
+- `test_25_live_diff_js_file_exists` — `dashboard/template/scripts/25_live_diff.js` が存在
+- `test_build_live_snapshot_function_defined` — `function buildLiveSnapshot(` が含まれる
+- `test_diff_live_snapshot_function_defined` — `function diffLiveSnapshot(` が含まれる
+- `test_apply_highlights_function_defined` — `function applyHighlights(` が含まれる
+- `test_format_toast_summary_function_defined` — `function formatToastSummary(` が含まれる
+- `test_show_live_toast_function_defined` — `function showLiveToast(` が含まれる
+- `test_25_listed_in_main_js_files_tuple` — `dashboard/server.py` の `_MAIN_JS_FILES` に `25_live_diff.js` が `20_load_and_render.js` と `30_renderers_patterns.js` の間に挟まる
+- `test_load_and_render_calls_diff_helpers` — `20_load_and_render.js` 末尾に `buildLiveSnapshot(` と `diffLiveSnapshot(` の呼び出しが新たに追加される
+- `test_assembled_template_contains_toast_element` — concat 後の `_HTML_TEMPLATE` に `id="liveToast"` が含まれる
+- `test_assembled_template_contains_pulse_keyframe` — `@keyframes pulse-bg` が含まれる
+- `test_pulse_keyframe_respects_reduced_motion` — `@media (prefers-reduced-motion: reduce)` ブロックが pulse-bg を override (e.g. `animation: none` か `animation-duration: 0.01ms`)
+- `test_load_render_does_not_redeclare_liveprev` — `20_load_and_render.js` に `let __livePrev` / `var __livePrev` / `const __livePrev` の宣言文が**存在しない** (declaration-only grep)
+- `test_25_declares_liveprev_at_iife_top` — `25_live_diff.js` の冒頭 (function 定義より前) に `let __livePrev = null` 宣言が存在
+- `test_load_render_does_not_directly_assign_liveprev` — `20_load_and_render.js` に `__livePrev =` (代入) が**存在しない** (commit helper 経由のみ強制)
+- `test_apply_highlights_uses_weakmap_for_timer_state` — `25_live_diff.js` に `new WeakMap(` が存在し、timer 用途で `new Map(` を使っていない (WeakMap 必須規約の pin)
+
+#### 1-b. Node round-trip (behavior pin)
+
+`tests/test_dashboard_local_tz.py::TestLocalDailyFromHourlyNode` と同 pattern で `_run_node` を再利用。新規 `TestBuildLiveSnapshot` / `TestDiffLiveSnapshot` / `TestFormatToastSummary` クラス:
+
+- `test_build_live_snapshot_extracts_kpi_keys` — `data = {total_events: 100, skill_ranking: [...], ...}` から `snapshot.kpi['kpi-total'] === 100` 等
+- `test_build_live_snapshot_handles_missing_data` — `data = {}` で `snapshot.kpi['kpi-total'] === 0` (defensive default)
+- `test_diff_returns_empty_when_first_render` — `prev === null` のとき diff 結果も「変化なし」を表現する empty 形を返す（toast 抑制経路）
+- `test_diff_kpi_increment_only` — KPI 値が増えたフィールドだけ delta > 0 の entry を持つ。`delta === 0` / `delta < 0` は出力に含まれない
+- `test_diff_lede_increment` — lede `ledeEvents` の delta も別 bucket に出る
+- `test_diff_ranking_new_name_treated_as_zero_baseline` — 新登場 skill (前回 Map 未登録) は `delta = current - 0` で出る
+- `test_diff_ranking_existing_name_count_growth` — 既存 skill の count 増分が正しく出る
+- `test_diff_ranking_name_disappeared_does_not_appear` — 前回 top10 にいたが今回消えた skill は diff 出力に出ない（toast のために**増分のみ**追う）
+- `test_format_toast_summary_aggregates_by_label` — diff から `+12 events · +1 skill · +2 subagent invocations` を生成
+- `test_format_toast_summary_returns_empty_when_no_growth` — delta 全 0 のとき空文字を返す（toast 表示抑制）
+- `test_format_toast_summary_skips_zero_delta_segments` — events 増えたが skills 不変なら skills セグメントは出ない
+- `test_format_toast_summary_caps_at_four_segments` — 5 種以上の delta があっても先頭 4 セグメントに切る (省略 `...` 等は付けない / segment 数 cap 規則をシンプルに)
+- `test_format_toast_summary_uses_singular_for_delta_one` — `+1 event` (events ではなく event)、`+1 skill`、`+1 subagent invocation` を pin (LABEL テーブル準拠)
+- `test_format_toast_summary_excludes_resume_rate` — `kpi-resume` の delta があっても toast には出ない (highlight のみ)
+- `test_format_toast_summary_excludes_lede_buckets` — lede 数字 (`ledeEvents` / `ledeDays` / `ledeProjects`) は toast に出ない (KPI と二重カウント防止)
+- `test_format_toast_summary_excludes_ranking_rows` — ranking row delta も toast に出ない (highlight のみ)
+- `test_commit_live_snapshot_then_diff_accumulates_across_skipped_commit` — `commitLiveSnapshot(snap1)` → `diffLiveSnapshot(getLivePrev(), snap3)` で累積 delta が出ることを Node round-trip で pin。catch 経路の擬似化 = 「`commitLiveSnapshot` を呼ばないシナリオ」を直接表現する (DOM-heavy な `loadAndRender()` は Node では走らないため、helper 単位で behavior を保証する)
+
+### Phase 2 — GREEN (helper 実装 / commit 3)
+
+- 2.1 `dashboard/template/scripts/25_live_diff.js` を新規作成
+  - `function buildLiveSnapshot(data)`: data から KPI / lede / ranking name→count Map を作る pure function
+  - `function diffLiveSnapshot(prev, next)`: `{kpi: [{id, delta}], lede: [{id, delta}], rankSkill: [{name, delta}], rankSub: [{name, delta}]}` を返す。delta ≤ 0 entry は除外。`prev === null` のときは all-empty を返す
+  - `function applyHighlights(diff)`: KPI / lede は `getElementById(id)` で `.bumped` を付ける → 1500ms で remove。ranking row は `querySelector('.rank-row[data-name="..."][data-kind="skill"]')` で取得。timer state は `WeakMap<Element, number>` (= 上記 D7)
+  - `function formatToastSummary(diff)`: aggregate label 集合を順序固定で生成
+  - `function showLiveToast(msg)`: msg 空ならば `el.hidden = true` で抑制、空でないとき textContent 置換 + animation restart + 4s 後に再 hidden
+  - `function commitLiveSnapshot(next)`: `__livePrev = next` を行う**唯一の writer**。20 番からはこの helper 経由でしか prev を更新しない (= catch 経路で呼ばないことが構造的に保証される)
+  - closure-private state (`let __livePrev = null` / `let toastTimer = null`) を **25 番ファイル冒頭 (IIFE 直下)** に配置し、`window.__liveDiff = { buildLiveSnapshot, diffLiveSnapshot, formatToastSummary, commitLiveSnapshot, getLivePrev: () => __livePrev }` で test から呼べるよう公開（Node round-trip でフックする）。**`getLivePrev` は test fixture 専用の read-only probe** で production code path では呼ばない（production 経路は `diffLiveSnapshot` の第一引数として 20 番から渡す path のみ通る）
+- 2.2 `dashboard/template/scripts/20_load_and_render.js` 末尾に diff 統合
+  ```js
+  const __liveNext = buildLiveSnapshot(data);
+  if (typeof window.__DATA__ === 'undefined') {  // live mode のみ
+    const __liveDiff = diffLiveSnapshot(__livePrev, __liveNext);
+    if (__livePrev !== null) {
+      applyHighlights(__liveDiff);
+      showLiveToast(formatToastSummary(__liveDiff));
+    }
+    commitLiveSnapshot(__liveNext);  // ← 直接代入は禁止。helper 経由のみ
+  }
+  ```
+  `__livePrev` は 25_live_diff.js 側に `let __livePrev = null` で宣言。20 番は `__livePrev` を**読み参照のみ** (`diffLiveSnapshot` の第一引数) で使い、**代入は `commitLiveSnapshot` 経由でしか行わない**
+- 2.3 `dashboard/template/styles/10_components.css` に追記
+  - `@keyframes pulse-bg`
+  - `.kpi.bumped` / `.kpi .v.bumped` / `.rank-row.bumped` / `.rank-row .rv.bumped` / `.lede .num.bumped`
+  - `.toast` (position fixed top right, padding, border-radius, font-family mono, opacity transition, slide-in keyframe)
+  - `@media (prefers-reduced-motion: reduce)` で `animation: none` + 静的 outline only
+- 2.4 `dashboard/template/shell.html` の footer 直前に toast div 追加
+- 2.5 `dashboard/server.py` の `_MAIN_JS_FILES` tuple に `25_live_diff.js` を `20_load_and_render.js` の直後に追加
+- 2.6 Phase 1 のテストが**全部 GREEN** になることを確認
+
+### Phase 3 — RED (renderer 統合の DOM 整合 / commit 4)
+
+statics export 経路と live 経路の両方で DOM が壊れていない構造的確認を Pin。
+
+- `test_static_export_does_not_show_toast` — `render_static_html(data)` の出力に `id="liveToast"` 要素は存在するが `hidden` 属性 (or `[hidden]` selector ヒット) が付いている。誤って toast を出していないことを HTML 文字列レベルで確認
+- `test_static_export_does_not_apply_bumped_class` — 出力 HTML に `class="... bumped"` が含まれない（render_static_html は 1 ショットなので diff 不能 → 当然 highlight 無し）
+- `test_kpi_id_attributes_persist_after_render` — kpiRow は完全置換されるが、`id="kpi-total"` 等の id 属性が `loadAndRender()` 後の HTML 文字列にも残っている（applyHighlights が getElementById で参照する前提を壊さない）
+- `test_rank_row_data_name_attribute_persists` — `data-name="..."` が rank renderer 出力に必ず含まれる（diff 統合後も既存属性が壊れていない）
+- `test_first_refresh_after_reload_does_not_emit_toast` — Node round-trip で `prevSnapshot=null` → `loadAndRender(dataA)` → toast textContent が空のままを pin
+
+### Phase 4 — GREEN + sha256 更新 (commit 5)
+
+- 4.1 Phase 3 で発見した不整合 (もしあれば) を修正
+- 4.2 `tests/test_dashboard_template_split.py::EXPECTED_TEMPLATE_SHA256` を新値に**上書き**更新（期待値は最新 sha のみ。コメントの履歴 list は documentation で assertion には使われない）。コメント履歴に Issue #69 entry を 1 行追加。fix-up commit で sha が再変動したら期待値を再上書きし履歴に追加 entry を append
+- 4.3 全テストグリーン確認 (`python3 -m pytest tests/`)
+
+### Phase 5 — visual smoke (commit 6 / **mandatory**)
+
+`prefers-reduced-motion` の効きと pulse / toast の見た目は Node round-trip では検証できず、実機ブラウザでの確認が唯一の検証手段。**accessibility 配慮は手動チェック必須**として Phase 5 を mandatory 扱いに格上げ (オプショナルではない)。
+
+- 5.1 `scripts/build_live_diff_fixture.py` を新規作成。2 段階の `usage.jsonl` (snapshot A / snapshot B) を生成し、`render_static_html` で順番に書き出す代わりに、live dashboard を起動して**手動で append** する手順を `print()` で説明する fixture
+- 5.2 動作確認シナリオ (commit message + PR description に記録):
+  1. fixture を起動 → A snapshot で初回描画 (toast 出ない / highlight 出ない)
+  2. usage.jsonl に skill_tool 5 件 + subagent 1 件を append
+  3. ~1 秒後に SSE refresh が来て KPI tiles の `kpi-total` / `kpi-skills` (新登場時) が pulse + toast `+5 events · +1 subagent invocation`
+  4. macOS のシステム設定「視差効果を減らす (Reduce motion)」を ON にして再確認 → pulse は静止 outline のみ / toast は fade のみ
+- 5.3 **PR description チェックリスト**（merge 前に必ずチェック）:
+  - [ ] live mode で highlight pulse 確認 (KPI / lede / ranking row)
+  - [ ] live mode で toast 表示確認 (1 行 aggregate / 4s 自動消滅)
+  - [ ] static export (HTML を `python3 reports/export_html.py` で生成) で toast / highlight が**出ない**ことを確認
+  - [ ] OS 設定で reduced motion ON にしたとき pulse が静止 outline / toast が opacity fade のみであることを確認
+  - [ ] **catch 経路の累積 delta**: SSE は alive のまま `/api/data` 単体が失敗するシナリオを再現し、復活後の累積 delta toast を確認。具体的には `dashboard/server.py` の `/api/data` ハンドラに一時的に `raise RuntimeError("forced 500")` を仕込み (revert 容易な単行) → usage.jsonl に skill_tool 1 件 append → toast 出ない (catch return) → revert → 再 append → 復活 refresh で **2 回分の累積 delta** が toast に出ることを確認。これが catch 経路の policy (D5) の唯一の正しい再現で、server kill では SSE channel ごと止まるため再現にはならない（`70_init_eventsource.js` の error handler は `loadAndRender()` を呼ばない）
+
+> 注: 「fetch 失敗 → 復活」は `loadAndRender()` の **try/catch 内**で発生したときだけ catch path policy が走る。SSE channel 自体が切れる server kill は EventSource の error 経路 (`setConnStatus('reconnect' | 'offline')`) であり、`loadAndRender` を呼ばない別経路。この区別を PR reviewer / 後続改修者にも明示しておくため、上記注釈を Phase 5 に残す。
+
+## 🧪 Test plan — 配置詳細
+
+| テストファイル | テスト対象 | pin 手法 |
+|---|---|---|
+| `tests/test_dashboard_live_diff.py` (新規) | `25_live_diff.js` の関数定義 / `_MAIN_JS_FILES` への登録 / shell.html の toast 要素 / CSS keyframe / `prefers-reduced-motion` | literal pin (regex / substring) |
+| `tests/test_dashboard_live_diff.py::TestBuildLiveSnapshotNode` | snapshot 抽出 / defensive default | Node round-trip (skipUnless) |
+| `tests/test_dashboard_live_diff.py::TestDiffLiveSnapshotNode` | KPI / lede / ranking name 単位 diff 規則 | Node round-trip |
+| `tests/test_dashboard_live_diff.py::TestFormatToastSummaryNode` | aggregate 文字列生成 / 順序 / cap | Node round-trip |
+| `tests/test_dashboard_live_diff.py::TestStaticExportNoLiveBehavior` | static export で toast 非表示 / bumped class 無 | `render_static_html(data)` を呼んで HTML 文字列 grep |
+| `tests/test_dashboard_template_split.py` | `EXPECTED_TEMPLATE_SHA256` 更新 + DOM anchor (`liveToast` 追加) | sha256 + substring |
+| `tests/test_dashboard_local_tz.py` の構造踏襲 | Node `_run_node` ヘルパパターン | コピペ + 拡張（fixture import） |
+| 手動 visual smoke | pulse / toast の見た目 / reduced-motion | `scripts/build_live_diff_fixture.py` + ブラウザ |
+
+> **Node round-trip の TZ 依存無し**: 本機能の関数群は時刻に依存しない pure function（snapshot extract / diff / formatter）なので `TZ` を `Asia/Tokyo` 固定にせずデフォルトで動かして問題ない。`_run_node` の env override は省略してよい。
+
+> **DOM 依存関数の Node 取扱い**: `applyHighlights(diff)` と `showLiveToast(msg)` は `getElementById` / `document` を触るため Node round-trip の対象外。`buildLiveSnapshot` / `diffLiveSnapshot` / `formatToastSummary` の 3 つだけが pure function として `_run_node` で pin される。DOM 依存ロジックは Phase 5 の visual smoke でのみ検証。
+
+### ファイル分離ポリシー
+
+`tests/test_dashboard_live.py` (既存) と `tests/test_dashboard_live_diff.py` (新規) の責務を明示分離:
+
+- `test_dashboard_live.py` = **server-side**: ThreadingHTTPServer / server.json lifecycle / idle watchdog / `/healthz` / SSE 経路のテスト
+- `test_dashboard_live_diff.py` = **client-side JS**: `buildLiveSnapshot` / `diffLiveSnapshot` / `formatToastSummary` の Node round-trip + template anchor (toast 要素 / pulse keyframe / `prefers-reduced-motion`) の literal pin
+
+両者は責務が直交するため統合しない。後続 issue で「次の live 機能」を追加する人が「どっちに書くか」を 0 秒で判断できるようにする。
+
+## ⚠️ Risks / tradeoffs / accessibility
+
+| Risk | 対策 |
+|---|---|
+| **`prefers-reduced-motion` 配慮抜け** | CSS で `@media (prefers-reduced-motion: reduce) { .kpi.bumped, .rank-row.bumped, .lede .num.bumped { animation: none !important; outline: 1px solid var(--mint); } .toast { animation: none !important; transition: opacity 200ms ease; } }` を必ず追加。Phase 1-a の `test_pulse_keyframe_respects_reduced_motion` で構造的に pin |
+| **高頻度 SSE refresh で toast がチカチカする** | toast は queue せず置換のみ。`clearTimeout` で前回 dismiss timer をキャンセルし、最新 toast の textContent をそのまま 4s 表示。delta 全 0 の refresh は toast を出さない (= ファイル touch のみのケースで silent) |
+| **静的 export で誤って toast / highlight が出る** | `if (typeof window.__DATA__ === 'undefined') { ... }` ガードで diff 経路自体に入らない。Phase 3 の `test_static_export_does_not_show_toast` で構造的に pin |
+| **ranking row の z-order と pulse の互換** | `.rank-row` の hover gauge / data-tip との pseudo-element 競合を避けるため、pulse は `box-shadow: inset` でなく **背景色 transition** + `outline` の組み合わせで実装。`.rank-row` 自体に `position: relative` は既に効いており追加不要 |
+| **Toast が固定 right-top で hover help-popover (右配置の `data-place="right"`) と競合** | help-popover は KPI 内側に出る短期 popover で z-index も低い。toast は z-index: 1000 で完全 overlay。視覚衝突は両方 visible でも文脈的に明確（toast = 自動表示 / popover = ユーザー操作）なので妥協可 |
+| **EXPECTED_TEMPLATE_SHA256 を意図的に更新する PR の review 負荷** | コミットメッセージで「Issue #69 で shell.html + 10_components.css + _MAIN_JS_FILES に変更があるため意図的に更新」を明記。`test_html_template_byte_equivalent_to_pre_split_snapshot` は変更後 sha で再 GREEN。**fix-up commit で template が再変更された場合**は、履歴 list に **追加** entry を 1 行ずつ append する（既存 Issue #65 fix-up エントリ慣習を踏襲 / `tests/test_dashboard_template_split.py` のコメント履歴を参照）|
+| **減少フィールドを silent に流す UX 妥当性** | 減少は実機ではほぼ起きない (retention で 180 日超データが落ちるとき位)。「+ aggregate のみ」の方が toast が「成長 signal」として機能する。減少強調は別 Issue で再考 |
+| **toast の文言 i18n** | dashboard の既存タイトルは日本語、KPI label は英語（"events" / "skills" 等）。toast も英語 aggregate (`+5 events · +1 skill`) で揃える方が既存 KPI ラベル文言と整合 |
+| **`box-shadow` animation の GPU 負荷** | 1.5s pulse × 同時最大 ~13 要素 (KPI 8 + lede 3 + rank 2) で safari/firefox とも問題なし (composite layer)。低スペック端末でも `prefers-reduced-motion` で off できる |
+
+## 🚫 Out of Scope
+
+明示的に「将来 Issue で再考」とするもの:
+
+- Patterns / Quality / Surface タブ内の数字の highlight / toast への取り込み（active page 検知で素直に拡張可能。本 PR の構造（key Map）にすでに将来拡張余地はある）
+- Toast の click-to-dismiss / hover で持続 / queue 表示 / 履歴 / 通知音
+- 数値**減少**の visual signal (retention 動作可視化など)
+- Sparkline / heatmap 等の cell-level 強調（cell 数が多く、視覚 noise が支配的になるリスク）
+- 静的 export での「過去 export 同士の diff」表示（diff 比較相手を生成する必要があり scope が爆発）
+- toast 内容の日本語化（既存 KPI label が英語のため整合性で英語維持。i18n 化は別 issue）
+
+## 📝 申し送り (post-merge memory file 候補)
+
+- `docs/reference/dashboard-server.md` に「**live diff & toast 統合の構造**」節を追記する余地。`__livePrev` closure-private state / live-only ガード / name 単位 ranking diff の理由 / sha256 更新の運用 を 1 ブロックで残しておくと、次の renderer 改修者が踏み抜かない
+- 将来 Patterns / Quality タブの数字を取り込むときは `buildLiveSnapshot(data)` に `patterns: { ... }` バケットを追加して、`active page` を `document.querySelector('section.page:not([hidden])').dataset.page` で取り、active page のみ highlight 適用する形に拡張する（toast は active 関係なく常に最新 aggregate を出してよい）
+- toast 文字列フォーマット (`+N events · +N skill`) の precision/i18n は将来 i18n layer 導入トリガーで `_UI_LABELS = {...}` 定数化する余地（#62 / #74 で踏襲済の hardcoded 慣習を本 PR でも踏襲）

--- a/scripts/build_live_diff_fixture.py
+++ b/scripts/build_live_diff_fixture.py
@@ -1,0 +1,209 @@
+"""scripts/build_live_diff_fixture.py — Issue #69 live diff highlight + toast の手動視覚スモーク fixture。
+
+ライブダッシュボードでしか発火しない pulse / toast の見た目と
+`prefers-reduced-motion` の効きを実機で確認するための 2 段階 usage.jsonl 生成器。
+
+使い方:
+    python3 scripts/build_live_diff_fixture.py
+
+出力:
+    /tmp/issue-69-fixture/
+      usage.jsonl       — snapshot A: 初期 events (live dashboard 起動時に読む)
+      append.jsonl      — snapshot B 追加 events (動作確認のときに手動 append)
+      run.sh            — dashboard 起動 + append コマンドの参考スクリプト
+
+シナリオ:
+    1. dashboard を fixture 向けに起動 (USAGE_JSONL=/tmp/issue-69-fixture/usage.jsonl)
+    2. 初回描画では toast / highlight 出ない (ベースライン)
+    3. `cat append.jsonl >> usage.jsonl` を実行
+    4. ~1 秒後に SSE refresh が来て:
+         - kpi-total が pulse + toast `+5 events · +1 subagent invocation`
+         - 既存 skill の rank-row が pulse
+         - 新登場 subagent の rank-row が pulse
+    5. macOS の「視差効果を減らす」を ON にして同じ操作 → pulse は静止 outline のみ /
+       toast は opacity fade のみ
+    6. catch 経路の累積 delta 確認: 一時的に /api/data ハンドラに `raise RuntimeError`
+       を入れて再起動 → append → toast 出ない (catch return) → revert + 再 append →
+       復活 refresh で 2 回分の累積 delta が toast に出る
+
+設計判断:
+    - static export ではなく usage.jsonl を 2 段階に切る (= live dashboard 経由でのみ
+      発火する pulse / toast を実機で見る)。
+    - 環境隔離: USAGE_JSONL を tmp に向け、本物の ~/.claude/transcript-analyzer は
+      触らない。
+"""
+import json
+import shutil
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+FIXTURE_DIR = Path("/tmp/issue-69-fixture")
+USAGE_JSONL = FIXTURE_DIR / "usage.jsonl"
+APPEND_JSONL = FIXTURE_DIR / "append.jsonl"
+RUN_SH = FIXTURE_DIR / "run.sh"
+
+NOW = datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def _iso(days_ago: float = 0, hours_ago: float = 0) -> str:
+    return (NOW - timedelta(days=days_ago, hours=hours_ago)).isoformat()
+
+
+def _tool(skill: str, *, hours_ago: float = 0, success: bool = True) -> dict:
+    return {
+        "event_type": "skill_tool",
+        "skill": skill,
+        "project": "issue-69-fixture",
+        "session_id": "issue-69-fixture",
+        "timestamp": _iso(hours_ago=hours_ago),
+        "success": success,
+        "duration_ms": 80,
+        "permission_mode": "default",
+        "tool_use_id": "issue-69-fixture",
+    }
+
+
+def _subagent_invocation(name: str, *, hours_ago: float = 0) -> list[dict]:
+    """1 invocation を表現する PostToolUse(Task|Agent) + SubagentStop 2 件のペア。
+
+    invocation 単位 dedup ロジック (subagent_metrics.py) が
+    PostToolUse → SubagentStop の timestamp 差で 1 invocation にまとめるため、
+    両方が必要。
+    """
+    base_ts = NOW - timedelta(hours=hours_ago)
+    return [
+        {
+            "event_type": "subagent_start",
+            "subagent_type": name,
+            "project": "issue-69-fixture",
+            "session_id": "issue-69-fixture",
+            "timestamp": base_ts.isoformat(),
+            "duration_ms": 1500,
+            "tool_use_id": f"issue-69-{name}-{int(base_ts.timestamp())}",
+        },
+        {
+            "event_type": "subagent_lifecycle_stop",
+            "subagent_type": name,
+            "project": "issue-69-fixture",
+            "session_id": "issue-69-fixture",
+            "timestamp": (base_ts + timedelta(seconds=1.5)).isoformat(),
+            "duration_ms": 1500,
+            "tool_use_id": f"issue-69-{name}-{int(base_ts.timestamp())}",
+        },
+    ]
+
+
+def build_snapshot_a() -> list[dict]:
+    """snapshot A — dashboard 起動時の初期状態 (1 セッション + 既存 skill 利用)。"""
+    events: list[dict] = []
+    events.append({
+        "event_type": "session_start",
+        "session_id": "issue-69-fixture",
+        "project": "issue-69-fixture",
+        "timestamp": _iso(hours_ago=2),
+        "source": "startup",
+    })
+    # 既存の skill A が 3 件 (rank top に出る)
+    for h in (1.5, 1.0, 0.5):
+        events.append(_tool("codex-review", hours_ago=h))
+    # 既存の skill B が 1 件
+    events.append(_tool("simplify", hours_ago=1.2))
+    # subagent invocation 1 件 (rank top)
+    events += _subagent_invocation("Explore", hours_ago=0.8)
+    return events
+
+
+def build_snapshot_b_append() -> list[dict]:
+    """snapshot A 上に **追加** で append する events。
+
+    確認したい delta:
+      - kpi-total: +5 events
+      - kpi-skills: +1 (新登場 skill `frontend-design`)
+      - kpi-subs: +1 (新登場 subagent `Plan`)
+      - skill rank-row: codex-review が +2 で pulse / frontend-design が +3 で新登場 pulse
+      - subagent rank-row: Plan が +1 で新登場 pulse
+    """
+    events: list[dict] = []
+    # 既存 skill +2 (codex-review)
+    events.append(_tool("codex-review", hours_ago=0.2))
+    events.append(_tool("codex-review", hours_ago=0.1))
+    # 新登場 skill +3 (frontend-design)
+    for h in (0.05, 0.04, 0.03):
+        events.append(_tool("frontend-design", hours_ago=h))
+    # 新登場 subagent +1 (Plan)
+    events += _subagent_invocation("Plan", hours_ago=0.02)
+    return events
+
+
+def main() -> None:
+    if FIXTURE_DIR.exists():
+        shutil.rmtree(FIXTURE_DIR)
+    FIXTURE_DIR.mkdir(parents=True)
+
+    snap_a = build_snapshot_a()
+    append_b = build_snapshot_b_append()
+
+    with USAGE_JSONL.open("w", encoding="utf-8") as f:
+        for ev in snap_a:
+            f.write(json.dumps(ev) + "\n")
+    with APPEND_JSONL.open("w", encoding="utf-8") as f:
+        for ev in append_b:
+            f.write(json.dumps(ev) + "\n")
+
+    run_sh = """#!/usr/bin/env bash
+# Issue #69 live diff highlight + toast 手動視覚スモーク手順
+set -e
+
+FIXTURE_DIR=/tmp/issue-69-fixture
+USAGE=$FIXTURE_DIR/usage.jsonl
+APPEND=$FIXTURE_DIR/append.jsonl
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+
+echo "1) dashboard を fixture 向けに起動 (Ctrl-C で停止)"
+echo "   ブラウザで http://localhost:<auto-port> を開いて Overview タブを確認"
+echo ""
+echo "   USAGE_JSONL=$USAGE python3 $REPO_DIR/dashboard/server.py"
+echo ""
+echo "   ※ 起動 log の 'Dashboard available: http://localhost:NNNN' を別ターミナルで使う"
+echo ""
+echo "2) 別ターミナルで append を実行 (1 秒以内に SSE refresh)"
+echo "   cat $APPEND >> $USAGE"
+echo ""
+echo "3) 期待される観測:"
+echo "   - kpi-total / kpi-skills / kpi-subs が mint pulse (1.5s で fade)"
+echo "   - rank-row 'codex-review' が pulse (count +2)"
+echo "   - rank-row 'frontend-design' が新登場で pulse (delta = 3)"
+echo "   - rank-row 'Plan' が subagent panel に新登場で pulse"
+echo "   - 画面右上に toast '+5 events · +1 skill · +1 subagent invocation' が 4s 表示"
+echo ""
+echo "4) macOS で 'システム設定 > アクセシビリティ > 表示 > 視差効果を減らす' を ON に"
+echo "   して step 1-2 をやり直す → pulse が静止 outline のみ / toast が opacity fade のみ"
+echo ""
+echo "5) catch 経路の累積 delta:"
+echo "   dashboard/server.py の _serve_api() に一時的に 'raise RuntimeError(\"forced 500\")'"
+echo "   を仕込んで再起動 → cat 1 件 append → toast 出ない (loadAndRender catch return) →"
+echo "   raise を revert → cat もう 1 件 append → 復活 refresh で 2 回分の累積 delta が toast に"
+"""
+    RUN_SH.write_text(run_sh, encoding="utf-8")
+    RUN_SH.chmod(0o755)
+
+    print("=" * 60)
+    print("Issue #69 live diff fixture 生成完了")
+    print("=" * 60)
+    print(f"  snapshot A (初期): {USAGE_JSONL}  ({len(snap_a)} events)")
+    print(f"  snapshot B (append): {APPEND_JSONL}  ({len(append_b)} events)")
+    print(f"  手順スクリプト:    {RUN_SH}")
+    print()
+    print("次のコマンド:")
+    print(f"  bash {RUN_SH}     # 手順を表示するだけ (実行はせず)")
+    print()
+    print("または手動で:")
+    print(f"  USAGE_JSONL={USAGE_JSONL} python3 dashboard/server.py")
+    print(f"  cat {APPEND_JSONL} >> {USAGE_JSONL}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -595,6 +595,42 @@ class TestFormatToastSummaryNode(unittest.TestCase):
 
 
 @unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestFirstRefreshAfterReloadNode(unittest.TestCase):
+    """page reload 直後の SSE refresh 1 発目で toast が出ない構造保証。
+
+    module 評価から始まるので __livePrev = null で初期化される。reload 直後の
+    初回 refresh は diff 不能で toast 出ない (= ユーザーが意図的に reload した
+    直後の noise を構造的に防ぐ)。
+    """
+
+    def test_first_refresh_after_reload_does_not_emit_toast(self):
+        out = _node_eval(
+            "// reload 直後の状態 = __livePrev === null。20_load_and_render.js が\n"
+            "// 末尾でやることの抜粋: __livePrev !== null をガードに toast を出す。\n"
+            "// commit 前の livePrev probe = null。\n"
+            "const probe = (typeof window !== 'undefined' && window.__liveDiff)\n"
+            "  ? window.__liveDiff.getLivePrev()\n"
+            "  : __livePrev;\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 100,\n"
+            "  skill_ranking: [{name:'a', count:5}],\n"
+            "});\n"
+            "// __livePrev === null のため diff = empty / toast = 空文字\n"
+            "const d = diffLiveSnapshot(probe, next);\n"
+            "const toast = formatToastSummary(d);\n"
+            "process.stdout.write(JSON.stringify({\n"
+            "  probeIsNull: probe === null,\n"
+            "  kpiLen: d.kpi.length,\n"
+            "  toast: toast,\n"
+            "}));\n"
+        )
+        self.assertTrue(out["probeIsNull"], "reload 直後 __livePrev は null のはず")
+        self.assertEqual(out["kpiLen"], 0)
+        self.assertEqual(out["toast"], "",
+                         "reload 直後の初回 refresh で toast が出てしまっている")
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
 class TestCommitLiveSnapshotNode(unittest.TestCase):
     def test_commit_then_diff_accumulates_across_skipped_commit(self):
         """commitLiveSnapshot(snap1) → (skip commit for snap2) → diff(getLivePrev(), snap3)

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -706,8 +706,10 @@ class TestStaticExportNoLiveBehavior:
         """kpi の id 属性は loadAndRender 後の HTML 文字列にも残っている前提。
 
         applyHighlights が getElementById で参照する前提を壊さない。
-        ここは shell.html の kpiRow placeholder + 20_load_and_render.js の HTML 生成で
-        `id="kpi-..."` を出していること (= JS の出力 string に含まれること) を pin。
+        kpiRow.innerHTML 完全置換の出力で各 KPI tile div に id=\"kpi-...\" を
+        付けて出していることを source-level に pin。
+        chrome-devtools での実機確認で id 属性漏れを検出できたケースを後追いで
+        構造保証する (Phase 5 visual smoke で見つけた gap)。
         """
         body = _read(_LOAD_RENDER_JS)
         # kpis array の各 entry に id: 'kpi-...' があること
@@ -715,12 +717,12 @@ class TestStaticExportNoLiveBehavior:
                        "kpi-sess", "kpi-resume", "kpi-compact", "kpi-perm"):
             assert f"'{kpi_id}'" in body, \
                 f"20_load_and_render.js の kpis array に '{kpi_id}' が無い"
-        # KPI tile DIV に id=' を付けて出力していること
-        assert re.search(r"<div class=\"kpi[^\"]*\"\s+id=", body) \
-            or "+ g.id" in body \
-            or "id=\"' + g.id + '\"" in body \
-            or "id=\\\"' + g.id + '\\\"" in body, \
-            "KPI tile の HTML 出力で id 属性を埋め込めていない"
+        # kpiRow.innerHTML 直前 / 内部の map() で kpi tile div に
+        # `id="' + g.id + '"` を埋め込んでいること。
+        # クォートのエスケープバリエーションを許容する。
+        assert ("id=\"' + g.id + '\"" in body) or ("id=' + g.id + '" in body), \
+            "KPI tile の HTML 出力で id=\"' + g.id + '\" を埋め込めていない " \
+            "(applyHighlights の getElementById が hit しない)"
 
     def test_rank_row_data_name_attribute_persists(self):
         """rank renderer 出力に data-name=\"...\" が必ず含まれる。"""

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -100,6 +100,61 @@ class TestLiveDiffJsStructure:
         assert "new WeakMap(" in body, \
             "25_live_diff.js に new WeakMap(...) が無い (timer state は WeakMap 必須)"
 
+    def test_show_live_toast_replays_slide_in_on_overwrite(self):
+        """表示中の toast に上書き表示が来たとき slide-in animation を再生する構造。
+
+        CSS transition 方式では Browser が同フレーム内の連続 style 変更を collapse
+        して transition を skip する問題があり、実機で「text だけ瞬時置換」になる。
+        CSS animation (@keyframes toast-in) を使い、reflow trick (`.remove + offsetWidth
+        + .add`) で確実に animation を再起動する classic pattern を pin する。
+
+        pins:
+          - @keyframes toast-in / toast-out が CSS に含まれる (concat 後 _HTML_TEMPLATE)
+          - .toast.show に animation: toast-in が適用される
+          - showLiveToast で `.show` remove → reflow → re-add の順序がある
+        """
+        body = _read(_LIVE_DIFF_JS)
+        match = re.search(
+            r"function\s+showLiveToast\s*\([^)]*\)\s*\{",
+            body,
+        )
+        assert match is not None
+        start = match.end()
+        depth = 1
+        i = start
+        while i < len(body) and depth > 0:
+            if body[i] == "{":
+                depth += 1
+            elif body[i] == "}":
+                depth -= 1
+            i += 1
+        fn_body = body[start:i - 1]
+        # `.show` を一度 remove してから reflow trick を経て再 add する pattern
+        assert "classList.remove('show')" in fn_body, \
+            "showLiveToast に classList.remove('show') が無い (animation 再起動の起点)"
+        assert "void el.offsetWidth" in fn_body, \
+            "showLiveToast に void el.offsetWidth が無い (CSS animation 再起動の reflow trick)"
+        assert "classList.add('show')" in fn_body, \
+            "showLiveToast に classList.add('show') が無い (animation 再起動の終点)"
+        # 順序確認: remove('show') → offsetWidth → add('show')
+        i_rem = fn_body.find("classList.remove('show')")
+        i_reflow = fn_body.find("void el.offsetWidth")
+        i_add = fn_body.find("classList.add('show')")
+        assert i_rem < i_reflow < i_add, \
+            "showLiveToast の reflow trick 順序が誤っている (remove → reflow → add でないと animation 再起動しない)"
+        # CSS 側に @keyframes toast-in / toast-out が定義されている
+        css_body = _read(_COMPONENTS_CSS)
+        assert "@keyframes toast-in" in css_body, \
+            "10_components.css に @keyframes toast-in が無い (CSS animation 不在)"
+        assert "@keyframes toast-out" in css_body, \
+            "10_components.css に @keyframes toast-out が無い (fade-out animation 不在)"
+        # .toast.show に animation: toast-in が当たる
+        assert re.search(r"\.toast\.show\s*\{[^}]*animation:\s*toast-in", css_body), \
+            ".toast.show に animation: toast-in が当たっていない (slide-in 再生されない)"
+        # .toast.fading に animation: toast-out が当たる
+        assert re.search(r"\.toast\.fading\s*\{[^}]*animation:\s*toast-out", css_body), \
+            ".toast.fading に animation: toast-out が当たっていない (fade-out 再生されない)"
+
     def test_show_live_toast_fade_out_completes_before_hidden(self):
         """showLiveToast の fade-out transition が display: none で打ち切られない構造。
 

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -100,6 +100,51 @@ class TestLiveDiffJsStructure:
         assert "new WeakMap(" in body, \
             "25_live_diff.js に new WeakMap(...) が無い (timer state は WeakMap 必須)"
 
+    def test_show_live_toast_fade_out_completes_before_hidden(self):
+        """showLiveToast の fade-out transition が display: none で打ち切られない構造。
+
+        `.show` を remove したあと **同フレームで** `hidden = true` を当てると CSS
+        `transition: opacity 240ms ease` がキャンセルされて瞬間消失する。CSS と
+        同期した __TOAST_FADE_MS 経過後に hidden を当てる二段 timer 設計を強制
+        する。pure DOM 副作用なので Node round-trip では検証できず、source レベル
+        の structural pin で代替する。
+        """
+        body = _read(_LIVE_DIFF_JS)
+        # __TOAST_FADE_MS 定数の存在 (CSS の 240ms と同期)
+        assert re.search(r"__TOAST_FADE_MS\s*=\s*\d+", body), \
+            "__TOAST_FADE_MS 定数 (CSS transition と同期) が定義されていない"
+        # __toastFadeTimer (fade-out 終了 → hidden 化) と __toastTimer (display 期間終了 →
+        # fade-out 開始) が両方存在
+        assert "__toastFadeTimer" in body, \
+            "__toastFadeTimer (fade-out 完了後 hidden 化用) が無い — fade-out が瞬間消失する"
+        # showLiveToast 関数本体を抜き出して、内側に二段 setTimeout (TOAST_MS と
+        # TOAST_FADE_MS) があることを構造的に確認
+        match = re.search(
+            r"function\s+showLiveToast\s*\([^)]*\)\s*\{",
+            body,
+        )
+        assert match is not None
+        start = match.end()
+        depth = 1
+        i = start
+        while i < len(body) and depth > 0:
+            if body[i] == "{":
+                depth += 1
+            elif body[i] == "}":
+                depth -= 1
+            i += 1
+        fn_body = body[start:i - 1]
+        # 二段 setTimeout 構造: 外側 __TOAST_MS / 内側 __TOAST_FADE_MS
+        assert "__TOAST_MS" in fn_body and "__TOAST_FADE_MS" in fn_body, \
+            "showLiveToast 内に __TOAST_MS / __TOAST_FADE_MS 両方が無い (二段 timer 設計違反)"
+        # `.show` remove と `hidden = true` を同 statement / 同フレームで打っていない
+        # ことを確認: `el.classList.remove('show'); el.hidden = true` のような
+        # 直接連結が無い (= setTimeout を挟んでいる)
+        assert not re.search(
+            r"classList\.remove\(['\"]show['\"]\)\s*;\s*\n?\s*[a-zA-Z_].*?hidden\s*=\s*true",
+            fn_body,
+        ), "showLiveToast で .show remove 直後に hidden=true を打っている (fade-out transition がキャンセルされる)"
+
 
 # ============================================================
 #  1-a. Literal pin: 20_load_and_render.js 側の統合と __livePrev 規律

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -138,8 +138,10 @@ class TestLoadRenderIntegration:
 class TestMainJsTupleOrder:
     def test_25_listed_in_main_js_files_tuple(self):
         body = _read(_DASHBOARD_PY)
-        # _MAIN_JS_FILES tuple を切り出して順序を見る
-        match = re.search(r"_MAIN_JS_FILES\s*=\s*\(([^)]*)\)", body, re.DOTALL)
+        # _MAIN_JS_FILES tuple を切り出して順序を見る。
+        # `[^)]*` だと tuple 内コメント (例: "(KPI / ranking / ... / projects)") の閉じ
+        # 括弧で early-stop するため、開き行から閉じ行 `\n)\n` までを multi-line で取る。
+        match = re.search(r"_MAIN_JS_FILES\s*=\s*\(\n(.*?)\n\)\n", body, re.DOTALL)
         assert match is not None, "dashboard/server.py に _MAIN_JS_FILES tuple が無い"
         tuple_body = match.group(1)
         # 各エントリの " ... " の中身だけを順序保ったまま抜き出す
@@ -646,7 +648,11 @@ class TestStaticExportNoLiveBehavior:
             f"liveToast に hidden 属性が無い (tag={tag!r})"
 
     def test_static_export_does_not_apply_bumped_class(self):
-        """static export では diff 不能なので bumped class が出ない。"""
+        """static export では diff 不能なので bumped class が DOM 要素に付かない。
+
+        CSS / コメント内の `bumped` 文字列は許容 (.kpi.bumped セレクタ定義は CSS に
+        含まれてよい)。HTML 要素の class attribute 値として出現していないことを pin。
+        """
         import importlib.util
         spec = importlib.util.spec_from_file_location(
             "_dashboard_for_static_export_test2", _DASHBOARD_PY
@@ -655,8 +661,10 @@ class TestStaticExportNoLiveBehavior:
         spec.loader.exec_module(mod)
         data = mod.build_dashboard_data([])
         html = mod.render_static_html(data)
-        assert "bumped" not in html, \
-            "static export 出力に bumped class が混入している (highlight は live mode 限定)"
+        # `class="...bumped..."` のように HTML attribute 値として bumped が現れたら fail。
+        bad_match = re.search(r'class="[^"]*\bbumped\b[^"]*"', html)
+        assert bad_match is None, \
+            f"static export 出力に bumped class が混入している (highlight は live mode 限定): {bad_match.group(0) if bad_match else ''}"
 
     def test_kpi_id_attributes_persist(self):
         """kpi の id 属性は loadAndRender 後の HTML 文字列にも残っている前提。

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -1,0 +1,685 @@
+"""tests/test_dashboard_live_diff.py — Issue #69: live diff highlight + toast.
+
+Live mode (`/events` SSE refresh) のときだけ走る差分ハイライト + 更新概要 toast。
+
+仕分け:
+  1-a. literal pin: ファイル存在 / 関数定義 / `_MAIN_JS_FILES` 配置 / shell.html の
+       toast 要素 / CSS keyframe / `prefers-reduced-motion` / `__livePrev` 宣言の
+       一意性 / 直接代入禁止 / WeakMap 必須規約。grep で十分なものは正規表現で pin。
+  1-b. Node round-trip: `buildLiveSnapshot` / `diffLiveSnapshot` / `formatToastSummary`
+       / `commitLiveSnapshot` の behavior 検証。host TZ には依存しないので env override
+       は不要。
+  3.   static export 経路で toast / highlight が出ないことの構造 pin。
+
+DOM 依存関数 (`applyHighlights` / `showLiveToast`) は Node round-trip では検証しない
+(Phase 5 visual smoke で実機確認)。
+"""
+# pylint: disable=line-too-long
+import json
+import os
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+from _dashboard_template_loader import load_assembled_template
+
+_TEMPLATE_DIR = Path(__file__).parent.parent / "dashboard" / "template"
+_LIVE_DIFF_JS = _TEMPLATE_DIR / "scripts" / "25_live_diff.js"
+_LOAD_RENDER_JS = _TEMPLATE_DIR / "scripts" / "20_load_and_render.js"
+_HELPERS_JS = _TEMPLATE_DIR / "scripts" / "10_helpers.js"
+_DASHBOARD_PY = Path(__file__).parent.parent / "dashboard" / "server.py"
+_COMPONENTS_CSS = _TEMPLATE_DIR / "styles" / "10_components.css"
+_SHELL_HTML = _TEMPLATE_DIR / "shell.html"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ============================================================
+#  1-a. Literal pin: 25_live_diff.js の関数 / 構造規約
+# ============================================================
+class TestLiveDiffJsStructure:
+    def test_25_live_diff_js_file_exists(self):
+        assert _LIVE_DIFF_JS.is_file(), \
+            "dashboard/template/scripts/25_live_diff.js が存在しない"
+
+    def test_build_live_snapshot_function_defined(self):
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+buildLiveSnapshot\s*\(", body), \
+            "function buildLiveSnapshot(...) が 25_live_diff.js に定義されていない"
+
+    def test_diff_live_snapshot_function_defined(self):
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+diffLiveSnapshot\s*\(", body), \
+            "function diffLiveSnapshot(...) が 25_live_diff.js に定義されていない"
+
+    def test_apply_highlights_function_defined(self):
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+applyHighlights\s*\(", body), \
+            "function applyHighlights(...) が 25_live_diff.js に定義されていない"
+
+    def test_format_toast_summary_function_defined(self):
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+formatToastSummary\s*\(", body), \
+            "function formatToastSummary(...) が 25_live_diff.js に定義されていない"
+
+    def test_show_live_toast_function_defined(self):
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+showLiveToast\s*\(", body), \
+            "function showLiveToast(...) が 25_live_diff.js に定義されていない"
+
+    def test_commit_live_snapshot_function_defined(self):
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+commitLiveSnapshot\s*\(", body), \
+            "function commitLiveSnapshot(...) が 25_live_diff.js に定義されていない"
+
+    def test_25_declares_liveprev_at_iife_top(self):
+        """25_live_diff.js 冒頭 (関数定義より前) に `let __livePrev` 宣言が存在する。
+
+        TDZ 安全性根拠: shell.html は全 main_js を単一 IIFE で wrap するため、
+        20 番の loadAndRender 関数 body が呼び出される時点で 25 番冒頭の `let` は
+        評価済 → ReferenceError は構造的に発生しない。
+        """
+        body = _read(_LIVE_DIFF_JS)
+        first_fn_match = re.search(r"\bfunction\s+", body)
+        assert first_fn_match is not None, "25_live_diff.js に関数定義が無い"
+        head = body[: first_fn_match.start()]
+        assert re.search(r"\blet\s+__livePrev\s*=", head), \
+            "25_live_diff.js 冒頭 (関数定義より前) に let __livePrev = ... 宣言が無い"
+
+    def test_apply_highlights_uses_weakmap_for_timer_state(self):
+        """applyHighlights の per-element timer state は WeakMap で持つ。
+
+        rank row は loadAndRender ごとに innerHTML 完全置換で element 参照が detach
+        するため、Map だと detach 済 DOM を pin して slow leak になる。WeakMap 必須。
+        """
+        body = _read(_LIVE_DIFF_JS)
+        assert "new WeakMap(" in body, \
+            "25_live_diff.js に new WeakMap(...) が無い (timer state は WeakMap 必須)"
+
+
+# ============================================================
+#  1-a. Literal pin: 20_load_and_render.js 側の統合と __livePrev 規律
+# ============================================================
+class TestLoadRenderIntegration:
+    def test_load_and_render_calls_diff_helpers(self):
+        body = _read(_LOAD_RENDER_JS)
+        assert "buildLiveSnapshot(" in body, \
+            "20_load_and_render.js から buildLiveSnapshot(...) が呼ばれていない"
+        assert "diffLiveSnapshot(" in body, \
+            "20_load_and_render.js から diffLiveSnapshot(...) が呼ばれていない"
+
+    def test_load_render_does_not_redeclare_liveprev(self):
+        """20 番に `let __livePrev` / `var __livePrev` / `const __livePrev` の
+        **宣言文** が無いことを pin。25 番 IIFE-top 宣言の lexical 一意性を構造保証。
+        """
+        body = _read(_LOAD_RENDER_JS)
+        for kw in ("let", "var", "const"):
+            assert not re.search(rf"\b{kw}\s+__livePrev\b", body), \
+                f"20_load_and_render.js に `{kw} __livePrev` 宣言が混入している"
+
+    def test_load_render_does_not_directly_assign_liveprev(self):
+        """20 番から `__livePrev =` 直接代入を禁止 (commitLiveSnapshot 経由のみ強制)。
+
+        catch 経路で `commitLiveSnapshot` を呼ばない契約を構造保証する。
+        """
+        body = _read(_LOAD_RENDER_JS)
+        assert not re.search(r"__livePrev\s*=", body), \
+            "20_load_and_render.js に __livePrev への直接代入が混入している" \
+            " (commitLiveSnapshot(...) 経由のみ許可)"
+
+
+# ============================================================
+#  1-a. Literal pin: server.py の _MAIN_JS_FILES に 25 が挟まる
+# ============================================================
+class TestMainJsTupleOrder:
+    def test_25_listed_in_main_js_files_tuple(self):
+        body = _read(_DASHBOARD_PY)
+        # _MAIN_JS_FILES tuple を切り出して順序を見る
+        match = re.search(r"_MAIN_JS_FILES\s*=\s*\(([^)]*)\)", body, re.DOTALL)
+        assert match is not None, "dashboard/server.py に _MAIN_JS_FILES tuple が無い"
+        tuple_body = match.group(1)
+        # 各エントリの " ... " の中身だけを順序保ったまま抜き出す
+        names = re.findall(r'"([^"]+\.js)"', tuple_body)
+        assert "25_live_diff.js" in names, \
+            "_MAIN_JS_FILES に 25_live_diff.js が含まれていない"
+        assert "20_load_and_render.js" in names and "30_renderers_patterns.js" in names, \
+            "_MAIN_JS_FILES の前提エントリ (20 / 30) が無い"
+        i_20 = names.index("20_load_and_render.js")
+        i_25 = names.index("25_live_diff.js")
+        i_30 = names.index("30_renderers_patterns.js")
+        assert i_20 < i_25 < i_30, \
+            "25_live_diff.js は 20_load_and_render.js と 30_renderers_patterns.js " \
+            f"の間に挟まる必要がある (got order: {names})"
+
+
+# ============================================================
+#  1-a. Literal pin: shell.html / 10_components.css への変更
+# ============================================================
+class TestShellAndComponentsAssets:
+    def test_assembled_template_contains_toast_element(self):
+        template = load_assembled_template()
+        assert 'id="liveToast"' in template, \
+            "concat 後 _HTML_TEMPLATE に id=\"liveToast\" 要素が含まれていない"
+
+    def test_assembled_template_toast_has_role_and_aria(self):
+        template = load_assembled_template()
+        # liveToast 要素を含む 1 行を取り出してアトリビュートを確認
+        match = re.search(r'<[^>]*id="liveToast"[^>]*>', template)
+        assert match is not None, "liveToast 要素のタグが無い"
+        tag = match.group(0)
+        assert 'role="status"' in tag, "liveToast に role=\"status\" が無い"
+        assert 'aria-live="polite"' in tag, "liveToast に aria-live=\"polite\" が無い"
+
+    def test_assembled_template_contains_pulse_keyframe(self):
+        template = load_assembled_template()
+        assert "@keyframes pulse-bg" in template, \
+            "concat 後 _HTML_TEMPLATE に @keyframes pulse-bg が含まれていない"
+
+    def test_pulse_keyframe_respects_reduced_motion(self):
+        """`@media (prefers-reduced-motion: reduce)` ブロックで `.bumped` の
+        animation を無効化していることを構造的に pin。
+        """
+        css = _read(_COMPONENTS_CSS)
+        assert "prefers-reduced-motion" in css, \
+            "10_components.css に prefers-reduced-motion メディアクエリが無い"
+        # メディアクエリ block を抜き出して .bumped の animation 無効化を確認
+        match = re.search(
+            r"@media\s*\([^)]*prefers-reduced-motion[^)]*\)\s*\{(.*?)\n\s*\}\s*\n",
+            css, re.DOTALL,
+        )
+        assert match is not None, \
+            "prefers-reduced-motion ブロックが閉じていない / 構造化できていない"
+        block = match.group(1)
+        assert ".bumped" in block, \
+            "prefers-reduced-motion ブロックで .bumped の制御が見当たらない"
+        assert ("animation: none" in block) or ("animation:none" in block), \
+            "prefers-reduced-motion ブロックで animation: none による無効化が無い"
+
+
+# ============================================================
+#  1-b. Node round-trip: pure helper の behavior
+#  CI に node が無いので skipUnless gate
+# ============================================================
+_NODE = shutil.which("node")
+
+
+def _node_eval(script: str) -> object:
+    """Node で script を評価し JSON 結果を返す。
+
+    helpers.js + 25_live_diff.js を IIFE 内側で動く前提でそのまま eval する。
+    Windows CI で os.environ を継承して PATH 等が消えないように env.copy する。
+    """
+    helpers_src = _read(_HELPERS_JS)
+    live_src = _read(_LIVE_DIFF_JS)
+    full = helpers_src + "\n" + live_src + "\n" + script
+    env = os.environ.copy()
+    proc = subprocess.run(
+        [_NODE, "-e", full],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node failed (returncode={proc.returncode}): stderr={proc.stderr}"
+        )
+    return json.loads(proc.stdout)
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestBuildLiveSnapshotNode(unittest.TestCase):
+    def test_extracts_kpi_keys(self):
+        """data の各種カウントが kpi bucket に対応 id で入る。"""
+        data = {
+            "total_events": 100,
+            "skill_ranking": [{"name": "a", "count": 10}, {"name": "b", "count": 5}],
+            "subagent_ranking": [{"name": "x", "count": 3}],
+            "project_breakdown": [{"project": "p1", "count": 2}],
+            "session_stats": {
+                "total_sessions": 7,
+                "resume_rate": 0.5,
+                "compact_count": 4,
+                "permission_prompt_count": 2,
+            },
+            "hourly_heatmap": {"buckets": [
+                {"hour_utc": "2026-04-29T00:00:00+00:00", "count": 8},
+                {"hour_utc": "2026-04-30T00:00:00+00:00", "count": 4},
+            ]},
+        }
+        out = _node_eval(
+            "const s = buildLiveSnapshot(" + json.dumps(data) + ");\n"
+            "process.stdout.write(JSON.stringify({\n"
+            "  kpiTotal: s.kpi['kpi-total'],\n"
+            "  kpiSkills: s.kpi['kpi-skills'],\n"
+            "  kpiSubs: s.kpi['kpi-subs'],\n"
+            "  kpiProjs: s.kpi['kpi-projs'],\n"
+            "  kpiSess: s.kpi['kpi-sess'],\n"
+            "  kpiCompact: s.kpi['kpi-compact'],\n"
+            "  kpiPerm: s.kpi['kpi-perm'],\n"
+            "  ledeEvents: s.lede.ledeEvents,\n"
+            "  ledeProjects: s.lede.ledeProjects,\n"
+            "}));\n"
+        )
+        self.assertEqual(out["kpiTotal"], 100)
+        self.assertEqual(out["kpiSkills"], 2)
+        self.assertEqual(out["kpiSubs"], 1)
+        self.assertEqual(out["kpiProjs"], 1)
+        self.assertEqual(out["kpiSess"], 7)
+        self.assertEqual(out["kpiCompact"], 4)
+        self.assertEqual(out["kpiPerm"], 2)
+        self.assertEqual(out["ledeEvents"], 100)
+        self.assertEqual(out["ledeProjects"], 1)
+
+    def test_handles_missing_data_with_defensive_default(self):
+        """data = {} でも全 KPI が 0 で埋まる。"""
+        out = _node_eval(
+            "const s = buildLiveSnapshot({});\n"
+            "process.stdout.write(JSON.stringify({\n"
+            "  kpiTotal: s.kpi['kpi-total'],\n"
+            "  kpiSkills: s.kpi['kpi-skills'],\n"
+            "  kpiSubs: s.kpi['kpi-subs'],\n"
+            "  ledeEvents: s.lede.ledeEvents,\n"
+            "  ledeDays: s.lede.ledeDays,\n"
+            "  rankSkillSize: s.rankSkill.size,\n"
+            "  rankSubSize: s.rankSub.size,\n"
+            "}));\n"
+        )
+        self.assertEqual(out["kpiTotal"], 0)
+        self.assertEqual(out["kpiSkills"], 0)
+        self.assertEqual(out["kpiSubs"], 0)
+        self.assertEqual(out["ledeEvents"], 0)
+        self.assertEqual(out["ledeDays"], 0)
+        self.assertEqual(out["rankSkillSize"], 0)
+        self.assertEqual(out["rankSubSize"], 0)
+
+    def test_rank_skill_is_map_keyed_by_name(self):
+        """rankSkill は name → count Map で、同 rank index でも name 単位で diff できる。"""
+        data = {
+            "skill_ranking": [
+                {"name": "alpha", "count": 11},
+                {"name": "beta", "count": 7},
+            ],
+        }
+        out = _node_eval(
+            "const s = buildLiveSnapshot(" + json.dumps(data) + ");\n"
+            "process.stdout.write(JSON.stringify({\n"
+            "  alpha: s.rankSkill.get('alpha'),\n"
+            "  beta: s.rankSkill.get('beta'),\n"
+            "}));\n"
+        )
+        self.assertEqual(out["alpha"], 11)
+        self.assertEqual(out["beta"], 7)
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestDiffLiveSnapshotNode(unittest.TestCase):
+    def test_returns_empty_when_first_render(self):
+        """prev === null のとき diff は all-empty を返す (toast 抑制経路)。"""
+        out = _node_eval(
+            "const next = buildLiveSnapshot({total_events: 1});\n"
+            "const d = diffLiveSnapshot(null, next);\n"
+            "process.stdout.write(JSON.stringify({\n"
+            "  kpiLen: d.kpi.length,\n"
+            "  ledeLen: d.lede.length,\n"
+            "  rankSkillLen: d.rankSkill.length,\n"
+            "  rankSubLen: d.rankSub.length,\n"
+            "}));\n"
+        )
+        self.assertEqual(out, {"kpiLen": 0, "ledeLen": 0, "rankSkillLen": 0, "rankSubLen": 0})
+
+    def test_kpi_increment_only(self):
+        """KPI 増加フィールドだけ delta > 0 entry。delta == 0 / < 0 は出ない。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  total_events: 100,\n"
+            "  session_stats: {total_sessions: 5},\n"
+            "});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 105,\n"
+            "  session_stats: {total_sessions: 5},\n"
+            "});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(d.kpi));\n"
+        )
+        # kpi-total +5 だけ。kpi-sess は不変なので含まれない
+        ids = [e["id"] for e in out]
+        self.assertIn("kpi-total", ids)
+        self.assertNotIn("kpi-sess", ids)
+        kpi_total = next(e for e in out if e["id"] == "kpi-total")
+        self.assertEqual(kpi_total["delta"], 5)
+
+    def test_kpi_decrement_excluded(self):
+        """delta < 0 は出力に含まれない (Issue #69 scope: 増分のみ)。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({total_events: 100});\n"
+            "const next = buildLiveSnapshot({total_events: 90});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(d.kpi));\n"
+        )
+        self.assertEqual(out, [])
+
+    def test_lede_increment(self):
+        """lede ledeEvents の delta は別 bucket に出る。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({total_events: 50});\n"
+            "const next = buildLiveSnapshot({total_events: 62});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(d.lede));\n"
+        )
+        ids = [e["id"] for e in out]
+        self.assertIn("ledeEvents", ids)
+        e = next(x for x in out if x["id"] == "ledeEvents")
+        self.assertEqual(e["delta"], 12)
+
+    def test_ranking_new_name_treated_as_zero_baseline(self):
+        """前回 Map に key 無しの新登場 skill は delta = current - 0 で出る。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({skill_ranking: [{name:'a', count:5}]});\n"
+            "const next = buildLiveSnapshot({skill_ranking: ["
+            "  {name:'a', count:5}, {name:'b', count:3}]});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(d.rankSkill));\n"
+        )
+        names = [e["name"] for e in out]
+        self.assertIn("b", names)
+        b = next(e for e in out if e["name"] == "b")
+        self.assertEqual(b["delta"], 3)
+        # a は不変なので含まれない
+        self.assertNotIn("a", names)
+
+    def test_ranking_existing_name_count_growth(self):
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({skill_ranking: [{name:'a', count:5}]});\n"
+            "const next = buildLiveSnapshot({skill_ranking: [{name:'a', count:8}]});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(d.rankSkill));\n"
+        )
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["name"], "a")
+        self.assertEqual(out[0]["delta"], 3)
+
+    def test_ranking_name_disappeared_does_not_appear(self):
+        """前回 top10 にいたが今回消えた skill は出力に出ない (toast は増分のみ)。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({skill_ranking: [{name:'a', count:5}]});\n"
+            "const next = buildLiveSnapshot({skill_ranking: []});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(d.rankSkill));\n"
+        )
+        self.assertEqual(out, [])
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestFormatToastSummaryNode(unittest.TestCase):
+    def test_aggregates_by_label(self):
+        """diff から `+12 events · +1 skill · +2 subagent invocations` を生成。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  total_events: 100,\n"
+            "  skill_ranking: [{name:'a', count:5}],\n"
+            "  subagent_ranking: [{name:'x', count:1}],\n"
+            "});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 112,\n"
+            "  skill_ranking: [{name:'a', count:5}, {name:'b', count:3}],\n"
+            "  subagent_ranking: [{name:'x', count:1}, {name:'y', count:1}, {name:'z', count:1}],\n"
+            "});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        # +12 events · +1 skill · +2 subagent invocations
+        self.assertIn("+12 events", out)
+        self.assertIn("+1 skill", out)
+        self.assertIn("+2 subagent invocations", out)
+        # セパレータは " · "
+        self.assertIn(" · ", out)
+        # 順序固定: events → skills → subagent
+        i_events = out.index("+12 events")
+        i_skill = out.index("+1 skill")
+        i_sub = out.index("+2 subagent invocations")
+        self.assertTrue(i_events < i_skill < i_sub,
+                        f"順序が events → skill → subagent でない: {out!r}")
+
+    def test_returns_empty_when_no_growth(self):
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({total_events: 5});\n"
+            "const next = buildLiveSnapshot({total_events: 5});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        self.assertEqual(out, "")
+
+    def test_skips_zero_delta_segments(self):
+        """events 増えたが skills 不変なら skills セグメントは出ない。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  total_events: 10, skill_ranking: [{name:'a', count:1}]});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 13, skill_ranking: [{name:'a', count:1}]});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        self.assertIn("+3 events", out)
+        self.assertNotIn("skill", out)
+
+    def test_caps_at_four_segments(self):
+        """5 種以上の delta があっても先頭 4 セグメントに切る (省略 ... を付けない)。
+
+        順序固定: events → skills → subagent → sessions → projects → compact → permission
+        priority 順から先頭 4 が残る。
+        """
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  total_events: 0,\n"
+            "  skill_ranking: [],\n"
+            "  subagent_ranking: [],\n"
+            "  project_breakdown: [],\n"
+            "  session_stats: {total_sessions: 0, compact_count: 0, permission_prompt_count: 0},\n"
+            "});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 10,\n"
+            "  skill_ranking: [{name:'a', count:1}],\n"
+            "  subagent_ranking: [{name:'x', count:1}],\n"
+            "  project_breakdown: [{project:'p1', count:1}],\n"
+            "  session_stats: {total_sessions: 2, compact_count: 1, permission_prompt_count: 1},\n"
+            "});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        # セグメント数 = " · " で分割した数
+        segments = out.split(" · ")
+        self.assertEqual(len(segments), 4, f"4 セグメントを超えた: {out!r}")
+        # 先頭 4: events, skill, subagent, session (priority 順)
+        self.assertTrue(segments[0].startswith("+10 event"))
+        self.assertIn("skill", segments[1])
+        self.assertIn("subagent", segments[2])
+        self.assertIn("session", segments[3])
+        # cap 後ろの projects / compact / permission は出ない
+        self.assertNotIn("project", out)
+        self.assertNotIn("compaction", out)
+        self.assertNotIn("permission", out)
+        # 省略 "..." を付けない
+        self.assertNotIn("...", out)
+
+    def test_uses_singular_for_delta_one(self):
+        """+1 event / +1 skill / +1 subagent invocation (singular)。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  total_events: 0,\n"
+            "  skill_ranking: [],\n"
+            "  subagent_ranking: [],\n"
+            "});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 1,\n"
+            "  skill_ranking: [{name:'a', count:1}],\n"
+            "  subagent_ranking: [{name:'x', count:1}],\n"
+            "});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        self.assertIn("+1 event", out)
+        self.assertIn("+1 skill", out)
+        self.assertIn("+1 subagent invocation", out)
+        # plural が混入していない (event(s) / skill(s) / invocation(s) を見分ける)
+        self.assertNotIn("+1 events", out)
+        self.assertNotIn("+1 skills", out)
+        self.assertNotIn("+1 subagent invocations", out)
+
+    def test_excludes_resume_rate(self):
+        """kpi-resume の delta があっても toast には出ない (highlight のみ)。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  total_events: 5,\n"
+            "  session_stats: {total_sessions: 10, resume_rate: 0.1},\n"
+            "});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  total_events: 5,\n"
+            "  session_stats: {total_sessions: 10, resume_rate: 0.5},\n"
+            "});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        self.assertNotIn("resume", out.lower())
+
+    def test_excludes_lede_buckets(self):
+        """lede 数字 (ledeEvents/ledeDays/ledeProjects) は toast に出ない。
+
+        KPI と二重カウント防止。total_events の lede と kpi-total は同値なので、
+        toast に出るのは kpi-total 経由の "+N events" のみで、ledeEvents 経由は出ない。
+        ledeDays / ledeProjects 単独で toast 出ないことを確認するには、KPI が
+        全 0 で lede のみ動くシナリオを作る (kpi-projs の bump が同時に出るので
+        分離しにくい → ledeDays bucket を直接見る)。
+        """
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({\n"
+            "  hourly_heatmap: {buckets: ["
+            "    {hour_utc: '2026-04-29T00:00:00+00:00', count: 1}]}\n"
+            "});\n"
+            "const next = buildLiveSnapshot({\n"
+            "  hourly_heatmap: {buckets: ["
+            "    {hour_utc: '2026-04-29T00:00:00+00:00', count: 1},"
+            "    {hour_utc: '2026-04-30T00:00:00+00:00', count: 1}]}\n"
+            "});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify({\n"
+            "  ledeBucketHasDays: d.lede.some(e => e.id === 'ledeDays'),\n"
+            "  toast: formatToastSummary(d),\n"
+            "}));\n"
+        )
+        # lede bucket には ledeDays delta は出るが、toast には出ない
+        self.assertTrue(out["ledeBucketHasDays"],
+                        "diff の lede bucket に ledeDays delta が出ていない (前提崩れ)")
+        # toast 文字列に "day" が含まれない
+        self.assertNotIn("day", out["toast"].lower())
+
+    def test_excludes_ranking_rows(self):
+        """ranking row delta も toast に出ない (highlight のみ)。"""
+        out = _node_eval(
+            "const prev = buildLiveSnapshot({skill_ranking: [{name:'codex-review', count:5}]});\n"
+            "const next = buildLiveSnapshot({skill_ranking: [{name:'codex-review', count:8}]});\n"
+            "const d = diffLiveSnapshot(prev, next);\n"
+            "process.stdout.write(JSON.stringify(formatToastSummary(d)));\n"
+        )
+        # rankSkill bucket の name は toast に出ない
+        self.assertNotIn("codex-review", out)
+        # 同 name の +3 を kpi-skills (kind 数 = 1 のまま) と勘違いしないこと
+        self.assertNotIn("skill", out)
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestCommitLiveSnapshotNode(unittest.TestCase):
+    def test_commit_then_diff_accumulates_across_skipped_commit(self):
+        """commitLiveSnapshot(snap1) → (skip commit for snap2) → diff(getLivePrev(), snap3)
+        で snap1 vs snap3 の累積 delta が出る。catch 経路で commit を呼ばないシナリオ。
+
+        production code path で `getLivePrev` を直接呼ぶのは禁止 (test fixture probe 専用)
+        だが、Node round-trip では `__livePrev` 内部状態に依存することを直接検証する。
+        """
+        out = _node_eval(
+            "const snap1 = buildLiveSnapshot({total_events: 10});\n"
+            "const snap2 = buildLiveSnapshot({total_events: 12});\n"
+            "const snap3 = buildLiveSnapshot({total_events: 15});\n"
+            "commitLiveSnapshot(snap1);\n"
+            "// snap2 では commit を呼ばずに skip (catch 経路の擬似化)\n"
+            "// snap3 で復活: __livePrev は snap1 のままなので 15 - 10 = 5 の累積 delta\n"
+            "const probe = (typeof window !== 'undefined' && window.__liveDiff)\n"
+            "  ? window.__liveDiff.getLivePrev()\n"
+            "  : __livePrev;\n"
+            "const d = diffLiveSnapshot(probe, snap3);\n"
+            "process.stdout.write(JSON.stringify(d.kpi));\n"
+        )
+        ids = [e["id"] for e in out]
+        self.assertIn("kpi-total", ids)
+        e = next(x for x in out if x["id"] == "kpi-total")
+        self.assertEqual(e["delta"], 5,
+                         "commit を skip した場合 累積 delta (snap1→snap3) が出るべき")
+
+
+# ============================================================
+#  Phase 3: Static export と first-render では toast / highlight が出ない
+# ============================================================
+class TestStaticExportNoLiveBehavior:
+    def test_static_export_does_not_show_toast(self):
+        """render_static_html(data) の出力に id=\"liveToast\" 要素は存在するが
+        hidden 属性が付いている (誤って toast 表示しない)。
+        """
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "_dashboard_for_static_export_test", _DASHBOARD_PY
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        data = mod.build_dashboard_data([])
+        html = mod.render_static_html(data)
+        assert 'id="liveToast"' in html, "static export 出力に liveToast 要素が無い"
+        match = re.search(r'<[^>]*id="liveToast"[^>]*>', html)
+        assert match is not None
+        tag = match.group(0)
+        # `hidden` boolean attribute が付いている
+        assert re.search(r'\bhidden\b', tag), \
+            f"liveToast に hidden 属性が無い (tag={tag!r})"
+
+    def test_static_export_does_not_apply_bumped_class(self):
+        """static export では diff 不能なので bumped class が出ない。"""
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "_dashboard_for_static_export_test2", _DASHBOARD_PY
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        data = mod.build_dashboard_data([])
+        html = mod.render_static_html(data)
+        assert "bumped" not in html, \
+            "static export 出力に bumped class が混入している (highlight は live mode 限定)"
+
+    def test_kpi_id_attributes_persist(self):
+        """kpi の id 属性は loadAndRender 後の HTML 文字列にも残っている前提。
+
+        applyHighlights が getElementById で参照する前提を壊さない。
+        ここは shell.html の kpiRow placeholder + 20_load_and_render.js の HTML 生成で
+        `id="kpi-..."` を出していること (= JS の出力 string に含まれること) を pin。
+        """
+        body = _read(_LOAD_RENDER_JS)
+        # kpis array の各 entry に id: 'kpi-...' があること
+        for kpi_id in ("kpi-total", "kpi-skills", "kpi-subs", "kpi-projs",
+                       "kpi-sess", "kpi-resume", "kpi-compact", "kpi-perm"):
+            assert f"'{kpi_id}'" in body, \
+                f"20_load_and_render.js の kpis array に '{kpi_id}' が無い"
+        # KPI tile DIV に id=' を付けて出力していること
+        assert re.search(r"<div class=\"kpi[^\"]*\"\s+id=", body) \
+            or "+ g.id" in body \
+            or "id=\"' + g.id + '\"" in body \
+            or "id=\\\"' + g.id + '\\\"" in body, \
+            "KPI tile の HTML 出力で id 属性を埋め込めていない"
+
+    def test_rank_row_data_name_attribute_persists(self):
+        """rank renderer 出力に data-name=\"...\" が必ず含まれる。"""
+        body = _read(_LOAD_RENDER_JS)
+        assert "data-name=\"' + esc(it.name) + '\"" in body, \
+            "rank-row の data-name 属性が rank renderer で出力されていない"

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -314,6 +314,12 @@ def _node_eval(script: str) -> object:
 
     helpers.js + 25_live_diff.js を IIFE 内側で動く前提でそのまま eval する。
     Windows CI で os.environ を継承して PATH 等が消えないように env.copy する。
+
+    encoding='utf-8' を明示する理由: subprocess.run(text=True) は Windows で
+    OS デフォルト encoding (cp932 / cp1252 等) を使うため、Node stdout の UTF-8
+    multibyte 文字 (本機能の toast separator " · " = U+00B7 等) が誤 decode され
+    'Â·' / '·' のような mojibake になり、Windows CI 上で test 失敗する
+    (Linux/macOS では `LANG=*.UTF-8` がデフォルトなので顕在化しない)。
     """
     helpers_src = _read(_HELPERS_JS)
     live_src = _read(_LIVE_DIFF_JS)
@@ -324,6 +330,7 @@ def _node_eval(script: str) -> object:
         env=env,
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
         timeout=10,
     )

--- a/tests/test_dashboard_live_diff.py
+++ b/tests/test_dashboard_live_diff.py
@@ -29,6 +29,8 @@ _TEMPLATE_DIR = Path(__file__).parent.parent / "dashboard" / "template"
 _LIVE_DIFF_JS = _TEMPLATE_DIR / "scripts" / "25_live_diff.js"
 _LOAD_RENDER_JS = _TEMPLATE_DIR / "scripts" / "20_load_and_render.js"
 _HELPERS_JS = _TEMPLATE_DIR / "scripts" / "10_helpers.js"
+_INIT_ES_JS = _TEMPLATE_DIR / "scripts" / "70_init_eventsource.js"
+_HASHCHANGE_JS = _TEMPLATE_DIR / "scripts" / "60_hashchange_listener.js"
 _DASHBOARD_PY = Path(__file__).parent.parent / "dashboard" / "server.py"
 _COMPONENTS_CSS = _TEMPLATE_DIR / "styles" / "10_components.css"
 _SHELL_HTML = _TEMPLATE_DIR / "shell.html"
@@ -75,6 +77,30 @@ class TestLiveDiffJsStructure:
         body = _read(_LIVE_DIFF_JS)
         assert re.search(r"\bfunction\s+commitLiveSnapshot\s*\(", body), \
             "function commitLiveSnapshot(...) が 25_live_diff.js に定義されていない"
+
+    def test_schedule_load_and_render_function_defined(self):
+        """SSE refresh / hashchange の loadAndRender 並行発火を直列化する
+        scheduleLoadAndRender が 25_live_diff.js に定義されている。defining
+        ファイルを 25 にする理由: __activeRender / __pendingRefresh の
+        closure-private state が 25 番冒頭の IIFE-top 宣言群と同居しているため。
+        """
+        body = _read(_LIVE_DIFF_JS)
+        assert re.search(r"\bfunction\s+scheduleLoadAndRender\s*\(", body), \
+            "function scheduleLoadAndRender(...) が 25_live_diff.js に定義されていない"
+
+    def test_schedule_state_declared_at_iife_top(self):
+        """`__activeRender` / `__pendingRefresh` が 25_live_diff.js 冒頭 (関数定義
+        より前) に宣言されている。25 番冒頭に集約する理由は 25_live_diff.js の
+        TDZ 安全性コメントと同じ — IIFE-top の `let` 群と一緒に評価済にする。
+        """
+        body = _read(_LIVE_DIFF_JS)
+        first_fn_match = re.search(r"\bfunction\s+", body)
+        assert first_fn_match is not None
+        head = body[: first_fn_match.start()]
+        assert re.search(r"\blet\s+__activeRender\s*=", head), \
+            "25_live_diff.js 冒頭に let __activeRender = ... 宣言が無い"
+        assert re.search(r"\blet\s+__pendingRefresh\s*=", head), \
+            "25_live_diff.js 冒頭に let __pendingRefresh = ... 宣言が無い"
 
     def test_25_declares_liveprev_at_iife_top(self):
         """25_live_diff.js 冒頭 (関数定義より前) に `let __livePrev` 宣言が存在する。
@@ -230,6 +256,43 @@ class TestLoadRenderIntegration:
         assert not re.search(r"__livePrev\s*=", body), \
             "20_load_and_render.js に __livePrev への直接代入が混入している" \
             " (commitLiveSnapshot(...) 経由のみ許可)"
+
+    def test_init_eventsource_uses_schedule_wrapper_for_sse_refresh(self):
+        """SSE refresh の fire-and-forget 経路は scheduleLoadAndRender 経由で呼ぶ。
+
+        bare `loadAndRender()` を fire-and-forget すると、fetch1 / fetch2 が overlap
+        した際に DOM が古い data1 で上書き → commitLiveSnapshot で __livePrev も
+        snap1 に巻き戻る race が再来する。
+        """
+        body = _read(_INIT_ES_JS)
+        # message handler 内で loadAndRender 直接呼出ではなく schedule 経由
+        msg_handler = re.search(
+            r"addEventListener\(['\"]message['\"][^{]*\{(.*?)\}\)",
+            body, re.DOTALL,
+        )
+        assert msg_handler is not None, \
+            "70_init_eventsource.js の message handler が見つからない"
+        handler_body = msg_handler.group(1)
+        assert "scheduleLoadAndRender(" in handler_body, \
+            "70_init_eventsource.js の SSE message handler が " \
+            "scheduleLoadAndRender(...) を呼んでいない"
+        # bare loadAndRender( を message handler 内で fire-and-forget していない
+        # (= "loadAndRender(" が現れたとしても scheduleLoadAndRender( の一部として)
+        bare_calls = re.findall(r"(?<!schedule)\bloadAndRender\s*\(", handler_body)
+        assert not bare_calls, \
+            "70_init_eventsource.js の SSE message handler に bare loadAndRender(...) " \
+            "の fire-and-forget が残っている (race 防止のため schedule 経由必須)"
+
+    def test_hashchange_listener_uses_schedule_wrapper(self):
+        """hashchange handler も SSE refresh と並行して走り得るので schedule 経由。"""
+        body = _read(_HASHCHANGE_JS)
+        assert "scheduleLoadAndRender(" in body, \
+            "60_hashchange_listener.js が scheduleLoadAndRender(...) を呼んでいない"
+        # bare loadAndRender( が残っていない
+        bare_calls = re.findall(r"(?<!schedule)\bloadAndRender\s*\(", body)
+        assert not bare_calls, \
+            "60_hashchange_listener.js に bare loadAndRender(...) が残っている " \
+            "(race 防止のため schedule 経由必須)"
 
 
 # ============================================================
@@ -764,6 +827,122 @@ class TestCommitLiveSnapshotNode(unittest.TestCase):
         e = next(x for x in out if x["id"] == "kpi-total")
         self.assertEqual(e["delta"], 5,
                          "commit を skip した場合 累積 delta (snap1→snap3) が出るべき")
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestScheduleLoadAndRenderNode(unittest.TestCase):
+    """scheduleLoadAndRender が overlap を直列化し、in-flight 中の追加要求は
+    coalesce して 1 件 pending に絞ることを検証する (stale-snapshot race 対策)。
+    """
+
+    def test_serializes_overlapping_calls_strictly(self):
+        """scheduleLoadAndRender を 2 連続で呼んでも、2 件目の loadAndRender は
+        1 件目が完了するまで開始されない (strict serial order)。
+
+        失敗時の症状: 並行実行で start1 / start2 が先に並び end1 / end2 が後ろに
+        来る ('start1','start2','end1','end2')。修正後は完全直列で
+        ['start1','end1','start2','end2'] になる。
+        """
+        out = _node_eval(
+            "let counter = 0;\n"
+            "let order = [];\n"
+            "let resolvers = [];\n"
+            "// scheduleLoadAndRender が呼び出す lexical な loadAndRender を override する。\n"
+            "// JS の関数宣言は再代入可能 (strict mode の Module ではないので)。\n"
+            "loadAndRender = function () {\n"
+            "  counter += 1;\n"
+            "  const my = counter;\n"
+            "  order.push('start' + my);\n"
+            "  return new Promise(resolve => {\n"
+            "    resolvers.push(function () { order.push('end' + my); resolve(); });\n"
+            "  });\n"
+            "};\n"
+            "(async function () {\n"
+            "  const p1 = scheduleLoadAndRender();\n"
+            "  const p2 = scheduleLoadAndRender();\n"
+            "  // microtask を流して p1 の Promise.resolve().then(...) を発火させる\n"
+            "  await Promise.resolve(); await Promise.resolve();\n"
+            "  const midStarted = counter;\n"
+            "  const midOrder = order.slice();\n"
+            "  // __pendingRefresh は live_diff.js の script-scope let なので bare name で参照\n"
+            "  const midPending = __pendingRefresh;\n"
+            "  // 1 件目の loadAndRender を resolve\n"
+            "  resolvers[0]();\n"
+            "  // finally → pending fire → 2 件目の loadAndRender 開始までの microtask を流す\n"
+            "  await Promise.resolve(); await Promise.resolve(); await Promise.resolve();\n"
+            "  const afterFirst = counter;\n"
+            "  const afterFirstOrder = order.slice();\n"
+            "  // 2 件目を resolve\n"
+            "  resolvers[1]();\n"
+            "  await Promise.resolve(); await Promise.resolve();\n"
+            "  process.stdout.write(JSON.stringify({\n"
+            "    midStarted,            // 1 件目開始 / 2 件目はまだ → 1\n"
+            "    midOrder,              // ['start1']\n"
+            "    midPending,            // true (2 件目が coalesce 済)\n"
+            "    afterFirst,            // 1 件目完了後に 2 件目開始 → 2\n"
+            "    afterFirstOrder,       // ['start1','end1','start2']\n"
+            "    finalCounter: counter, // 2 (それ以上 fire しない)\n"
+            "    finalOrder: order,     // ['start1','end1','start2','end2']\n"
+            "    p1eq_p2: p1 === p2,    // true (coalesce で同 promise 返却)\n"
+            "  }));\n"
+            "})().catch(e => { console.error(e); process.exit(1); });\n"
+        )
+        self.assertEqual(out["midStarted"], 1,
+                         "1 件目開始時点で 2 件目が同時に走り出している (直列化されていない)")
+        self.assertEqual(out["midOrder"], ["start1"])
+        self.assertTrue(out["midPending"],
+                        "2 件目が __pendingRefresh = true で coalesce されていない")
+        self.assertEqual(out["afterFirst"], 2,
+                         "1 件目完了後に 2 件目が fire していない (pending refresh が消えている)")
+        self.assertEqual(out["afterFirstOrder"], ["start1", "end1", "start2"],
+                         f"strict serial order が崩れている: {out['afterFirstOrder']}")
+        self.assertEqual(out["finalCounter"], 2,
+                         "想定外に 3 回目以降 fire している")
+        self.assertEqual(out["finalOrder"], ["start1", "end1", "start2", "end2"],
+                         f"final 直列順序が崩れている: {out['finalOrder']}")
+        self.assertTrue(out["p1eq_p2"],
+                        "scheduleLoadAndRender が in-flight 中に同じ promise を返していない")
+
+    def test_third_call_during_first_does_not_double_pend(self):
+        """1 件目 in-flight 中に 3 回連続 schedule しても pending は 1 件に
+        coalesce される (queue 肥大しない)。最終的な loadAndRender 呼出回数 = 2。
+        """
+        out = _node_eval(
+            "let counter = 0;\n"
+            "let resolvers = [];\n"
+            "loadAndRender = function () {\n"
+            "  counter += 1;\n"
+            "  return new Promise(resolve => { resolvers.push(resolve); });\n"
+            "};\n"
+            "(async function () {\n"
+            "  scheduleLoadAndRender();\n"
+            "  scheduleLoadAndRender();\n"
+            "  scheduleLoadAndRender();\n"
+            "  scheduleLoadAndRender();\n"
+            "  await Promise.resolve(); await Promise.resolve();\n"
+            "  // 1 件目だけ start している\n"
+            "  const startedFirst = counter;\n"
+            "  resolvers[0]();\n"
+            "  await Promise.resolve(); await Promise.resolve(); await Promise.resolve();\n"
+            "  // pending 1 件だけが fire (3 件 coalesce → 1 件)\n"
+            "  const startedSecond = counter;\n"
+            "  resolvers[1]();\n"
+            "  await Promise.resolve(); await Promise.resolve();\n"
+            "  // 全完了後 pending 残らない\n"
+            "  const final = counter;\n"
+            "  const tailPending = __pendingRefresh;\n"
+            "  process.stdout.write(JSON.stringify({\n"
+            "    startedFirst, startedSecond, final, tailPending,\n"
+            "  }));\n"
+            "})().catch(e => { console.error(e); process.exit(1); });\n"
+        )
+        self.assertEqual(out["startedFirst"], 1)
+        self.assertEqual(out["startedSecond"], 2,
+                         "3 件以上 schedule しても pending は 1 件に coalesce される必要がある")
+        self.assertEqual(out["final"], 2,
+                         f"queue が肥大して 2 を超えている (got {out['final']})")
+        self.assertFalse(out["tailPending"],
+                         "全完了後も __pendingRefresh が立っている (cleanup 漏れ)")
 
 
 # ============================================================

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -37,7 +37,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 42d23915...: Issue #69 UX 調整 / 表示中上書き時の slide-in 再生 + 表示時間を 6s → 4s に戻す
 #   - 2964f3e9...: Issue #69 UX 調整 / requestAnimationFrame で frame 分割 (style 変更 collapse 回避)
 #   - e787b78b...: Issue #69 UX 調整 / CSS animation (@keyframes toast-in/out) に切替 (CSS transition 方式は実機で再生されない問題への対処)
-EXPECTED_TEMPLATE_SHA256 = "e787b78b9d4bdf106972f9675dc3f033bf55dbca2c0370e1def44a9119c6b4be"
+#   - 4f4b511f...: Issue #69 fix-up / scheduleLoadAndRender で SSE refresh と hashchange の loadAndRender 並行発火を直列化 (stale-snapshot race 対策)
+EXPECTED_TEMPLATE_SHA256 = "4f4b511f26e6ab599e69cad5d70d2319dfe8244c9271d6d5354c2753f44b430f"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -34,7 +34,10 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - f53d0dab...: Issue #69 UX 調整 / toast を横方向中央寄せ + coral 系 color に変更
 #   - a4885a23...: Issue #69 UX 調整 / toast 表示時間を 4s → 6s に延長
 #   - f7bcb6b0...: Issue #69 UX 調整 / toast fade-out transition を 240ms 完走させる二段 timer 設計
-EXPECTED_TEMPLATE_SHA256 = "f7bcb6b02968bb2b1dd1672cb9938a8638055c197b1b04ee841e68950eed3054"
+#   - 42d23915...: Issue #69 UX 調整 / 表示中上書き時の slide-in 再生 + 表示時間を 6s → 4s に戻す
+#   - 2964f3e9...: Issue #69 UX 調整 / requestAnimationFrame で frame 分割 (style 変更 collapse 回避)
+#   - e787b78b...: Issue #69 UX 調整 / CSS animation (@keyframes toast-in/out) に切替 (CSS transition 方式は実機で再生されない問題への対処)
+EXPECTED_TEMPLATE_SHA256 = "e787b78b9d4bdf106972f9675dc3f033bf55dbca2c0370e1def44a9119c6b4be"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -29,7 +29,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 39ad755c...: v0.7.0 / Issue #67 split 直後
 #   - 7538e22b...: Issue #65 / local TZ 化で 10_helpers.js + 20_load_and_render.js 改修
 #   - f27e07c7...: Issue #65 fix-up / formatLocalTimestamp に falsy ガード追加
-EXPECTED_TEMPLATE_SHA256 = "f27e07c762a321a8c9d89f4c183b13a57e7e5ccd2e9d313ab743d386a9286ec9"
+#   - e7440528...: Issue #69 / live diff highlight + toast (25_live_diff.js 追加, shell.html / 10_components.css / 20_load_and_render.js / _MAIN_JS_FILES 改修)
+EXPECTED_TEMPLATE_SHA256 = "e7440528645d274418c2435cddc57dbd6db92305dcaa2bac0d53fff8d087ef6f"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -31,7 +31,10 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - f27e07c7...: Issue #65 fix-up / formatLocalTimestamp に falsy ガード追加
 #   - e7440528...: Issue #69 / live diff highlight + toast (25_live_diff.js 追加, shell.html / 10_components.css / 20_load_and_render.js / _MAIN_JS_FILES 改修)
 #   - 4feb318f...: Issue #69 fix-up / KPI tile に id="' + g.id + '" を追加 (applyHighlights getElementById 命中)
-EXPECTED_TEMPLATE_SHA256 = "4feb318fd600a8052edf0d49a1be507451ce5a492a3d9d194786e6adfad09401"
+#   - f53d0dab...: Issue #69 UX 調整 / toast を横方向中央寄せ + coral 系 color に変更
+#   - a4885a23...: Issue #69 UX 調整 / toast 表示時間を 4s → 6s に延長
+#   - f7bcb6b0...: Issue #69 UX 調整 / toast fade-out transition を 240ms 完走させる二段 timer 設計
+EXPECTED_TEMPLATE_SHA256 = "f7bcb6b02968bb2b1dd1672cb9938a8638055c197b1b04ee841e68950eed3054"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -30,7 +30,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 7538e22b...: Issue #65 / local TZ 化で 10_helpers.js + 20_load_and_render.js 改修
 #   - f27e07c7...: Issue #65 fix-up / formatLocalTimestamp に falsy ガード追加
 #   - e7440528...: Issue #69 / live diff highlight + toast (25_live_diff.js 追加, shell.html / 10_components.css / 20_load_and_render.js / _MAIN_JS_FILES 改修)
-EXPECTED_TEMPLATE_SHA256 = "e7440528645d274418c2435cddc57dbd6db92305dcaa2bac0d53fff8d087ef6f"
+#   - 4feb318f...: Issue #69 fix-up / KPI tile に id="' + g.id + '" を追加 (applyHighlights getElementById 命中)
+EXPECTED_TEMPLATE_SHA256 = "4feb318fd600a8052edf0d49a1be507451ce5a492a3d9d194786e6adfad09401"
 
 
 def _load_dashboard_module(tmp_path: Path):


### PR DESCRIPTION
## Summary

ライブダッシュボードに **差分ハイライト + 更新概要 toast** を追加 (Issue #69)。

- **対象**: Overview ページの KPI tiles 8 種 / lede 数字 3 種 / ranking rows (skill / subagent, name 単位)
- **Pulse animation**: `@keyframes pulse-bg` 1.5s ease-out, mint background pulse + `prefers-reduced-motion: reduce` で静止 outline
- **Toast**: 画面上部 horizontal center / coral 色 / 4s 表示 / `@keyframes toast-in/toast-out` 各 240ms / 上書き時に slide-in 再起動
- **Live mode 限定**: \`window.__DATA__\` 経由 (static export) では diff path に入らない

## Closes
Closes #69

## 設計判断 (D1〜D7)

詳細は \`docs/plans/69-live-update-highlight.md\` を参照。

| | 設計判断 |
|---|---|
| D1 | Diff の単位 = closure 内の \`__livePrev\` Map (25_live_diff.js IIFE 直下宣言) |
| D2 | Highlight = CSS keyframes pulse-bg (background pulse, layout-safe) |
| D3 | Toast = 1 行 aggregate / 単一要素 / queue しない置換 / 上書き時 animation 再生 |
| D4 | Diff scope = Overview のみ (Patterns / Quality / Surface は OOS) |
| D5 | First-render / catch 経路は \`commitLiveSnapshot\` 経由のみで snap1→snap3 累積 delta |
| D6 | Ranking row identity = name 単位 (rank index ではない) |
| D7 | 連発時は \`WeakMap<Element, number>\` で per-element timer cleanup + reflow trick で animation 再起動 |

## Toast 文言 (LABEL テーブル)

priority 順, 先頭 4 segment が残る:

\`\`\`
+N event(s) · +N skill(s) · +N subagent invocation(s) · +N session(s) · +N project(s) · +N compaction(s) · +N permission(s)
\`\`\`

- delta > 0 のみ
- delta = 1 で singular / >1 で plural
- \`kpi-resume\` / lede 数字 / ranking row 名は **toast には出さない** (highlight のみ)

## UX 調整経緯 (commit 履歴に対応)

1. 初版: 右上配置 / mint border / 4s 表示
2. **位置を上中央に / coral 色に / 6s 表示に**
3. **fade-out が display:none で打ち切られる bug** を修正 → 二段 timer (display end → fade-out start → 240ms 後に hidden) で transition 完走
4. **表示中 上書き時に slide-in 再起動が動かない bug** を修正 (CSS transition は同フレーム内変更を Browser が collapse) → CSS animation (\`@keyframes toast-in/toast-out\`) に切替
5. 表示時間を 4s に戻す

## Test plan

- [x] \`python3 -m pytest tests/\` → **937 passed / 1 skipped** (Node 不在環境向け gate)
- [x] 新規 \`tests/test_dashboard_live_diff.py\` (43 tests, literal pin + Node round-trip)
- [x] \`EXPECTED_TEMPLATE_SHA256\` を \`e787b78b...\` に更新 (履歴コメントに Issue #69 entry × 5)
- [x] 静的 export を \`reports/export_html.py\` で生成して chrome-devtools MCP 検証:
  - 全 8 KPI tile が \`id="kpi-..."\` 付きで \`getElementById\` 命中 ✓
  - bumped class が DOM 要素に付かない (live diff path 未実行) ✓
  - liveToast 要素が hidden 初期状態 ✓
  - \`.toast.show\` で \`Element.getAnimations()\` が \`toast-in\` (running) を返す ✓
  - 上書き時 currentTime が 0 から再カウント = 物理的に slide-in 再起動 ✓
  - 個別 highlight (\`.bumped\`) で全 5 target が \`pulse-bg\` 1.5s ease-out running ✓
- [x] \`scripts/build_live_diff_fixture.py\` で 2 段階 usage.jsonl + 手順スクリプト生成
- [ ] **手動チェック (merge 前)**:
  - [ ] live mode で highlight pulse 確認 (KPI / lede / ranking row)
  - [ ] live mode で toast 表示確認 (1 行 aggregate / 4s 自動消滅 / fade-out 240ms)
  - [ ] 上書き再 toast で slide-in が visual に再生されることを確認
  - [ ] static export で toast / highlight が**出ない**ことを確認
  - [ ] OS 設定で reduced motion ON にしたとき pulse が静止 outline / toast が opacity fade のみであることを確認
  - [ ] **catch 経路の累積 delta**: \`/api/data\` に一時 \`raise RuntimeError\` を仕込んで再起動 → append → toast 出ない → revert + 再 append → 復活 refresh で 2 回分の累積 delta が toast に出ることを確認

## codex-review loop

2 rounds run / **0 actionable resolved** / 1 advisory dismissed (verified false-positive)。

### Dismissed P1 — \`_build_html_template\` CRLF concern (Round 1 & Round 2 stateless re-raise)

codex flagged \`dashboard/server.py:969-972\` for "exact \`__INCLUDE_*__\\n\` replacement breaks under CRLF checkouts".

**Verified false-positive**: Python's \`Path.read_text(encoding="utf-8")\` defaults to universal newlines mode (\`newline=None\`), which translates \`\\r\\n\` / \`\\r\` / \`\\n\` all to \`\\n\` on read. Direct REPL probe with a CRLF-encoded fixture confirmed:

\`\`\`
read_text result: 'line1\\nline2\\n__INCLUDE_STYLES__\\nline4\\n'
LF normalized: True
sentinel match: True
replaced: 'line1\\nline2\\nCSS\\nline4\\n'
\`\`\`

Additionally **out-of-scope**: that code path is Issue #67 (template-split) territory; Issue #69 only adds one entry to \`_MAIN_JS_FILES\`. Round 2 re-raised the identical finding statelessly without engaging the rebuttal — recorded as \`[SUGGESTION]\` per \`verify-bot-review\` skill discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)