### PR TITLE
feat(dashboard): live heartbeat sparkline (Issue #83)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -957,6 +957,7 @@ _TEMPLATE_DIR = Path(__file__).resolve().parent / "template"
 _CSS_FILES = (
     "00_base.css",          # root vars / reset / body / .app
     "10_components.css",    # header / live badge / KPI / panel / two-up / ranking / spark / projects / footer
+    "15_heartbeat.css",     # live heartbeat sparkline (Issue #83)
     "20_help_tooltip.css",  # help button + data tooltip (graph data points)
     "30_pages.css",         # multipage shell (Issue #57)
     "40_patterns.css",      # hourly heatmap + skill cooccurrence + project×skill (Issue #58/59)
@@ -965,6 +966,7 @@ _CSS_FILES = (
 )
 _MAIN_JS_FILES = (
     "10_helpers.js",              # esc / fmtN / pad / STATUS_LABEL / setConnStatus
+    "15_heartbeat.js",            # live heartbeat sparkline (Issue #83)
     "20_load_and_render.js",      # async loadAndRender (KPI / ranking / sparkline / projects)
     "25_live_diff.js",            # live mode 差分 highlight + toast (Issue #69)
     "30_renderers_patterns.js",   # heatmap / cooccurrence / project×skill matrix renderers

--- a/dashboard/template/scripts/10_helpers.js
+++ b/dashboard/template/scripts/10_helpers.js
@@ -60,6 +60,10 @@
     static:    '— 静的レポート',
   };
   function setConnStatus(state) {
+    // Issue #83: heartbeat 状態は connStatus DOM 不在 / 削除時にも sync させる。
+    // (connStatus は footer に居住するので 4 ページ全てに必ずあるが、防衛的に
+    //  ガードより前に書く。)
+    if (window.__heartbeat) window.__heartbeat.setState(state);
     const el = document.getElementById('connStatus');
     if (!el) return;
     el.dataset.state = state;

--- a/dashboard/template/scripts/15_heartbeat.js
+++ b/dashboard/template/scripts/15_heartbeat.js
@@ -27,6 +27,10 @@
   let __hbReducedMotion = false;
   let __hbLastTickMs = 0;
   let __hbAccumMs = 0;
+  // 各 sample 進む度にインクリメント。idle 時の subtle baseline breathing wave の
+  // phase 入力 + buffer overflow worry なし (30 sample/s × Number.MAX_SAFE_INTEGER で
+  // 数万年スケール)。
+  let __hbTickCount = 0;
 
   function __hbDetectReducedMotion() {
     if (typeof window === 'undefined') return false;
@@ -55,17 +59,25 @@
   }
 
   function __hbAdvanceOneSample() {
-    // 1 sample 左シフト + 末尾追加 (spike 残量があれば SHAPE * amp、なければ baseline 0)
+    // 1 sample 左シフト + 末尾追加。
+    // spike 残量があれば SHAPE * amp、なければ idle baseline breathing wave。
+    // breathing は振幅 ~0.6px / 周期 ~3.3s の sin。プラン acceptance criteria
+    // 「idle 30s 以上でも line が左→右に流れ続ける (= 凍ってない)」を視覚的に
+    // 担保するため (Issue #83 codex Round 2 P1)。__hbSpikeAmp で state スケール
+    // するので offline/static (amp=0) では完全 flat = 既存テストの「buf 全 0」契約と整合。
     for (let i = 0; i < __hbBuf.length - 1; i++) {
       __hbBuf[i] = __hbBuf[i + 1];
     }
-    let nextSample = 0;
+    let nextSample;
     if (__hbSpikeRemain > 0) {
       const idx = HB_SPIKE_SHAPE.length - __hbSpikeRemain;
       nextSample = HB_SPIKE_SHAPE[idx] * __hbSpikeAmp;
       __hbSpikeRemain -= 1;
+    } else {
+      nextSample = 0.6 * Math.sin(__hbTickCount * 0.06) * __hbSpikeAmp;
     }
     __hbBuf[__hbBuf.length - 1] = nextSample;
+    __hbTickCount += 1;
   }
 
   function __hbTick(timestamp) {
@@ -110,6 +122,11 @@
       cancelAnimationFrame(__hbRafId);
       __hbRafId = null;
     }
+    // pause 後の resume 時に stale dt で catch-up モード暴走を起こさないよう
+    // timing state を毎回クリア (Issue #83 codex Round 2 P2)。次回 tick の
+    // 初回 frame で `__hbLastTickMs > 0` ガードに落ちて dt = 0 から再開する。
+    __hbLastTickMs = 0;
+    __hbAccumMs = 0;
   }
 
   // 全 state で __hbSpikeAmp を明示的に書き込む (state transition 時の amplitude leak 防止)。
@@ -191,6 +208,7 @@
         __hbSpikeRemain = 0;
         __hbLastTickMs = 0;
         __hbAccumMs = 0;
+        __hbTickCount = 0;
       },
     };
   }

--- a/dashboard/template/scripts/15_heartbeat.js
+++ b/dashboard/template/scripts/15_heartbeat.js
@@ -1,0 +1,166 @@
+  // Issue #83: live heartbeat sparkline.
+  //
+  // ・closure-private state は 15 番ファイル冒頭 (= 全 main_js を wrap する単一
+  //   shared IIFE 直下) に置く。20 番以降から `window.__heartbeat` 経由で参照。
+  // ・全識別子を `__hb` prefix で名前空間隔離 (Issue #69 の `__livePrev` 等と同じ慣習)。
+  // ・別 file (10_helpers.js / 70_init_eventsource.js) からは window.__heartbeat 経由で
+  //   API 越しにアクセスする (= __hbState 等を直接 read/write しない)。
+  const HB_SAMPLES = 60;
+  const HB_VIEW_W = 140;
+  const HB_VIEW_H = 22;
+  // PQRS 風の単一スパイク shape (上に -9px → 下に +4px → 0px)。10 frames 固定 duration、
+  // 強弱は __hbSpikeAmp で別軸制御 (online=1.0 / reconnect=0.3 / offline・static=0.0)。
+  const HB_SPIKE_SHAPE = [-2, -5, -9, -7, -3, 2, 4, 3, 1, 0];
+  let __hbState = 'idle';
+  let __hbBuf = new Float32Array(HB_SAMPLES);
+  let __hbSpikeRemain = 0;
+  let __hbSpikeAmp = 1.0;
+  let __hbRafId = null;
+  let __hbReducedMotion = false;
+
+  function __hbDetectReducedMotion() {
+    if (typeof window === 'undefined') return false;
+    if (typeof window.matchMedia !== 'function') return false;
+    try {
+      return !!(window.matchMedia('(prefers-reduced-motion: reduce)').matches);
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function __hbRenderPoly() {
+    if (typeof document === 'undefined') return;
+    const svg = document.getElementById('heartbeat');
+    if (!svg) return;
+    const poly = (typeof svg.querySelector === 'function') ? svg.querySelector('polyline') : null;
+    if (!poly || typeof poly.setAttribute !== 'function') return;
+    const stepX = HB_VIEW_W / (HB_SAMPLES - 1);
+    const midY = HB_VIEW_H / 2;
+    let pts = '';
+    for (let i = 0; i < HB_SAMPLES; i++) {
+      pts += (i * stepX).toFixed(2) + ',' + (midY + __hbBuf[i]).toFixed(2);
+      if (i < HB_SAMPLES - 1) pts += ' ';
+    }
+    poly.setAttribute('points', pts);
+  }
+
+  function __hbTick() {
+    // 1 sample 左シフト + 末尾追加
+    for (let i = 0; i < __hbBuf.length - 1; i++) {
+      __hbBuf[i] = __hbBuf[i + 1];
+    }
+    let nextSample = 0;
+    if (__hbSpikeRemain > 0) {
+      const idx = HB_SPIKE_SHAPE.length - __hbSpikeRemain;
+      nextSample = HB_SPIKE_SHAPE[idx] * __hbSpikeAmp;
+      __hbSpikeRemain -= 1;
+    }
+    __hbBuf[__hbBuf.length - 1] = nextSample;
+    __hbRenderPoly();
+    __hbRafId = requestAnimationFrame(__hbTick);
+  }
+
+  function startHeartbeat() {
+    if (typeof window === 'undefined') return;
+    if (__hbRafId !== null) return;
+    __hbReducedMotion = __hbDetectReducedMotion();
+    // shell.html の default `hidden` を解除して live 経路で初めて見せる
+    const svg = (typeof document !== 'undefined') ? document.getElementById('heartbeat') : null;
+    if (svg) svg.hidden = false;
+    if (__hbReducedMotion) {
+      // flat line を 1 度だけ描画して以降 tick しない
+      for (let i = 0; i < __hbBuf.length; i++) __hbBuf[i] = 0;
+      __hbRenderPoly();
+      return;
+    }
+    __hbRafId = requestAnimationFrame(__hbTick);
+  }
+
+  function stopHeartbeat() {
+    if (__hbRafId !== null) {
+      cancelAnimationFrame(__hbRafId);
+      __hbRafId = null;
+    }
+  }
+
+  // 全 state で __hbSpikeAmp を明示的に書き込む (state transition 時の amplitude leak 防止)。
+  // STATUS_LABEL keys (online / reconnect / offline / static) と 1:1 対応 (test pin)。
+  function setHeartbeatState(state) {
+    __hbState = state;
+    const svg = (typeof document !== 'undefined') ? document.getElementById('heartbeat') : null;
+    if (svg) {
+      if (svg.dataset) svg.dataset.state = state;
+      else if (typeof svg.setAttribute === 'function') svg.setAttribute('data-state', state);
+    }
+    switch (state) {
+      case 'online':
+        __hbSpikeAmp = 1.0;
+        if (svg) svg.hidden = false;
+        if (__hbRafId === null && !__hbReducedMotion && typeof requestAnimationFrame === 'function') {
+          __hbRafId = requestAnimationFrame(__hbTick);
+        }
+        break;
+      case 'reconnect':
+        __hbSpikeAmp = 0.3;
+        if (svg) svg.hidden = false;
+        if (__hbRafId === null && !__hbReducedMotion && typeof requestAnimationFrame === 'function') {
+          __hbRafId = requestAnimationFrame(__hbTick);
+        }
+        break;
+      case 'offline':
+        __hbSpikeAmp = 0.0;
+        stopHeartbeat();
+        for (let i = 0; i < __hbBuf.length; i++) __hbBuf[i] = 0;
+        __hbSpikeRemain = 0;
+        __hbRenderPoly();
+        if (svg) svg.hidden = false;
+        break;
+      case 'static':
+        __hbSpikeAmp = 0.0;
+        stopHeartbeat();
+        for (let i = 0; i < __hbBuf.length; i++) __hbBuf[i] = 0;
+        __hbSpikeRemain = 0;
+        if (svg) svg.hidden = true;
+        break;
+      default:
+        // 未知 state: no-op (defensive)。STATUS_LABEL keys 1:1 は test pin。
+        break;
+    }
+  }
+
+  function bumpHeartbeat() {
+    if (__hbReducedMotion) {
+      // reduced-motion: 視覚 spike を出さず aria-live 領域に通知。連発時にも
+      // 同一文字列の no-op 化を避けるため一旦 '' に戻してから本文を再書き込む
+      // (microtask boundary を挟んで DOM diff として確実に発火させる)。
+      const sr = (typeof document !== 'undefined') ? document.getElementById('heartbeatSr') : null;
+      if (sr) {
+        sr.textContent = '';
+        Promise.resolve().then(function () { sr.textContent = '更新を受信しました'; });
+      }
+      return;
+    }
+    if (__hbState === 'offline' || __hbState === 'static') return;
+    __hbSpikeRemain = HB_SPIKE_SHAPE.length;
+  }
+
+  if (typeof window !== 'undefined') {
+    window.__heartbeat = {
+      bump: bumpHeartbeat,
+      setState: setHeartbeatState,
+      start: startHeartbeat,
+      stop: stopHeartbeat,
+      // _buf / _reset は test 専用 hook。production 経路から呼ばない。
+      _buf: function () { return __hbBuf; },
+      _reset: function () {
+        if (__hbRafId !== null) {
+          if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(__hbRafId);
+          __hbRafId = null;
+        }
+        __hbReducedMotion = __hbDetectReducedMotion();
+        for (let i = 0; i < __hbBuf.length; i++) __hbBuf[i] = 0;
+        __hbSpikeRemain = 0;
+      },
+    };
+  }
+

--- a/dashboard/template/scripts/15_heartbeat.js
+++ b/dashboard/template/scripts/15_heartbeat.js
@@ -8,15 +8,25 @@
   const HB_SAMPLES = 60;
   const HB_VIEW_W = 140;
   const HB_VIEW_H = 22;
-  // PQRS 風の単一スパイク shape (上に -9px → 下に +4px → 0px)。10 frames 固定 duration、
+  // PQRS 風の単一スパイク shape (上に -9px → 下に +4px → 0px)。10 sample 固定 duration、
   // 強弱は __hbSpikeAmp で別軸制御 (online=1.0 / reconnect=0.3 / offline・static=0.0)。
   const HB_SPIKE_SHAPE = [-2, -5, -9, -7, -3, 2, 4, 3, 1, 0];
+  // 1 sample あたりの経過時間 (ms)。30 sample/s = 30 px/s (プラン Decisions: 60fps 環境で
+  // frame あたり 0.5 px に整合)。requestAnimationFrame の timestamp 引数で elapsed time
+  // 駆動するため、120Hz / 60Hz の display refresh rate に挙動が依存しない。
+  const HB_MS_PER_SAMPLE = 33;
+  // tab 復帰や long-paused tab で huge dt が来たときに waveform が急流するのを防ぐ
+  // ための catch-up 上限。HB_SPIKE_SHAPE.length を超えない値にしておけば、
+  // 「1 frame で spike 全消費」のような視覚 glitch も自然に避けられる。
+  const HB_MAX_CATCHUP_SAMPLES = 5;
   let __hbState = 'idle';
   let __hbBuf = new Float32Array(HB_SAMPLES);
   let __hbSpikeRemain = 0;
   let __hbSpikeAmp = 1.0;
   let __hbRafId = null;
   let __hbReducedMotion = false;
+  let __hbLastTickMs = 0;
+  let __hbAccumMs = 0;
 
   function __hbDetectReducedMotion() {
     if (typeof window === 'undefined') return false;
@@ -44,8 +54,8 @@
     poly.setAttribute('points', pts);
   }
 
-  function __hbTick() {
-    // 1 sample 左シフト + 末尾追加
+  function __hbAdvanceOneSample() {
+    // 1 sample 左シフト + 末尾追加 (spike 残量があれば SHAPE * amp、なければ baseline 0)
     for (let i = 0; i < __hbBuf.length - 1; i++) {
       __hbBuf[i] = __hbBuf[i + 1];
     }
@@ -56,7 +66,26 @@
       __hbSpikeRemain -= 1;
     }
     __hbBuf[__hbBuf.length - 1] = nextSample;
-    __hbRenderPoly();
+  }
+
+  function __hbTick(timestamp) {
+    // elapsed-ms 駆動: 経過 ms を HB_MS_PER_SAMPLE で割って消費する sample 数を決める。
+    // 60Hz / 120Hz いずれの display でも 30 sample/s で進む = scroll 速度 / spike duration が
+    // refresh rate に依存しない。timestamp は requestAnimationFrame が渡す DOMHighResTimeStamp。
+    let dt = 0;
+    if (__hbLastTickMs > 0 && typeof timestamp === 'number') {
+      dt = timestamp - __hbLastTickMs;
+      if (dt < 0) dt = 0;
+    }
+    if (typeof timestamp === 'number') __hbLastTickMs = timestamp;
+    __hbAccumMs += dt;
+    let samples = Math.floor(__hbAccumMs / HB_MS_PER_SAMPLE);
+    if (samples > HB_MAX_CATCHUP_SAMPLES) samples = HB_MAX_CATCHUP_SAMPLES;
+    if (samples > 0) {
+      __hbAccumMs -= samples * HB_MS_PER_SAMPLE;
+      for (let s = 0; s < samples; s++) __hbAdvanceOneSample();
+      __hbRenderPoly();
+    }
     __hbRafId = requestAnimationFrame(__hbTick);
   }
 
@@ -160,6 +189,8 @@
         __hbReducedMotion = __hbDetectReducedMotion();
         for (let i = 0; i < __hbBuf.length; i++) __hbBuf[i] = 0;
         __hbSpikeRemain = 0;
+        __hbLastTickMs = 0;
+        __hbAccumMs = 0;
       },
     };
   }

--- a/dashboard/template/scripts/70_init_eventsource.js
+++ b/dashboard/template/scripts/70_init_eventsource.js
@@ -3,9 +3,12 @@
   // serialization wrapper が coalesce してくれる (25_live_diff.js を参照)。
   await scheduleLoadAndRender();
   if (typeof window.__DATA__ !== 'undefined') {
-    // 静的 export 経路では EventSource を起動せず、バッジを「静的レポート」表示に固定
+    // 静的 export 経路では EventSource を起動せず、バッジを「静的レポート」表示に固定。
+    // heartbeat も start() 不要 (setConnStatus('static') 経由で hidden 確定)。
     setConnStatus('static');
   } else if (typeof EventSource !== 'undefined') {
+    // Issue #83: live 経路で初めて heartbeat を起動 (= shell.html の default `hidden` を解除)。
+    if (window.__heartbeat) window.__heartbeat.start();
     setConnStatus('reconnect');
     let offlineTimer = null;
     let firstError = null;
@@ -34,6 +37,8 @@
       // scheduleLoadAndRender 経由で並行 refresh を直列化する
       // (stale-snapshot race 対策 / 25_live_diff.js を参照)。
       if (typeof ev.data === 'string' && ev.data.indexOf('refresh') !== -1) {
+        // Issue #83: refresh 受信を契機に heartbeat に山を 1 発立てる。
+        if (window.__heartbeat) window.__heartbeat.bump();
         scheduleLoadAndRender().catch(err => console.error('refresh 失敗', err));
       }
     });

--- a/dashboard/template/shell.html
+++ b/dashboard/template/shell.html
@@ -19,6 +19,13 @@ __INCLUDE_STYLES__
       <a href="#/patterns" data-page-link="patterns" tabindex="0">Patterns</a>
       <a href="#/quality" data-page-link="quality" tabindex="0">Quality</a>
       <a href="#/surface" data-page-link="surface" tabindex="0">Surface</a>
+      <!-- Issue #83: live heartbeat sparkline。
+           default `hidden` で static export 経路では非表示、live 経路で
+           startHeartbeat() が hidden を解除する。 -->
+      <svg class="heartbeat" id="heartbeat" data-state="reconnect" hidden viewBox="0 0 140 22" preserveAspectRatio="none" role="img" aria-label="ライブ更新インジケータ">
+        <polyline points=""/>
+      </svg>
+      <span class="sr-only" id="heartbeatSr" aria-live="polite" aria-atomic="true"></span>
     </nav>
 
     <!-- Overview ページ (現状互換) -->

--- a/dashboard/template/styles/15_heartbeat.css
+++ b/dashboard/template/styles/15_heartbeat.css
@@ -15,6 +15,15 @@
   stroke: var(--mint);
   stroke-width: 1.5px;
   fill: none;
+  /* 常時明滅 (Issue #83 user follow-up): 線そのものを周期的に明滅させる。
+   * stroke-opacity 軸を使う = state 別の `opacity:` と独立して動かせる
+   * (= reconnect / offline で全体 opacity を薄くしつつ pulse は維持できる)。
+   * @media (prefers-reduced-motion: reduce) でこの animation を停止する。 */
+  animation: heartbeat-pulse 1s ease-in-out infinite;
+}
+@keyframes heartbeat-pulse {
+  0%, 100% { stroke-opacity: 1.0; }
+  50%      { stroke-opacity: 0.4; }
 }
 .heartbeat[data-state="reconnect"] polyline {
   stroke: var(--peach);

--- a/dashboard/template/styles/15_heartbeat.css
+++ b/dashboard/template/styles/15_heartbeat.css
@@ -1,0 +1,49 @@
+/* Issue #83: Live heartbeat sparkline.
+ *
+ * page-nav 右端に置く ECG 風 sparkline。state 別 stroke 色を data-state 属性で切替。
+ * 静的 export では shell.html 側で `hidden` boolean attribute が default で付くので
+ * tick / 表示は live 経路 (= JS が startHeartbeat を呼ぶ経路) でのみ起動する。
+ */
+.heartbeat {
+  display: inline-block;
+  width: 140px;
+  height: 22px;
+  margin-left: auto;
+  vertical-align: middle;
+}
+.heartbeat polyline {
+  stroke: var(--mint);
+  stroke-width: 1.5px;
+  fill: none;
+}
+.heartbeat[data-state="reconnect"] polyline {
+  stroke: var(--peach);
+  opacity: 0.7;
+}
+.heartbeat[data-state="offline"] polyline {
+  stroke: var(--coral);
+  opacity: 0.5;
+}
+/* JS が `setHeartbeatState('static')` で hidden 属性を立てる前提だが、CSS でも
+ * 二段保険として display: none。hidden 属性で隠れていれば CSS は無効化されない。 */
+.heartbeat[data-state="static"] {
+  display: none;
+}
+
+/* heartbeat 専用 SR 用 visually-hidden ユーティリティ。将来別箇所で再利用する
+ * ケースが出たら 00_base.css に昇格させる。 */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .heartbeat polyline { animation: none; }
+}

--- a/dashboard/template/styles/15_heartbeat.css
+++ b/dashboard/template/styles/15_heartbeat.css
@@ -19,7 +19,7 @@
    * stroke-opacity 軸を使う = state 別の `opacity:` と独立して動かせる
    * (= reconnect / offline で全体 opacity を薄くしつつ pulse は維持できる)。
    * @media (prefers-reduced-motion: reduce) でこの animation を停止する。 */
-  animation: heartbeat-pulse 1s ease-in-out infinite;
+  animation: heartbeat-pulse 3s ease-in-out infinite;
 }
 @keyframes heartbeat-pulse {
   0%, 100% { stroke-opacity: 1.0; }

--- a/docs/plans/83-live-heartbeat.md
+++ b/docs/plans/83-live-heartbeat.md
@@ -1,0 +1,275 @@
+# Issue #83 Implementation Plan — Live Heartbeat Sparkline
+
+## 1. Goal
+
+Idle 中も「動き続けてる」感を出すため、ダッシュボード上部に常時左→右へ流れる ECG 風 heartbeat sparkline を新設し、SSE refresh メッセージ受信を契機に山を一発立てる。既存の conn-status / lastRx / liveToast / `.bumped` highlight とは責務を分けて重複させない。
+
+## 2. Acceptance Criteria
+
+- [ ] Live mode で dashboard を開くと、画面上部 (page-nav 帯) の右端に幅 ~140px / 高さ ~22px の heartbeat sparkline が常時アニメーションする
+- [ ] アイドル 30 秒以上でも line が左→右に流れ続ける (= 「凍ってない」)
+- [ ] EventSource `message` (data に `refresh`) 受信時、現在の波形位置に山 (amplitude ~10px、~700ms で減衰) が 1 発立つ
+- [ ] `setConnStatus('reconnect')` 中は line 色が peach 系に薄く、山立ては抑制 (薄い反応のみ)
+- [ ] `setConnStatus('offline')` 中は流れを停止し flat line が静止
+- [ ] 静的 export (`window.__DATA__`) では sparkline 要素は DOM に存在するが `hidden` 属性で表示されない
+- [ ] `prefers-reduced-motion: reduce` 環境では line のスクロール / 山立てを停止し、視覚要素は静的 baseline のみ。受信時は `aria-live="polite"` の SR 通知に縮退
+- [ ] 全 4 ページ (Overview / Patterns / Quality / Surface) で同じ heartbeat が同位置に表示される
+- [ ] `pytest tests/` 全件 green。新規 `tests/test_dashboard_heartbeat.py` が template / concat / static export / reduced-motion / sentinel 整合を pin
+- [ ] `EXPECTED_TEMPLATE_SHA256` が新 hash に更新され、`test_html_template_byte_equivalent_to_pre_split_snapshot` が green
+
+## 3. Out of Scope (User explicitly rejected)
+
+- relative time auto-tick (`lastRx` を "X秒前" + 1 秒 tick) — 案 C
+- activity sparkline (受信頻度の mini graph) — 案 D
+- top-edge progress beam — Q3 D 案
+- 全画面 breathing animation — Q3 G 案
+- conn-status badge を上にも複製する案
+- Patterns / Quality / Surface の page-specific heartbeat バリエーション (共通要素として 1 個)
+- 複数本同時に走る波形 / multi-channel ECG
+- 受信頻度をグラフ化する経時 plot
+- **Footer version bump (`v0.7.1` → `v0.7.2`)**: stays at `v0.7.1` in this PR。bump は `v0.7.2 → main` の release PR で行う (`patch-release` skill convention)。理由: feature PR cycle と release cycle の責務分離 / release タイミング slip 時の merge 競合回避
+
+## 4. Decisions Made in This Plan
+
+### 配置 — 推奨: **(i) `nav.page-nav` の右端**
+
+選定: `nav.page-nav` (4 タブの flex 行) の **右端** に `<svg id="heartbeat">` を置き、`margin-left: auto` で右寄せする。
+
+理由:
+- 「画面の上の方」というユーザー要件を満たす最上位の永続 chrome
+- 4 ページ全てに既に存在する共通要素 → router 切替で消えない (Overview limited な case (iii) 不要)
+- 新規 chrome バンドを増やさず縦スペース消費がゼロ (案 (ii) は新規 band で密度アップ → page-nav の `border-bottom: 1px solid var(--line)` の下に余計な分割線が 1 本増える)
+- `.page-nav` は既に `flex-wrap: wrap` なので、狭幅で改行しても破綻しない
+
+代替条件:
+- **案 (ii) を採るべきとき**: heartbeat の幅を 240px+ に伸ばしたい / amplitude を 24px+ に上げたい場合。page-nav の縦幅 (~37px) 内に収まらなくなる
+- **案 (iii) を採るべきとき**: ユーザーが Overview 限定の "演出" として欲しいと方針転換した場合のみ。共通要素として不適なので **plan としては非推奨**
+
+### 残り未決の仕様の決定
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | flat line の演出 | **ECG 風に右へスクロールする静的 baseline**。SVG `<polyline>` の `points` 配列を `requestAnimationFrame` で 1 frame ごとに 1 サンプル左シフト + 末尾に baseline (y=0) サンプル追加。速度は `~30 px/s` (= 60fps 環境で frame あたり 0.5px) |
+| 2 | 山の形・amplitude・持続時間 | **PQRS 風の単一スパイク** (上に -10px → 下に +4px → 0px) を ~0.7s で `points` に書き込む。`refresh` 受信時に `__hbSpikeRemain = SPIKE_SHAPE.length (= 10 frames)` をセットし、tick で sample 値を `SPIKE_SHAPE[i] * __hbSpikeAmp` で消費。**duration (10 frames) は固定**、強弱は `__hbSpikeAmp` で別軸制御 |
+| 3 | 接続切れ挙動 | `online` → 通常 (mint, `__hbSpikeAmp = 1.0`)。`reconnect` → 流速半分・色 peach・**spike 振幅を 0.3 倍** (`__hbSpikeAmp = 0.3`、duration は 10 frames で online と同じ)。`offline` → tick 停止 + line を flat にクリア (色 coral)。`static` → `hidden` 属性で完全非表示 |
+| 4 | 静的 export 経路 | **完全非表示** (`hidden` 属性)。10_helpers.js の `setConnStatus('static')` 経由で確実に隠す。理由: 静的 export は受信契機が無いので「動き続け感」自体が無意味、視覚 noise になる |
+| 5 | `prefers-reduced-motion: reduce` | tick を起動せず、`<polyline>` は flat line 1 本を SVG 描画のみ。受信時は `points` を変えず、`aria-live="polite"` 領域 (新規 `<span class="sr-only" id="heartbeatSr">` を sparkline の隣に置き、refresh 時に `"更新を受信しました"` を 1 度書き込む) で SR 通知に縮退 |
+| 6 | アクセシビリティ | SVG 要素に `role="img"` + `aria-label="ライブ更新インジケータ"`。隣に visually-hidden な `<span id="heartbeatSr" aria-live="polite"></span>` を追加。conn-status (`role="status"`) との重複は避け、heartbeat SR は受信時のみ短文。**reduced-motion 環境でのみ実際に書き込む** (通常環境では noisy / 数秒に 1 度発火する aria-live は逆効果)。 通常 SR ユーザーには conn-status の `aria-live="polite"` で接続生存が伝わるので heartbeat の SR 補完は副次的。Reduced-motion 時のみ視覚 spike が消える分の補完として作動 |
+| 7 | 実装手段 | **inline SVG `<polyline>` + `requestAnimationFrame`**。理由: stdlib + vanilla JS 規約準拠 / Canvas は state 管理 + DPR 対応が増える / CSS-only は `refresh` イベント駆動の山立てが書けない / SVG なら既存 `.spark-svg` (overview sparkline) と同じ pattern で `viewBox` resize に強い。Trade-off: 60fps × 60 sample で 1 frame あたり ~60 polyline point の文字列再構築だがブラウザの SVG path diff は CPU 数 % で済む。**closure-private state は既存の単一 shared IIFE 内で宣言** (`25_live_diff.js` 冒頭コメント参照: 全 main_js は単一 IIFE で wrap される)。Per-file IIFE 新設は既存パターンと不一致になるので **しない**。代わりに 全識別子を `__hb` prefix で名前空間隔離し、Step 1 の literal pin で再宣言禁止を test レベルで保証 |
+| 8 | データ source | **EventSource `message` の onmessage で発火**。`70_init_eventsource.js` の `es.addEventListener('message', ...)` 内で `scheduleLoadAndRender()` の前に `bumpHeartbeat()` を呼ぶ。`/api/data` のメタデータは使わない (受信契機 = 鼓動の意味的整合がそのまま取れる) |
+
+## 5. Critical Files
+
+### New
+
+| Path | 役割 |
+|---|---|
+| `dashboard/template/scripts/15_heartbeat.js` | heartbeat tick state + `bumpHeartbeat()` + `startHeartbeat()` / `stopHeartbeat()` API。10 (helpers) と 20 (load_and_render) の間に置き、20 番から見えるように先に評価させる |
+| `dashboard/template/styles/15_heartbeat.css` | `.heartbeat` SVG / line stroke 色 (state 別) / `prefers-reduced-motion` 縮退 |
+| `tests/test_dashboard_heartbeat.py` | template smoke / concat 順 / static export hidden / reduced-motion CSS pin / `setConnStatus` 経路の `bumpHeartbeat` 呼び出し pin (Node round-trip) |
+
+### Changed
+
+| Path | 変更内容 |
+|---|---|
+| `dashboard/template/shell.html` | `nav.page-nav` の最後 (4 タブの後) に `<svg id="heartbeat">` + 隣の SR span を追加。footer version は `v0.7.1` のまま据え置き (release PR で bump) |
+| `dashboard/template/scripts/10_helpers.js` | `setConnStatus(state)` の中で heartbeat 状態 (`startHeartbeat` / `stopHeartbeat` / amplitude scaling) も呼ぶ。**heartbeat sync は `if (!el) return` ガードより前** に書く (connStatus DOM 削除 / 不在時にも heartbeat sync を維持する防衛措置)。`STATUS_LABEL` は据え置き。**verified**: `connStatus` は `shell.html:466` の `footer.app-footer` 内 shared chrome に居住するので 4 ページ全てで存在 (per-page header 仮説は誤り) |
+| `dashboard/template/scripts/70_init_eventsource.js` | `es.addEventListener('message', ...)` 内の `scheduleLoadAndRender()` 呼び出し前に `bumpHeartbeat()` を fire。static 経路では heartbeat 起動しない (`setConnStatus('static')` 後は何もしない) |
+| `dashboard/server.py` | `_CSS_FILES` に `15_heartbeat.css`、`_MAIN_JS_FILES` に `15_heartbeat.js` を **20_load_and_render.js の直前** に追加 |
+| `tests/test_dashboard_template_split.py` | `EXPECTED_TEMPLATE_SHA256` を新 hash に更新 + 履歴コメント追記。`test_html_template_contains_critical_dom_anchors` の id list に `heartbeat` / `heartbeatSr` を追加 |
+
+### Deleted
+
+なし。
+
+## 6. Ordered Implementation Steps (TDD: failing test 先 → impl → green)
+
+### Step 0 — Branch / version 準備
+
+- `git checkout v0.7.2 -b feature/83-live-heartbeat` (本作業ブランチ)。**実装ステップ外、PM 操作**
+
+### Step 1 — Failing test: server template smoke (concat / sentinel 整合)
+
+**先**: `tests/test_dashboard_heartbeat.py::TestTemplateConcat`
+
+- `_HTML_TEMPLATE` に `id="heartbeat"` SVG が含まれる
+- `_HTML_TEMPLATE` に `id="heartbeatSr"` aria-live span が含まれる
+- `_CSS_FILES` tuple に `"15_heartbeat.css"` が `"10_components.css"` の後 / `"20_help_tooltip.css"` の前にある
+- `_MAIN_JS_FILES` tuple に `"15_heartbeat.js"` が `"10_helpers.js"` の後 / `"20_load_and_render.js"` の前にある
+- **literal pin** `test_hb_state_declared_only_in_15_heartbeat_js`: 全 main_js を concat した string で `let __hbState` の出現が **1 回のみ** (= 既存の `25_live_diff.js` 等の closure と shared IIFE 内で名前競合しないことを grep ベースで保証)。同様に `__hbBuf` / `__hbSpikeRemain` / `__hbSpikeAmp` / `__hbRafId` も 1 回ずつ
+- **state contract pin** `test_setHeartbeatState_accepts_status_label_keys`: `STATUS_LABEL` の keys (= `online` / `reconnect` / `offline` / `static`) と `setHeartbeatState` の switch case が **1:1 対応** していることを grep ベースで pin。一方の追加が他方に伝搬しないと test red になる。これにより `setConnStatus` 内の heartbeat sync 順序 (heartbeat sync → connStatus DOM ガード) で渡される state value の domain を test 化
+- 期待: 全部 fail (まだファイル無い)
+
+### Step 2 — Failing test: static export 縮退 + reduced-motion CSS pin
+
+**先**: `tests/test_dashboard_heartbeat.py::TestStaticExportHidden` + `TestReducedMotionCss`
+
+- `render_static_html(data)` の出力で `<svg id="heartbeat"` を含む tag に `hidden` boolean attribute がついている (regex で確認)
+- `15_heartbeat.css` に `@media (prefers-reduced-motion: reduce)` ブロックがあり、その中で `.heartbeat` の `animation: none` または tick 停止 marker (`--heartbeat-paused: 1`) のいずれかが立つ
+- 期待: ファイル無いので fail
+
+### Step 3 — Failing test: Node round-trip behavior (`requestAnimationFrame` mock)
+
+**先**: `tests/test_dashboard_heartbeat.py::TestHeartbeatTickNode` (`@unittest.skipUnless(_NODE, ...)`)
+
+- **ロード対象**: `15_heartbeat.js` を **単体ファイル** で `_node_eval` する (concat 後ではない、ファイル単位 unit test として完結)
+- **完全な stub list** (Node に存在しない browser API 全部):
+  ```js
+  // Node 環境では window / document が undefined。`15_heartbeat.js` 単体ロード時に
+  // `window.matchMedia(...)` / `window.requestAnimationFrame(...)` への参照が global 上で
+  // 解決されるよう先に bind する。
+  globalThis.window = globalThis;
+  globalThis.document = globalThis.document || {};
+  let _fakePoly = { setAttribute() {}, getAttribute: () => '' };
+  let _fakeSvg = { dataset: {}, setAttribute() {}, getAttribute: () => '', querySelector: () => _fakePoly, hidden: false };
+  let _fakeSr = { textContent: '' };
+  document.getElementById = (id) => id === 'heartbeat' ? _fakeSvg : id === 'heartbeatSr' ? _fakeSr : null;
+  let _rafQueue = []; let _rafId = 0;
+  window.requestAnimationFrame = (fn) => { _rafQueue.push({id: ++_rafId, fn}); return _rafId; };
+  window.cancelAnimationFrame = (id) => { _rafQueue = _rafQueue.filter(x => x.id !== id); };
+  window.matchMedia = (q) => ({ matches: false });
+  function flushFrames(n) { for (let i = 0; i < n; i++) { const item = _rafQueue.shift(); if (item) item.fn(); } }
+  function flushMicrotasks() { return Promise.resolve().then(() => Promise.resolve()); }  // microtask 2 段 drain
+  ```
+- **Pre-flight assertion** (= "test ran but tested nothing" 防止): file load 直後に `assert typeof window.__heartbeat === 'object'` / `assert typeof window.__heartbeat.bump === 'function'`。`15_heartbeat.js` の module 末尾の `window.__heartbeat = {...}` 代入が成功したかを最初に確認 → stub 不足時に loud fail
+- **同期的 frame drain** で確定: `setImmediate` 経由ではなく `flushFrames(N)` で N 回同期 dequeue → 微小 task の event loop ordering に依存しない
+- **Online assertion**: `__heartbeat.start()` → `__heartbeat.bump()` → `flushFrames(15)` 後、`__heartbeat._buf()` の `Math.min(...buf) < -5` (= 山が立った)
+- **Reconnect assertion (Proposal 4 整合)**: `__heartbeat.setState('reconnect')` → `__heartbeat.bump()` → `flushFrames(15)` 後、`Math.max(...buf.map(Math.abs)) < 5` (= online と同じ duration / 振幅 0.3 倍 で薄い反応)。online との対比で振幅 scaling が duration scaling ではないことが pin される
+- **Offline assertion**: `__heartbeat.setState('offline')` 後 `__heartbeat.bump()` → `flushFrames(15)` でも `__heartbeat._buf()` が flat (`Math.max(...buf.map(Math.abs)) < 1`)
+- **State transition leak assertion (Proposal 4 追補)**: `__heartbeat.setState('reconnect')` → `setState('online')` → `bump()` → `flushFrames(15)` 後、buf 振幅は **online 用 (`>= 5`)**。reconnect 時代の `__hbSpikeAmp = 0.3` が leak していないことを pin
+- **Reduced-motion bump 連発 SR 通知 assertion (Proposal 5 追補, microtask drain 込み)**: テスト関数を `async` で書く。flow:
+  1. `__heartbeat.stop()` (前段の online テストで設定済の rAF を停止)
+  2. `window.matchMedia = () => ({matches: true})` に差し替え
+  3. `__heartbeat._reset()` (= 後述する test 専用 hook を呼んで `__hbReducedMotion` を再評価)
+  4. `_fakeSr` を `{ _history: [], set textContent(v) { this._history.push(v); } }` の spy に差し替え
+  5. `__heartbeat.bump()` → `await flushMicrotasks()` → `__heartbeat.bump()` → `await flushMicrotasks()`
+  6. `_fakeSr._history` が `['', '更新を受信しました', '', '更新を受信しました']` と並ぶことを assert (= 同一文字列でも一旦 `''` を経由するので aria-live が再発火する設計を pin)
+  7. `_node_eval` の test runner は `async` 戻り値を `await` するので microtask が確実に drain される
+- 期待: `15_heartbeat.js` 無いので fail
+
+### Step 4 — Impl: 新規 CSS / JS 作成
+
+**impl**:
+
+- `dashboard/template/styles/15_heartbeat.css` 新設
+  - `.heartbeat` SVG 既定 size (140 × 22), `display: inline-block`, `margin-left: auto`, `vertical-align: middle`
+  - `.heartbeat polyline` stroke `var(--mint)` `stroke-width: 1.5px`、`fill: none`
+  - state 別 stroke color: `.heartbeat[data-state="reconnect"] polyline { stroke: var(--peach); opacity: 0.7; }` / `[data-state="offline"] { stroke: var(--coral); opacity: 0.5; }` / `[data-state="static"] { display: none; }` (hidden 属性とのフォールバック二段保険)
+  - `@media (prefers-reduced-motion: reduce) { .heartbeat { /* tick は JS 側で起動しない、CSS は hint */ } }` + 上記 reduced-motion ブロックで `.heartbeat polyline { animation: none; }`
+  - `.sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }` (heartbeatSr が visually-hidden に必要)
+  - **note (Proposal 3 verify 結果)**: `dashboard/template/styles/` 全 7 ファイルに `.sr-only` / `visually-hidden` の既存定義は **無し** (grep verified)。今は heartbeat 専用 utility としてここに置く。将来別箇所で SR 用 visually-hidden を再利用する case が出たら `00_base.css` に昇格させる (deferred to that future PR)
+- `dashboard/template/scripts/15_heartbeat.js` 新設
+  - closure-private state は **既存の単一 shared IIFE 内** に直接宣言 (per-file IIFE では wrap しない、`25_live_diff.js` と同じ慣習)。全識別子を `__hb` prefix で名前空間隔離:
+    ```js
+    const SAMPLES = 60;
+    const FRAME_PX_PER_SAMPLE = 1;
+    const SPIKE_SHAPE = [-2,-5,-9,-7,-3,2,4,3,1,0];
+    let __hbState = 'idle';
+    let __hbBuf = new Float32Array(SAMPLES);
+    let __hbSpikeRemain = 0;
+    let __hbSpikeAmp = 1.0;       // online=1.0 / reconnect=0.3 / offline 等は bump 自体抑制
+    let __hbRafId = null;
+    let __hbReducedMotion = false;
+    ```
+  - `function startHeartbeat() { if (__hbRafId !== null) return; __hbReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches; if (__hbReducedMotion) { renderFlat(); return; } tick(); }`
+  - `function stopHeartbeat() { if (__hbRafId !== null) { cancelAnimationFrame(__hbRafId); __hbRafId = null; } }`
+  - `function setHeartbeatState(state)` — **全 state で `__hbSpikeAmp` を明示的に書き込む** (state transition race 防止 / Proposal 4):
+    - `online` → `__hbSpikeAmp = 1.0`、tick 起動
+    - `reconnect` → `__hbSpikeAmp = 0.3`、tick 起動
+    - `offline` → `__hbSpikeAmp = 0.0`、tick 停止 + buf を全要素 0 に clear (flat)
+    - `static` → `__hbSpikeAmp = 0.0`、tick 停止 + buf を全要素 0 に clear + `hidden` 属性付与 (将来 `hidden` 解除時に spike 残骸が出ないよう offline と同じく buf clear)
+    - 未知 state → no-op (defensive)。`STATUS_LABEL` keys との 1:1 対応は Step 1 の literal pin で保証
+    - SVG `data-state` 属性も同期書き込み
+  - `function bumpHeartbeat()`:
+    - reduced-motion 分岐 (Proposal 5 — 連発時の aria-live 再発火を保証):
+      ```js
+      if (__hbReducedMotion) {
+        const sr = document.getElementById('heartbeatSr');
+        if (sr) {
+          sr.textContent = '';   // 一旦クリア (同一文字列の連続 set による aria-live no-op を防止)
+          // microtask boundary を挟んで textContent を再書き込み — DOM diff として確実に発火させる
+          Promise.resolve().then(() => { sr.textContent = '更新を受信しました'; });
+        }
+        return;
+      }
+      ```
+    - `if (__hbState === 'offline' || __hbState === 'static') return;`
+    - `__hbSpikeRemain = SPIKE_SHAPE.length;` // **duration 固定 10 frames**, 振幅は __hbSpikeAmp で別軸
+  - `function tick()` — buf を 1 sample 左シフト、spike 残量があれば末尾に `SPIKE_SHAPE[len - remain] * __hbSpikeAmp` を書き込み (= **振幅スケール / duration スケールではない**)、なければ baseline 0 を書き込み、polyline.points を再構築。最後に `__hbRafId = requestAnimationFrame(tick);`
+  - `window.__heartbeat = { bump: bumpHeartbeat, setState: setHeartbeatState, start: startHeartbeat, stop: stopHeartbeat, _buf: () => __hbBuf, _reset: function() { if (__hbRafId !== null) { cancelAnimationFrame(__hbRafId); __hbRafId = null; } __hbReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches; for (let i = 0; i < __hbBuf.length; i++) __hbBuf[i] = 0; __hbSpikeRemain = 0; } };` (`_reset` は **test 専用** hook: `start()` の re-entry guard を回避し `__hbReducedMotion` / buf / spike 残量を初期化する。production code から呼ばない)
+- 期待: Step 1 / 3 の test がまだ fail (server.py / shell.html 未更新のため)
+
+### Step 5 — Impl: shell.html / server.py / 10_helpers.js / 70_init_eventsource.js
+
+**impl**:
+
+- `shell.html`:
+  - `<nav class="page-nav" role="navigation" aria-label="ダッシュボードページ">` の 4 リンクの後、`</nav>` 直前に:
+    ```html
+    <svg class="heartbeat" id="heartbeat" data-state="reconnect" viewBox="0 0 140 22" preserveAspectRatio="none" role="img" aria-label="ライブ更新インジケータ">
+      <polyline points=""/>
+    </svg>
+    <span class="sr-only" id="heartbeatSr" aria-live="polite" aria-atomic="true"></span>
+    ```
+  - footer version は `v0.7.1` のまま据え置き (release PR で bump、`patch-release` skill convention)
+- `server.py`:
+  - `_CSS_FILES` に `"15_heartbeat.css"` を `"10_components.css"` の直後に追加 (cascade 順は components の後 / help_tooltip の前)
+  - `_MAIN_JS_FILES` に `"15_heartbeat.js"` を `"10_helpers.js"` の直後・`"20_load_and_render.js"` の直前に追加
+- `10_helpers.js`:
+  - `setConnStatus(state)` の **冒頭** (= `getElementById('connStatus')` + `if (!el) return` ガードより前) に `if (window.__heartbeat) window.__heartbeat.setState(state);` を追加 (heartbeat sync を connStatus DOM 不在ガードから独立させる防衛措置)
+- `70_init_eventsource.js`:
+  - 先頭で (state init 前) `if (window.__heartbeat) window.__heartbeat.start();`
+  - `es.addEventListener('message', (ev) => { ... if (refresh) { if (window.__heartbeat) window.__heartbeat.bump(); scheduleLoadAndRender()...; } })`
+  - `__DATA__` 経路では `__heartbeat.start()` を呼ばず `setConnStatus('static')` (10_helpers.js 経由で hidden 化 + tick 抑制)
+- 期待: Step 1 / 2 / 3 全部 green になる
+
+### Step 6 — Failing test → green: template-split byte equivalence hash 更新
+
+**test 更新 (cassette regenerate)**:
+
+- `tests/test_dashboard_template_split.py` の `EXPECTED_TEMPLATE_SHA256` を新 hash に更新 + 履歴コメントに `: Issue #83 / live heartbeat sparkline` 行追記
+  - workflow: Step 5 完了後に `pytest tests/test_dashboard_template_split.py::test_html_template_byte_equivalent_to_pre_split_snapshot` を実行 → mismatch error message に出る新 hash を `EXPECTED_TEMPLATE_SHA256` に貼り付け (= cassette regenerate pattern。手動 hash 計算は **しない**)
+- `test_html_template_contains_critical_dom_anchors` の dom_id list に `"heartbeat"` / `"heartbeatSr"` を追加 (構造保証 二重化)
+- 期待: green
+
+### Step 7 — Manual QA (browser 実機 / chrome-devtools MCP 任意)
+
+- ダッシュボード起動 → page-nav 右端に流れる line を 30 秒以上観察 (idle 動き続け確認)
+- `touch ~/.claude/transcript-analyzer/usage.jsonl` または hook event を発火 → 山が一発立つ
+- ネットワーク切断 → conn-status `reconnect` → 30s 後 `offline` → line 流れ停止確認
+- ネットワーク再接続 → `online` 復帰 + 流れ再開
+- export_html → 静的 HTML を別ホストで開いて heartbeat が表示されないこと
+- `chrome://settings → Accessibility → Reduce motion` を ON で再 reload → flat line のみ + refresh で SR 通知 (VoiceOver / NVDA で読み上げ確認)
+
+### Step 8 — Manual QA Checklist (PR description に貼る用)
+
+```
+[ ] live mode で page-nav 右端に heartbeat が見える
+[ ] 30s 何もしなくても line が流れ続ける
+[ ] hook event を 1 個発火 → 山が立つ (toast / .bumped と同時に動く)
+[ ] 連続発火 (5 events / 1s) しても tick が乱れない
+[ ] ネットワーク切断 30s+ で line が flat に止まる
+[ ] 再接続で再開
+[ ] Patterns / Quality / Surface に切替えても heartbeat が消えない
+[ ] static export では heartbeat が消えている
+[ ] prefers-reduced-motion で flat line + 受信時 SR 読み上げ
+[ ] localhost dashboard を 5 分放置しても CPU が暴走しない (Activity Monitor で 5% 以下)
+```
+
+## 7. Risks / Tradeoffs
+
+- **配置 (i) の改行リスク**: `nav.page-nav` は `flex-wrap: wrap` のため、極端に狭い viewport (~360px) で SVG が次行に折れる可能性。許容判断 — heartbeat は装飾要素であり、最低でも tab は切れず使える
+- **狭幅 viewport での SVG 変形**: `viewBox preserveAspectRatio="none"` は狭幅で水平圧縮されスパイクが横長 blob 化する可能性。`min-width: 140px` で wrap 動作を歪めるよりは、装飾要素として変形を許容する選択 (4 タブの可読性 > heartbeat の形)。許容判断
+- **`prefers-reduced-motion` 検出のタイミング**: `startHeartbeat()` で 1 度だけ snapshot し、user が後から motion 設定を切り替えても再評価しない。許容判断 — dashboard を reload する前提
+- **reconnect 中の山立て抑制**: 「サーバが死んでて来てない」のに山が立つと誤情報。30% に減衰 + 色を peach にすることで「見えてはいるが live 値ではない」を視覚伝達。代替案として完全抑制も可だが、「再接続中も裏で何か聞こえてる」感を残すほうが Issue 趣旨 (= 動き続け) に近い
+- **静的 export 整合**: `setConnStatus('static')` 経路と CSS `display: none` の二段保険で、JS 起動失敗時にも heartbeat が変な flat line だけ残らないよう守る (hidden 属性は SR にも非通知)
+- **`requestAnimationFrame` の battery 影響**: 60fps × 60 sample で polyline reconstruct を毎 frame 行うが、SVG path diff は数 % CPU で済む。Tab 非表示時はブラウザが自動で `requestAnimationFrame` を 1Hz 以下に絞るので、background tab で battery を食わない (`hidden` document API への手動 hook は不要)
+- **`__livePrev` パターンとの整合**: Issue #69 で確立した「closure 内 state を専用ファイル冒頭に置く」原則を踏襲する (`15_heartbeat.js` の冒頭で IIFE 直下宣言 → 70 番から参照)。再宣言禁止の literal pin (`test_hb_state_declared_only_in_15_heartbeat_js` — Step 1 を参照) を入れて regression を防ぐ
+- **SVG `points` 文字列の length**: 60 sample × `"x.x,y.y "` で ~600 char × 60fps = 36KB/s のテキスト書換。長時間タブ放置で GC 圧。許容判断 — 既存 sparkline (overview) も同様の pattern。問題顕在化したら `requestAnimationFrame` を 30fps に absolute throttling
+
+## 8. Branch / Milestone
+
+- Branch: `feature/83-live-heartbeat` (`v0.7.2` から派生)
+- Milestone: `v0.7.2`
+- PR title: `feat(dashboard): ライブ更新インジケータ heartbeat sparkline を追加 (Issue #83)`
+- 単発 PR で完結。stacked PR 不要 (Issue #69 のように multi-phase ではない)

--- a/tests/test_dashboard_heartbeat.py
+++ b/tests/test_dashboard_heartbeat.py
@@ -1,0 +1,313 @@
+"""tests/test_dashboard_heartbeat.py — Issue #83: Live heartbeat sparkline tests.
+
+template smoke / concat 順 / sentinel pin / static export hidden / reduced-motion CSS pin /
+Node round-trip behavior (rAF mock 経由) を 1 ファイルで pin する。
+"""
+# pylint: disable=protected-access,line-too-long
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_REPO = Path(__file__).resolve().parent.parent
+_DASHBOARD_PATH = _REPO / "dashboard" / "server.py"
+_SCRIPTS_DIR = _REPO / "dashboard" / "template" / "scripts"
+_STYLES_DIR = _REPO / "dashboard" / "template" / "styles"
+_HEARTBEAT_JS = _SCRIPTS_DIR / "15_heartbeat.js"
+_HEARTBEAT_CSS = _STYLES_DIR / "15_heartbeat.css"
+
+
+def _load_dashboard_module(tmp_path: Path):
+    usage_jsonl = tmp_path / "usage.jsonl"
+    usage_jsonl.write_text("", encoding="utf-8")
+    os.environ["USAGE_JSONL"] = str(usage_jsonl)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "dashboard_server_heartbeat", _DASHBOARD_PATH
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        del os.environ["USAGE_JSONL"]
+    return mod
+
+
+# ============================================================
+#  Step 1: template concat / sentinel 整合 / literal pin
+# ============================================================
+class TestTemplateConcat:
+    def test_html_template_contains_heartbeat_svg(self, tmp_path):
+        mod = _load_dashboard_module(tmp_path)
+        assert 'id="heartbeat"' in mod._HTML_TEMPLATE
+
+    def test_html_template_contains_heartbeat_sr_span(self, tmp_path):
+        mod = _load_dashboard_module(tmp_path)
+        assert 'id="heartbeatSr"' in mod._HTML_TEMPLATE
+
+    def test_css_files_position(self, tmp_path):
+        mod = _load_dashboard_module(tmp_path)
+        files = list(mod._CSS_FILES)
+        assert "15_heartbeat.css" in files, f"15_heartbeat.css が _CSS_FILES に居ない: {files}"
+        assert files.index("10_components.css") < files.index("15_heartbeat.css") < files.index("20_help_tooltip.css"), \
+            f"15_heartbeat.css は 10_components.css の後 / 20_help_tooltip.css の前であるべき: {files}"
+
+    def test_main_js_files_position(self, tmp_path):
+        mod = _load_dashboard_module(tmp_path)
+        files = list(mod._MAIN_JS_FILES)
+        assert "15_heartbeat.js" in files, f"15_heartbeat.js が _MAIN_JS_FILES に居ない: {files}"
+        assert files.index("10_helpers.js") < files.index("15_heartbeat.js") < files.index("20_load_and_render.js"), \
+            f"15_heartbeat.js は 10_helpers.js の後 / 20_load_and_render.js の前であるべき: {files}"
+
+    def test_hb_state_declared_only_in_15_heartbeat_js(self, tmp_path):
+        """closure-private state が 15_heartbeat.js でのみ 1 回宣言されている。
+
+        全 main_js を concat した string で `let __hbX` の出現が 1 回ずつ。
+        既存の単一 shared IIFE 内で名前競合しないことを grep ベースで pin。
+        """
+        mod = _load_dashboard_module(tmp_path)
+        all_js = "".join(
+            (_SCRIPTS_DIR / name).read_text(encoding="utf-8")
+            for name in mod._MAIN_JS_FILES
+        )
+        for var in ("__hbState", "__hbBuf", "__hbSpikeRemain", "__hbSpikeAmp", "__hbRafId"):
+            count = all_js.count("let " + var)
+            assert count == 1, f"`let {var}` 出現は 1 回のみであるべきが {count} 回。再宣言禁止違反"
+
+    def test_setHeartbeatState_accepts_status_label_keys(self):
+        """STATUS_LABEL keys と setHeartbeatState の switch case が 1:1 対応。
+
+        一方を増やしてもう一方を増やし忘れると test red になる drift guard。
+        """
+        helpers_src = (_SCRIPTS_DIR / "10_helpers.js").read_text(encoding="utf-8")
+        heartbeat_src = _HEARTBEAT_JS.read_text(encoding="utf-8") if _HEARTBEAT_JS.exists() else ""
+        m = re.search(r"const STATUS_LABEL\s*=\s*\{([^}]+)\}", helpers_src)
+        assert m, "STATUS_LABEL definition が 10_helpers.js に見つからない"
+        keys = set(re.findall(r"(\w+)\s*:", m.group(1)))
+        # setHeartbeatState 関数本体を brace-match で抽出 (switch 内 if ブロックの
+        # `}` で early-exit しないように non-greedy regex ではなく深さカウンタで取る)。
+        m2 = re.search(r"function\s+setHeartbeatState\s*\([^)]*\)\s*\{", heartbeat_src)
+        assert m2, "setHeartbeatState 関数が 15_heartbeat.js に見つからない"
+        depth = 0
+        body_end = -1
+        for i in range(m2.end() - 1, len(heartbeat_src)):
+            ch = heartbeat_src[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    body_end = i
+                    break
+        assert body_end > 0, "setHeartbeatState の閉じ波括弧が見つからない"
+        body = heartbeat_src[m2.end():body_end]
+        cases = set(re.findall(r"case\s+['\"](\w+)['\"]", body))
+        assert keys == cases, \
+            f"STATUS_LABEL keys={sorted(keys)} と setHeartbeatState case labels={sorted(cases)} が一致しない"
+
+
+# ============================================================
+#  Step 2: static export hidden + reduced-motion CSS pin
+# ============================================================
+class TestStaticExportHidden:
+    def test_render_static_html_marks_heartbeat_hidden(self, tmp_path):
+        """render_static_html の出力で <svg id="heartbeat"> tag に hidden 属性が立つ。
+
+        live 経路では JS が hidden を解除するが、static export では JS が start しない
+        ので shell.html 側の default `hidden` がそのまま残る設計。
+        """
+        mod = _load_dashboard_module(tmp_path)
+        html = mod.render_static_html({"total_events": 0, "skill_ranking": []})
+        m = re.search(r"<svg[^>]*id=\"heartbeat\"[^>]*>", html)
+        assert m, "<svg id=\"heartbeat\"> tag が render_static_html 出力に見つからない"
+        tag = m.group(0)
+        # boolean attribute なので `hidden` 単体 / `hidden=""` のどちらでも OK
+        assert re.search(r"\bhidden(?:=|\b)", tag), \
+            f"static export で svg#heartbeat に hidden 属性が付いていない: {tag}"
+
+
+class TestReducedMotionCss:
+    def test_reduced_motion_block_disables_heartbeat_animation(self):
+        css = _HEARTBEAT_CSS.read_text(encoding="utf-8") if _HEARTBEAT_CSS.exists() else ""
+        m = re.search(r"@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{", css)
+        assert m, "15_heartbeat.css に @media (prefers-reduced-motion: reduce) ブロックが無い"
+        # ブロック内側を取り出す (brace match)
+        start = m.end() - 1
+        depth = 0
+        end = start
+        for i in range(start, len(css)):
+            ch = css[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        block = css[start:end + 1]
+        assert ".heartbeat" in block, \
+            "reduced-motion ブロック内に .heartbeat 制御が無い"
+        has_animation_none = ("animation: none" in block) or ("animation:none" in block)
+        has_paused_marker = "--heartbeat-paused: 1" in block
+        assert has_animation_none or has_paused_marker, \
+            "reduced-motion ブロック内で animation 停止 marker (animation: none / --heartbeat-paused: 1) が無い"
+
+
+# ============================================================
+#  Step 3: Node round-trip behavior (rAF mock)
+# ============================================================
+_NODE = shutil.which("node")
+
+
+def _node_eval_heartbeat(prelude: str, script: str) -> object:
+    """`15_heartbeat.js` を **単体ファイル** で eval し JSON 結果を返す。
+
+    プラン step 3 規律: heartbeat.js は単体で `window.__heartbeat` を完結させる
+    設計のため concat 後ではなく単体ロードで test する (closure-private state
+    の挙動が他 file と混ざらない)。
+
+    `prelude` は heartbeat.js 評価 **前** に入れる stub (window / document /
+    requestAnimationFrame 等)。`script` は heartbeat.js の **後** に入れる
+    assertion / console.log。
+    """
+    src = _HEARTBEAT_JS.read_text(encoding="utf-8")
+    full = prelude + "\n" + src + "\n" + script
+    env = os.environ.copy()
+    proc = subprocess.run(
+        [_NODE, "-e", full],
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        timeout=10,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"node failed (returncode={proc.returncode}): stderr={proc.stderr}"
+        )
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+_STUB_PRELUDE = r"""
+globalThis.window = globalThis;
+globalThis.document = globalThis.document || {};
+let _fakePoly = { setAttribute() {}, getAttribute: () => '' };
+let _fakeSvg = { dataset: {}, setAttribute() {}, getAttribute: () => '', querySelector: () => _fakePoly, hidden: false };
+let _fakeSr = { textContent: '' };
+document.getElementById = (id) => id === 'heartbeat' ? _fakeSvg : id === 'heartbeatSr' ? _fakeSr : null;
+let _rafQueue = []; let _rafId = 0;
+window.requestAnimationFrame = (fn) => { _rafQueue.push({id: ++_rafId, fn}); return _rafId; };
+window.cancelAnimationFrame = (id) => { _rafQueue = _rafQueue.filter(x => x.id !== id); };
+window.matchMedia = (q) => ({ matches: false });
+function flushFrames(n) { for (let i = 0; i < n; i++) { const item = _rafQueue.shift(); if (item) item.fn(); } }
+"""
+
+_PRE_FLIGHT = r"""
+if (typeof window.__heartbeat !== 'object') throw new Error('pre-flight: window.__heartbeat 不在');
+if (typeof window.__heartbeat.bump !== 'function') throw new Error('pre-flight: __heartbeat.bump 不在');
+if (typeof window.__heartbeat.setState !== 'function') throw new Error('pre-flight: __heartbeat.setState 不在');
+if (typeof window.__heartbeat.start !== 'function') throw new Error('pre-flight: __heartbeat.start 不在');
+if (typeof window.__heartbeat.stop !== 'function') throw new Error('pre-flight: __heartbeat.stop 不在');
+if (typeof window.__heartbeat._buf !== 'function') throw new Error('pre-flight: __heartbeat._buf 不在');
+if (typeof window.__heartbeat._reset !== 'function') throw new Error('pre-flight: __heartbeat._reset 不在');
+"""
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestHeartbeatTickNode(unittest.TestCase):
+    def test_pre_flight_window_heartbeat_exposed(self):
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+console.log(JSON.stringify({ok: true}));
+""")
+        self.assertEqual(out, {"ok": True})
+
+    def test_online_bump_creates_spike(self):
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+window.__heartbeat.start();
+window.__heartbeat.bump();
+flushFrames(15);
+const buf = Array.from(window.__heartbeat._buf());
+console.log(JSON.stringify({minV: Math.min.apply(null, buf), maxAbs: Math.max.apply(null, buf.map(Math.abs))}));
+""")
+        # online 時 __hbSpikeAmp = 1.0 で SPIKE_SHAPE 中の -9 が乗るので min < -5
+        self.assertLess(out["minV"], -5)
+
+    def test_reconnect_bump_amplitude_is_attenuated(self):
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+window.__heartbeat.start();
+window.__heartbeat.setState('reconnect');
+window.__heartbeat.bump();
+flushFrames(15);
+const buf = Array.from(window.__heartbeat._buf());
+console.log(JSON.stringify({maxAbs: Math.max.apply(null, buf.map(Math.abs))}));
+""")
+        # 0.3 倍 → SPIKE_SHAPE max abs 9 * 0.3 = 2.7 < 5
+        self.assertLess(out["maxAbs"], 5)
+
+    def test_offline_bump_is_suppressed(self):
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+window.__heartbeat.start();
+window.__heartbeat.setState('offline');
+window.__heartbeat.bump();
+flushFrames(15);
+const buf = Array.from(window.__heartbeat._buf());
+console.log(JSON.stringify({maxAbs: Math.max.apply(null, buf.map(Math.abs))}));
+""")
+        # offline では spike 抑制 + buf clear → 全要素 0
+        self.assertLess(out["maxAbs"], 1)
+
+    def test_state_transition_amplitude_no_leak(self):
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+window.__heartbeat.start();
+window.__heartbeat.setState('reconnect');
+window.__heartbeat.setState('online');
+window.__heartbeat.bump();
+flushFrames(15);
+const buf = Array.from(window.__heartbeat._buf());
+console.log(JSON.stringify({maxAbs: Math.max.apply(null, buf.map(Math.abs))}));
+""")
+        # online に戻ったら振幅 1.0 → max abs >= 5 (SPIKE_SHAPE max abs 9)
+        self.assertGreaterEqual(out["maxAbs"], 5)
+
+    def test_reduced_motion_bump_writes_sr_with_microtask_drain(self):
+        """reduced-motion 環境で bump() 連発時に SR 通知が再発火する。
+
+        textContent への代入を spy で履歴に積み、['', '更新を受信しました', '', '更新を受信しました']
+        の並びを pin (= 一旦 '' を経由してから本文を書く設計を保証)。
+        """
+        prelude_with_sr_spy = r"""
+globalThis.window = globalThis;
+globalThis.document = globalThis.document || {};
+let _fakePoly = { setAttribute() {}, getAttribute: () => '' };
+let _fakeSvg = { dataset: {}, setAttribute() {}, getAttribute: () => '', querySelector: () => _fakePoly, hidden: false };
+let _srHistory = [];
+let _fakeSr = {
+  set textContent(v) { _srHistory.push(v); },
+  get textContent() { return _srHistory[_srHistory.length - 1] || ''; },
+};
+document.getElementById = (id) => id === 'heartbeat' ? _fakeSvg : id === 'heartbeatSr' ? _fakeSr : null;
+let _rafQueue = []; let _rafId = 0;
+window.requestAnimationFrame = (fn) => { _rafQueue.push({id: ++_rafId, fn}); return _rafId; };
+window.cancelAnimationFrame = (id) => { _rafQueue = _rafQueue.filter(x => x.id !== id); };
+window.matchMedia = (q) => ({ matches: true });  // reduced-motion ON
+function flushFrames(n) { for (let i = 0; i < n; i++) { const item = _rafQueue.shift(); if (item) item.fn(); } }
+"""
+        out = _node_eval_heartbeat(prelude_with_sr_spy, _PRE_FLIGHT + r"""
+(async () => {
+  window.__heartbeat._reset();
+  window.__heartbeat.bump();
+  await Promise.resolve().then(() => Promise.resolve());
+  window.__heartbeat.bump();
+  await Promise.resolve().then(() => Promise.resolve());
+  console.log(JSON.stringify({history: _srHistory}));
+})();
+""")
+        self.assertEqual(
+            out["history"],
+            ['', '更新を受信しました', '', '更新を受信しました'],
+        )

--- a/tests/test_dashboard_heartbeat.py
+++ b/tests/test_dashboard_heartbeat.py
@@ -162,6 +162,46 @@ class TestReducedMotionCss:
             "reduced-motion ブロック内で animation 停止 marker (animation: none / --heartbeat-paused: 1) が無い"
 
 
+class TestHeartbeatPulseCss:
+    """常時明滅 (Issue #83 user follow-up): line そのものを周期的に明滅させる。"""
+
+    def test_heartbeat_polyline_has_pulse_animation(self):
+        css = _HEARTBEAT_CSS.read_text(encoding="utf-8") if _HEARTBEAT_CSS.exists() else ""
+        # `.heartbeat polyline` ルールの中で animation: が `none` 以外の値で
+        # 当たっていること (= 常時明滅 keyframes が wired up)。@media 内の
+        # `animation: none` (reduced-motion 抑止) は対象外。
+        matches = re.findall(
+            r"\.heartbeat\s+polyline\s*\{[^}]*?animation:\s*([^;}]+)",
+            css,
+        )
+        assert matches, ".heartbeat polyline ルールに animation: プロパティが無い"
+        non_none = [v.strip() for v in matches if v.strip() != "none"]
+        assert non_none, \
+            f"常時明滅 animation が定義されていない (見つかった値は全部 none: {matches!r})"
+
+    def test_pulse_keyframes_define_stroke_opacity_variation(self):
+        css = _HEARTBEAT_CSS.read_text(encoding="utf-8") if _HEARTBEAT_CSS.exists() else ""
+        m = re.search(r"@keyframes\s+([A-Za-z_][\w-]*)\s*\{", css)
+        assert m, "15_heartbeat.css に @keyframes 定義が無い"
+        # keyframes ブロック内に stroke-opacity (state 別 opacity と独立した axis) の
+        # 変動が定義されていること。state 別の `opacity: 0.7` 等と conflict させない。
+        start = m.end() - 1
+        depth = 0
+        end = start
+        for i in range(start, len(css)):
+            ch = css[i]
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        block = css[start:end + 1]
+        assert "stroke-opacity" in block, \
+            "@keyframes 内で stroke-opacity を動かしていない (state 別 opacity と独立に明滅させるため stroke-opacity 軸を使う)"
+
+
 # ============================================================
 #  Step 3: Node round-trip behavior (rAF mock)
 # ============================================================

--- a/tests/test_dashboard_heartbeat.py
+++ b/tests/test_dashboard_heartbeat.py
@@ -74,7 +74,11 @@ class TestTemplateConcat:
             (_SCRIPTS_DIR / name).read_text(encoding="utf-8")
             for name in mod._MAIN_JS_FILES
         )
-        for var in ("__hbState", "__hbBuf", "__hbSpikeRemain", "__hbSpikeAmp", "__hbRafId"):
+        # __hbLastTickMs / __hbAccumMs は elapsed-time 駆動 tick の closure state (Issue #83 codex Round 1)。
+        for var in (
+            "__hbState", "__hbBuf", "__hbSpikeRemain", "__hbSpikeAmp", "__hbRafId",
+            "__hbLastTickMs", "__hbAccumMs",
+        ):
             count = all_js.count("let " + var)
             assert count == 1, f"`let {var}` 出現は 1 回のみであるべきが {count} 回。再宣言禁止違反"
 
@@ -201,10 +205,20 @@ let _fakeSvg = { dataset: {}, setAttribute() {}, getAttribute: () => '', querySe
 let _fakeSr = { textContent: '' };
 document.getElementById = (id) => id === 'heartbeat' ? _fakeSvg : id === 'heartbeatSr' ? _fakeSr : null;
 let _rafQueue = []; let _rafId = 0;
+let _simTime = 0;
 window.requestAnimationFrame = (fn) => { _rafQueue.push({id: ++_rafId, fn}); return _rafId; };
 window.cancelAnimationFrame = (id) => { _rafQueue = _rafQueue.filter(x => x.id !== id); };
 window.matchMedia = (q) => ({ matches: false });
-function flushFrames(n) { for (let i = 0; i < n; i++) { const item = _rafQueue.shift(); if (item) item.fn(); } }
+// elapsed-ms 駆動の __hbTick (Issue #83 codex Round 1) に追従するため timestamp を渡す。
+// 33ms / frame で進めると HB_MS_PER_SAMPLE と一致し 1 sample/frame で進む (= 元設計と同じ
+// 観測粒度)。catch-up 上限 5 を踏まないようにするため frame ごとの dt は 33ms に固定。
+function flushFrames(n) {
+  for (let i = 0; i < n; i++) {
+    const item = _rafQueue.shift();
+    if (item) item.fn(_simTime);
+    _simTime += 33;
+  }
+}
 """
 
 _PRE_FLIGHT = r"""

--- a/tests/test_dashboard_heartbeat.py
+++ b/tests/test_dashboard_heartbeat.py
@@ -75,9 +75,10 @@ class TestTemplateConcat:
             for name in mod._MAIN_JS_FILES
         )
         # __hbLastTickMs / __hbAccumMs は elapsed-time 駆動 tick の closure state (Issue #83 codex Round 1)。
+        # __hbTickCount は idle baseline breathing wave の phase 入力 (Issue #83 codex Round 2 P1)。
         for var in (
             "__hbState", "__hbBuf", "__hbSpikeRemain", "__hbSpikeAmp", "__hbRafId",
-            "__hbLastTickMs", "__hbAccumMs",
+            "__hbLastTickMs", "__hbAccumMs", "__hbTickCount",
         ):
             count = all_js.count("let " + var)
             assert count == 1, f"`let {var}` 出現は 1 回のみであるべきが {count} 回。再宣言禁止違反"
@@ -287,6 +288,50 @@ console.log(JSON.stringify({maxAbs: Math.max.apply(null, buf.map(Math.abs))}));
 """)
         # online に戻ったら振幅 1.0 → max abs >= 5 (SPIKE_SHAPE max abs 9)
         self.assertGreaterEqual(out["maxAbs"], 5)
+
+    def test_idle_baseline_animates_when_no_spike(self):
+        """idle 中 (spike 残量 0) で line が静止せず breathing wave で微小に動く。
+
+        Issue #83 codex Round 2 P1: baseline を 0 固定にすると polyline が完全静止
+        して acceptance criteria「アイドル 30 秒以上でも line が左→右に流れ続ける
+        (= 凍ってない)」を満たさない。breathing 振幅 ~0.6px の sin wave で生存感を出す。
+        offline / static (amp=0) では既存テストの flat 契約と整合させるため、
+        breathing も __hbSpikeAmp スケール下に置く。
+        """
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+window.__heartbeat.start();
+flushFrames(50);
+const buf = Array.from(window.__heartbeat._buf());
+console.log(JSON.stringify({
+  maxAbs: Math.max.apply(null, buf.map(Math.abs)),
+  allZero: buf.every(function (v) { return v === 0; }),
+}));
+""")
+        self.assertFalse(out["allZero"], "idle baseline が all-0 で静止している (Round 2 P1 regression)")
+        self.assertGreater(out["maxAbs"], 0.1, "idle breathing wave 振幅が小さすぎる")
+
+    def test_resume_after_stop_does_not_compress_spike(self):
+        """offline → online resume 後の bump() が spike full duration を出す。
+
+        Issue #83 codex Round 2 P2: stopHeartbeat() で __hbLastTickMs / __hbAccumMs を
+        クリアしないと、長い pause 後の resume で huge dt が catch-up cap=5 を踏んで
+        spike 先頭が一気に消費されて compress 表示になる。
+        """
+        out = _node_eval_heartbeat(_STUB_PRELUDE, _PRE_FLIGHT + r"""
+window.__heartbeat.start();
+flushFrames(3);
+window.__heartbeat.setState('offline');
+_simTime += 10000;
+window.__heartbeat.setState('online');
+window.__heartbeat.bump();
+flushFrames(15);
+const buf = Array.from(window.__heartbeat._buf());
+console.log(JSON.stringify({maxAbs: Math.max.apply(null, buf.map(Math.abs))}));
+""")
+        # stale timing state が漏れると先頭 5 sample が catch-up で消費されて
+        # 残り 5 sample (= [2,4,3,1,0] の持続部) しか buf に残らない → max abs ~4。
+        # 修正後は spike 全 10 sample が乗るので max abs = 9。
+        self.assertGreaterEqual(out["maxAbs"], 8)
 
     def test_reduced_motion_bump_writes_sr_with_microtask_drain(self):
         """reduced-motion 環境で bump() 連発時に SR 通知が再発火する。

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -42,7 +42,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 2c38c50e...: Issue #81 / Overview KPI 上段の `kpi-skills` / `kpi-subs` / `kpi-projs` / `ledeProjects` を `*_kinds_total` / `project_total` (cap 無し) を読むように切替 + help body 文言更新 + 25_live_diff.js も同期 (20_load_and_render.js / 25_live_diff.js)
 #   - af715e7b...: Issue #83 / Live heartbeat sparkline (15_heartbeat.css + 15_heartbeat.js 追加 / shell.html nav.page-nav に <svg id="heartbeat"> + sr-only span / 10_helpers.js setConnStatus 経由で heartbeat sync / 70_init_eventsource.js で start + bump)
 #   - 31fc9f48...: Issue #83 codex Round 1 fix-up / __hbTick を refresh-rate 非依存に切替 (requestAnimationFrame の timestamp で elapsed-ms 駆動。HB_MS_PER_SAMPLE=33 / HB_MAX_CATCHUP_SAMPLES=5 / __hbLastTickMs / __hbAccumMs 追加)
-EXPECTED_TEMPLATE_SHA256 = "31fc9f48285477bc0e65e999c9aaa46905bae6df08dd61cd2a008957492a3eb4"
+#   - 2bab4e88...: Issue #83 codex Round 2 fix-up / idle baseline に breathing wave 追加 (__hbTickCount + sin) + stopHeartbeat() で __hbLastTickMs / __hbAccumMs リセット (resume 時 catch-up 暴走防止)
+EXPECTED_TEMPLATE_SHA256 = "2bab4e888beb94d50dd1d85cb31a139226e9d39e5cabd67c0c0a13bf9f6cd495"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -40,7 +40,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 4f4b511f...: Issue #69 fix-up / scheduleLoadAndRender で SSE refresh と hashchange の loadAndRender 並行発火を直列化 (stale-snapshot race 対策)
 #   - ef1c669f...: v0.7.1 release / footer の version 表記 v0.7 → v0.7.1 に bump
 #   - 2c38c50e...: Issue #81 / Overview KPI 上段の `kpi-skills` / `kpi-subs` / `kpi-projs` / `ledeProjects` を `*_kinds_total` / `project_total` (cap 無し) を読むように切替 + help body 文言更新 + 25_live_diff.js も同期 (20_load_and_render.js / 25_live_diff.js)
-EXPECTED_TEMPLATE_SHA256 = "2c38c50ea63b2d2edad8051c9dcbd9966357aa5ac0612697f48738490b782d8d"
+#   - af715e7b...: Issue #83 / Live heartbeat sparkline (15_heartbeat.css + 15_heartbeat.js 追加 / shell.html nav.page-nav に <svg id="heartbeat"> + sr-only span / 10_helpers.js setConnStatus 経由で heartbeat sync / 70_init_eventsource.js で start + bump)
+EXPECTED_TEMPLATE_SHA256 = "af715e7b6bf24cfa0517ffb279f077dc1e453ffa9fba25ce4d4541a57c176201"
 
 
 def _load_dashboard_module(tmp_path: Path):
@@ -95,6 +96,8 @@ def test_html_template_contains_critical_dom_anchors(tmp_path):
         "stack", "stackLegend", "projSub",
         "lastRx", "sessVal", "connStatus",
         "dataTooltip",
+        # Issue #83: live heartbeat sparkline
+        "heartbeat", "heartbeatSr",
     ):
         assert f'id="{dom_id}"' in html, f"DOM id '{dom_id}' が消えている"
 

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -43,7 +43,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - af715e7b...: Issue #83 / Live heartbeat sparkline (15_heartbeat.css + 15_heartbeat.js 追加 / shell.html nav.page-nav に <svg id="heartbeat"> + sr-only span / 10_helpers.js setConnStatus 経由で heartbeat sync / 70_init_eventsource.js で start + bump)
 #   - 31fc9f48...: Issue #83 codex Round 1 fix-up / __hbTick を refresh-rate 非依存に切替 (requestAnimationFrame の timestamp で elapsed-ms 駆動。HB_MS_PER_SAMPLE=33 / HB_MAX_CATCHUP_SAMPLES=5 / __hbLastTickMs / __hbAccumMs 追加)
 #   - 2bab4e88...: Issue #83 codex Round 2 fix-up / idle baseline に breathing wave 追加 (__hbTickCount + sin) + stopHeartbeat() で __hbLastTickMs / __hbAccumMs リセット (resume 時 catch-up 暴走防止)
-EXPECTED_TEMPLATE_SHA256 = "2bab4e888beb94d50dd1d85cb31a139226e9d39e5cabd67c0c0a13bf9f6cd495"
+#   - 4b429ad2...: Issue #83 user follow-up / heartbeat 線そのものを常時明滅 (CSS @keyframes heartbeat-pulse で stroke-opacity を 1.0 ↔ 0.4 で 1s 周期、state 別 opacity と独立軸)
+EXPECTED_TEMPLATE_SHA256 = "4b429ad2fe7990b063f964e4df17e3e3d4ddf3f5fbfff08623e7a21fe7f2996b"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -41,7 +41,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - ef1c669f...: v0.7.1 release / footer の version 表記 v0.7 → v0.7.1 に bump
 #   - 2c38c50e...: Issue #81 / Overview KPI 上段の `kpi-skills` / `kpi-subs` / `kpi-projs` / `ledeProjects` を `*_kinds_total` / `project_total` (cap 無し) を読むように切替 + help body 文言更新 + 25_live_diff.js も同期 (20_load_and_render.js / 25_live_diff.js)
 #   - af715e7b...: Issue #83 / Live heartbeat sparkline (15_heartbeat.css + 15_heartbeat.js 追加 / shell.html nav.page-nav に <svg id="heartbeat"> + sr-only span / 10_helpers.js setConnStatus 経由で heartbeat sync / 70_init_eventsource.js で start + bump)
-EXPECTED_TEMPLATE_SHA256 = "af715e7b6bf24cfa0517ffb279f077dc1e453ffa9fba25ce4d4541a57c176201"
+#   - 31fc9f48...: Issue #83 codex Round 1 fix-up / __hbTick を refresh-rate 非依存に切替 (requestAnimationFrame の timestamp で elapsed-ms 駆動。HB_MS_PER_SAMPLE=33 / HB_MAX_CATCHUP_SAMPLES=5 / __hbLastTickMs / __hbAccumMs 追加)
+EXPECTED_TEMPLATE_SHA256 = "31fc9f48285477bc0e65e999c9aaa46905bae6df08dd61cd2a008957492a3eb4"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -44,7 +44,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 31fc9f48...: Issue #83 codex Round 1 fix-up / __hbTick を refresh-rate 非依存に切替 (requestAnimationFrame の timestamp で elapsed-ms 駆動。HB_MS_PER_SAMPLE=33 / HB_MAX_CATCHUP_SAMPLES=5 / __hbLastTickMs / __hbAccumMs 追加)
 #   - 2bab4e88...: Issue #83 codex Round 2 fix-up / idle baseline に breathing wave 追加 (__hbTickCount + sin) + stopHeartbeat() で __hbLastTickMs / __hbAccumMs リセット (resume 時 catch-up 暴走防止)
 #   - 4b429ad2...: Issue #83 user follow-up / heartbeat 線そのものを常時明滅 (CSS @keyframes heartbeat-pulse で stroke-opacity を 1.0 ↔ 0.4 で 1s 周期、state 別 opacity と独立軸)
-EXPECTED_TEMPLATE_SHA256 = "4b429ad2fe7990b063f964e4df17e3e3d4ddf3f5fbfff08623e7a21fe7f2996b"
+#   - 5883a091...: Issue #83 user follow-up tweak / 明滅周期を 1s → 3s に調整 (呼吸テンポ感 / ambient indicator として落ち着いた pulse)
+EXPECTED_TEMPLATE_SHA256 = "5883a09140cb73b4202e18cd3442453c9106be9b98079025b7d761c018e7ac88"
 
 
 def _load_dashboard_module(tmp_path: Path):


### PR DESCRIPTION
## Summary

- dashboard 上部 page-nav 右端に常時明滅する ECG 風 heartbeat sparkline を新設し、idle 中も「動き続けてる」感を出す
- SSE refresh 受信を契機に PQRS 風スパイク (10 sample 固定 / 振幅 0.3〜1.0 で state 別スケール) を 1 発立てる
- 既存の conn-status / lastRx / liveToast / `.bumped` highlight とは責務を分けて重複させない

## 主な変更点

### 新規
- `dashboard/template/styles/15_heartbeat.css` — state 別 stroke 色 + `@keyframes heartbeat-pulse` (3s 周期 / stroke-opacity 1.0 ↔ 0.4) + reduced-motion 縮退
- `dashboard/template/scripts/15_heartbeat.js` — closure-private state (`__hb*` prefix) / `requestAnimationFrame` の timestamp で elapsed-ms 駆動 / `window.__heartbeat` API
- `tests/test_dashboard_heartbeat.py` — 18 件 (template concat / sentinel / literal pin / static hidden / reduced-motion / pulse animation / Node round-trip × 7)

### 変更
- `dashboard/template/shell.html` — `nav.page-nav` 右端に `<svg id="heartbeat" hidden>` + visually-hidden `<span id="heartbeatSr">` 追加
- `dashboard/server.py` — `_CSS_FILES` / `_MAIN_JS_FILES` に新規ファイル追加
- `dashboard/template/scripts/10_helpers.js` — `setConnStatus()` 経由で heartbeat state を sync (DOM 不在ガードより前)
- `dashboard/template/scripts/70_init_eventsource.js` — live 経路で start() / message → bump() を結線
- `tests/test_dashboard_template_split.py` — `EXPECTED_TEMPLATE_SHA256` と DOM anchor list 更新

## Acceptance criteria 整合
- [x] page-nav 右端に幅 ~140px / 高さ ~22px の sparkline が常時アニメーション
- [x] idle 30s 以上でも line が流れ続ける (breathing wave + 常時明滅で生存感)
- [x] EventSource `message` 受信時に振幅 ~10px のスパイクが立つ
- [x] reconnect 中は line 色が peach 系に薄く、spike 振幅 0.3 倍に減衰
- [x] offline 中は流れ停止 + flat line に静止
- [x] 静的 export では `hidden` 属性で完全非表示
- [x] `prefers-reduced-motion: reduce` で tick / spike / 明滅停止、aria-live で SR 通知
- [x] 全 4 ページ (Overview / Patterns / Quality / Surface) で同じ heartbeat 表示
- [x] `pytest tests/` 全件 green (980 passed, 1 skipped)
- [x] `EXPECTED_TEMPLATE_SHA256` 更新

## codex-review summary

3 rounds · 4 actionable resolved · 1 spec-Q escalated → user 確認済

| Round | Finding | 対応 |
|---|---|---|
| R1 | [P2] timing が refresh rate 依存 → 120Hz で 2x 速い | `requestAnimationFrame(timestamp)` で elapsed-ms 駆動に変更 |
| R2 | [P1] idle baseline 全 0 で line が静止 → 凍ってない感薄い | `__hbTickCount` + sin breathing wave 追加 |
| R2 | [P2] stopHeartbeat で timing state 残存 → resume 後 spike 圧縮 | `__hbLastTickMs` / `__hbAccumMs` を stop でクリア |
| R3 | [P2] scroll direction が逆 (= 「左→右」を「点が動く方向」と解釈) | プラン Decisions table「1 サンプル左シフト + 末尾追加」+ ECG 慣習に整合する現状実装を維持 (user 確認済) |

User follow-up:
- 線そのものを常時明滅させる要望で `@keyframes heartbeat-pulse` 追加
- 明滅周期を 1s → 3s に調整 (呼吸テンポ感の ambient indicator)

## Test plan

- [ ] `python3 -m pytest tests/` 全件 green
- [ ] live mode で page-nav 右端に heartbeat が見える
- [ ] 30s 何もしなくても line が流れ続ける + 線そのものが ~3s 周期で明滅する
- [ ] hook event を 1 個発火 → 山が立つ (toast / `.bumped` と同時に動く)
- [ ] 連続発火 (5 events / 1s) しても tick が乱れない
- [ ] ネットワーク切断 30s+ で line が flat に止まる
- [ ] 再接続で再開 (spike が full duration で出る)
- [ ] Patterns / Quality / Surface に切替えても heartbeat が消えない
- [ ] static export では heartbeat が消えている
- [ ] `prefers-reduced-motion` で flat line + 受信時 SR 読み上げ + 明滅停止
- [ ] localhost dashboard を 5 分放置しても CPU が暴走しない (Activity Monitor で 5% 以下)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)