### PR TITLE
feat(dashboard): Period toggle on Overview/Patterns (Issue #85)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1030,8 +1030,29 @@ def load_health_alerts() -> list[dict]:
     return alerts[-_MAX_ALERTS:]
 
 
-def build_dashboard_data(events: list[dict]) -> dict:
-    usage_events = _filter_usage_events(events)
+def build_dashboard_data(
+    events: list[dict],
+    period: str = "all",
+    *,
+    now: Optional[datetime] = None,
+) -> dict:
+    """ダッシュボード API レスポンスを生成する (Issue #85: period toggle 対応).
+
+    period: "7d" / "30d" / "90d" / "all" (それ以外は "all" 相当)。
+      Overview / Patterns / KPI counter の 11 field は period 適用後の events で集計する。
+      Quality / Surface / session_stats の 8 field は **常に全期間** で集計する (period 不変)。
+    now: test 注入用。指定時は last_updated もこの値で override する (drift guard test 用途)。
+    """
+    # period 適用 view と未 filter view の二経路で aggregator に渡す。
+    # period_events_raw: timestamp + 三段 pair-straddling filter 適用後の raw events.
+    # period_events_usage: period_events_raw に _filter_usage_events (subagent invocation dedup) を適用後.
+    # 三段で再 include した stop event は _filter_usage_events の dedup window
+    # (INVOCATION_MERGE_WINDOW_SECONDS = 1.0s) と同じ window で動くので再脱落しない
+    # (TestFilterEventsByPeriod::test_three_stage_filter_survives_filter_usage_events).
+    period_events_raw = _filter_events_by_period(events, period, now=now)
+    period_events_usage = _filter_usage_events(period_events_raw)
+
+    # Quality / Surface 系は常に全期間。permission_breakdowns は raw events に適用。
     permission_breakdowns = aggregate_permission_breakdowns(events)
 
     # Issue #81 — Overview KPI 上段の "unique kinds" カウンタは TOP_N=10 cap を効かせない全件カウント。
@@ -1039,31 +1060,34 @@ def build_dashboard_data(events: list[dict]) -> dict:
     # filter / dedup 慣習は aggregate_skills / aggregate_subagent_metrics / aggregate_projects と一致させる
     # (drift guard は test_dashboard.py::TestBuildDashboardData の `*_matches_*_when_below_cap`)。
     skill_kinds_set: set[str] = set()
-    for ev in events:
+    for ev in period_events_raw:
         if ev.get("event_type") in ("skill_tool", "user_slash_command"):
             name = ev.get("skill", "")
             if name:
                 skill_kinds_set.add(name)
-    subagent_kinds_total = len(aggregate_subagent_metrics(events))
+    subagent_kinds_total = len(aggregate_subagent_metrics(period_events_raw))
     project_kinds_set: set[str] = set()
-    for ev in usage_events:
+    for ev in period_events_usage:
         project = ev.get("project", "")
         if project:
             project_kinds_set.add(project)
 
+    last_updated = now.isoformat() if now is not None else _now_iso()
+
     return {
-        "last_updated": _now_iso(),
-        "total_events": len(usage_events),
-        "skill_ranking": aggregate_skills(events),
-        "subagent_ranking": aggregate_subagents(events),
+        "last_updated": last_updated,
+        "total_events": len(period_events_usage),
+        "skill_ranking": aggregate_skills(period_events_raw),
+        "subagent_ranking": aggregate_subagents(period_events_raw),
         "skill_kinds_total": len(skill_kinds_set),
         "subagent_kinds_total": subagent_kinds_total,
         "project_total": len(project_kinds_set),
-        "daily_trend": aggregate_daily(usage_events),
-        "project_breakdown": aggregate_projects(usage_events),
-        "hourly_heatmap": aggregate_hourly_heatmap(usage_events),
-        "skill_cooccurrence": aggregate_skill_cooccurrence(events),
-        "project_skill_matrix": aggregate_project_skill_matrix(events),
+        # Issue #85: daily_trend stays in period-applied set despite frontend-deprecation (Issue #65)
+        "daily_trend": aggregate_daily(period_events_usage),
+        "project_breakdown": aggregate_projects(period_events_usage),
+        "hourly_heatmap": aggregate_hourly_heatmap(period_events_usage),
+        "skill_cooccurrence": aggregate_skill_cooccurrence(period_events_raw),
+        "project_skill_matrix": aggregate_project_skill_matrix(period_events_raw),
         "subagent_failure_trend": aggregate_subagent_failure_trend(events),
         "permission_prompt_skill_breakdown": permission_breakdowns["skill"],
         "permission_prompt_subagent_breakdown": permission_breakdowns["subagent"],
@@ -1071,8 +1095,9 @@ def build_dashboard_data(events: list[dict]) -> dict:
         "session_stats": aggregate_session_stats(events),
         "health_alerts": load_health_alerts(),
         "skill_invocation_breakdown": aggregate_skill_invocation_breakdown(events),
-        "skill_lifecycle": aggregate_skill_lifecycle(events),
-        "skill_hibernating": aggregate_skill_hibernating(events),
+        "skill_lifecycle": aggregate_skill_lifecycle(events, now=now),
+        "skill_hibernating": aggregate_skill_hibernating(events, now=now),
+        "period_applied": period if period in _PERIOD_DELTAS or period == "all" else "all",
     }
 
 

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1370,18 +1370,30 @@ class DashboardHandler(BaseHTTPRequestHandler):
         touch = getattr(self.server, "touch", None)
         if callable(touch):
             touch()
-        if self.path == "/api/data":
+        from urllib.parse import urlparse
+        path_only = urlparse(self.path).path
+        if path_only == "/api/data":
             self._serve_api()
-        elif self.path == "/healthz":
+        elif path_only == "/healthz":
             self._serve_healthz()
-        elif self.path == "/events":
+        elif path_only == "/events":
             self._serve_events()
         else:
             self._serve_html()
 
     def _serve_api(self):
+        # query param `period` を取得 → allow-list 外 / 欠落 / 空値は "all" に倒す。
+        # `parse_qs(keep_blank_values=False)` (default) は `?period=` を dict から drop するので
+        # `q.get("period", ["all"])[0]` が "all" を返す。allow-list check は dict lookup の **後** に
+        # 必ず効かせる順序で書く (将来 keep_blank_values=True に切替えても "empty で fallback しない"
+        # 誤動作を起こさないため。閉じた loop での UX 優先で 400 は返さない: lenient 慣習)。
+        from urllib.parse import parse_qs, urlparse
+        q = parse_qs(urlparse(self.path).query)
+        period = q.get("period", ["all"])[0]
+        if period not in _PERIOD_DELTAS and period != "all":
+            period = "all"
         events = load_events()
-        data = build_dashboard_data(events)
+        data = build_dashboard_data(events, period=period)
         body = json.dumps(data, ensure_ascii=False).encode("utf-8")
         self.send_response(200)
         self.send_header("Content-Type", "application/json; charset=utf-8")

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -17,6 +17,7 @@ from typing import Callable, Optional
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from subagent_metrics import (
+    INVOCATION_MERGE_WINDOW_SECONDS,
     aggregate_subagent_failure_trend,
     aggregate_subagent_metrics,
     usage_invocation_events,
@@ -97,6 +98,155 @@ _SKILL_USAGE_EVENT_TYPES = frozenset({
     "skill_tool",
     "user_slash_command",
 })
+
+
+_PERIOD_DELTAS = {"7d": 7, "30d": 30, "90d": 90}
+
+
+def _filter_events_by_period(
+    events: list[dict],
+    period: str,
+    *,
+    now: Optional[datetime] = None,
+) -> list[dict]:
+    """Overview / Patterns aggregator にのみ渡す view を返す。Quality / Surface aggregator は unfiltered events を受ける (Issue #85 plan §3 Step 1).
+
+    使い分け契約 (Quality / Surface 系の filtering を防ぐため、build_dashboard_data の call site で
+    本 helper を呼ばないことで対応する。本 helper は誤用防止のため call site でのみ使う):
+      - period 適用 11 field (KPI 4 + Overview 4 + Patterns 3) には本 view を渡す
+      - 全期間 8 field (Quality 4 + Surface 3 + session_stats) には未 filter events を渡す
+
+    `period` が allow-list (`7d` / `30d` / `90d` / `all`) 以外、または `all` のときは
+    events を index 同値で返す (parse 不能 timestamp も保持)。
+
+    period ∈ {7d, 30d, 90d} のときは三段 filter:
+
+      第一段 (rolling window): `cutoff <= ts <= now` の event を保持。
+         timestamp 不在 / 不正 → drop。`cutoff = now - timedelta(days=N)`。
+
+      第二段 (start ↔ lifecycle pair): 第一段で残った
+         `subagent_start` / `subagent_lifecycle_start` を起点に、
+         同じ `(session_id, subagent_type)` バケット内で
+         `INVOCATION_MERGE_WINDOW_SECONDS` 以内に発火した sibling 候補
+         (= 第一段で落とされた異なる source) を再 include。
+
+      第三段 (start ↔ stop pair): 第一段で残った `subagent_start` を起点に、
+         同バケット内で `start.ts <= stop.ts` を満たし、間に他の start が挟まらない
+         直近の `subagent_stop` (第一段で cutoff より過去に落ちたもの) を再 include。
+         逆経路: 第一段で残った `subagent_stop` を起点に、`stop.ts >= start.ts` かつ
+         間に他の start が挟まらない直近の `subagent_start` を再 include。
+         これは `subagent_metrics._pair_invocations_with_stops` の
+         `start_ts <= stop_ts < next_start_ts` semantics を尊重する補完で、
+         `failure_rate` / `avg_duration_ms` / pXX duration が period boundary 跨ぎで
+         silent drift しないことを保証する。
+
+    Mirrors subagent_metrics._pair_invocations_with_stops pairing semantics. Keep in sync.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    days = _PERIOD_DELTAS.get(period)
+    if days is None:
+        return list(events)
+    cutoff = now - timedelta(days=days)
+
+    parsed_idx: dict[int, datetime] = {}
+    for i, ev in enumerate(events):
+        ts = _parse_iso_utc(ev.get("timestamp", ""))
+        if ts is not None:
+            parsed_idx[i] = ts
+
+    kept: set[int] = set()
+    for i, ts in parsed_idx.items():
+        if cutoff <= ts <= now:
+            kept.add(i)
+
+    # 第二段 + 第三段は (session_id, subagent_type) バケット単位で動かす
+    bucket_indices: dict[tuple[str, str], list[int]] = {}
+    for i, ev in enumerate(events):
+        if ev.get("event_type") not in (
+            "subagent_start",
+            "subagent_lifecycle_start",
+            "subagent_stop",
+        ):
+            continue
+        if i not in parsed_idx:
+            continue
+        key = (ev.get("session_id", ""), ev.get("subagent_type", ""))
+        bucket_indices.setdefault(key, []).append(i)
+
+    # bucket は timestamp 順に並べておく
+    for indices in bucket_indices.values():
+        indices.sort(key=lambda idx: parsed_idx[idx])
+
+    # 第二段: kept start/lifecycle ↔ dropped sibling (異なる source)
+    for indices in bucket_indices.values():
+        for pos, i in enumerate(indices):
+            if i not in kept:
+                continue
+            ev = events[i]
+            et = ev.get("event_type")
+            if et not in ("subagent_start", "subagent_lifecycle_start"):
+                continue
+            sibling_et = (
+                "subagent_lifecycle_start" if et == "subagent_start" else "subagent_start"
+            )
+            ts_i = parsed_idx[i]
+            for j in indices:
+                if j in kept:
+                    continue
+                if events[j].get("event_type") != sibling_et:
+                    continue
+                ts_j = parsed_idx[j]
+                if abs((ts_j - ts_i).total_seconds()) <= INVOCATION_MERGE_WINDOW_SECONDS:
+                    kept.add(j)
+
+    # 第三段: kept start ↔ dropped stop (直後 / 直前 paired)
+    for indices in bucket_indices.values():
+        # 順経路: kept_start → 直後 stop (start.ts <= stop.ts, 間に他 start が挟まらない)
+        for pos, i in enumerate(indices):
+            if i not in kept:
+                continue
+            if events[i].get("event_type") != "subagent_start":
+                continue
+            ts_start = parsed_idx[i]
+            # 直後の stop を探す: pos より後ろを順に見て、次の start が来る前に登場した stop
+            for k in range(pos + 1, len(indices)):
+                cand = indices[k]
+                cand_et = events[cand].get("event_type")
+                if cand_et == "subagent_start":
+                    break  # next start; stop search 終了
+                if cand_et != "subagent_stop":
+                    continue
+                if parsed_idx[cand] < ts_start:
+                    continue  # 念のため (sort 済みだが defensive)
+                kept.add(cand)
+                break  # 直後の paired stop は 1 件のみ
+
+        # 逆経路: kept_stop → 直前 start (stop.ts >= start.ts, 間に他 start が挟まらない)
+        for pos in range(len(indices) - 1, -1, -1):
+            i = indices[pos]
+            if i not in kept:
+                continue
+            if events[i].get("event_type") != "subagent_stop":
+                continue
+            ts_stop = parsed_idx[i]
+            # 直前の start を探す: pos の前を逆順に見る
+            for k in range(pos - 1, -1, -1):
+                cand = indices[k]
+                cand_et = events[cand].get("event_type")
+                if cand_et == "subagent_stop":
+                    # 別 invocation の stop が間に挟まる → search 継続不能ではないが、
+                    # `_pair_invocations_with_stops` の semantics 上、間に stop が居ても OK。
+                    # (start↔stop の pair は次の start が境界。stop は単独で挟まれる)
+                    continue
+                if cand_et != "subagent_start":
+                    continue
+                if parsed_idx[cand] > ts_stop:
+                    continue  # defensive
+                kept.add(cand)
+                break
+
+    return [ev for i, ev in enumerate(events) if i in kept]
 
 
 def _filter_usage_events(events: list[dict]) -> list[dict]:

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -119,28 +119,27 @@ def _filter_events_by_period(
     `period` が allow-list (`7d` / `30d` / `90d` / `all`) 以外、または `all` のときは
     events を index 同値で返す (parse 不能 timestamp も保持)。
 
-    period ∈ {7d, 30d, 90d} のときは三段 filter:
+    period ∈ {7d, 30d, 90d} のときは二段 filter:
 
       第一段 (rolling window): `cutoff <= ts <= now` の event を保持。
-         timestamp 不在 / 不正 → drop。`cutoff = now - timedelta(days=N)`。
+         timestamp 不在 / 不正 / `ts > now` (clock skew) → drop。
+         `cutoff = now - timedelta(days=N)`。
 
-      第二段 (start ↔ lifecycle pair): 第一段で残った
-         `subagent_start` / `subagent_lifecycle_start` を起点に、
-         同じ `(session_id, subagent_type)` バケット内で
-         `INVOCATION_MERGE_WINDOW_SECONDS` 以内に発火した sibling 候補
-         (= 第一段で落とされた異なる source) を再 include。
+      第二段 (canonical invocation/pair propagation): 各 (session_id, subagent_type)
+         バケットを `subagent_metrics._build_invocations` と同等のロジックで
+         canonical invocation 列に再構成し (`subagent_start` / `subagent_lifecycle_start`
+         を `INVOCATION_MERGE_WINDOW_SECONDS` 以内 + 異なる source なら 1 invocation
+         に merge)、各 invocation の paired stop は `_pair_invocations_with_stops`
+         同等の窓 (`[anchor_ts, next_anchor_ts)`) で配り当てる。
+         pair (= invocation の全 event + paired stop) のうち 1 event でも第一段で
+         kept なら、pair 内全 event を再 include する。
+         これにより `failure_rate` / `avg_duration_ms` / pXX duration が period
+         boundary 跨ぎで silent drift しないことを構造的に保証する。
+         clock skew で `ts > now` と落ちた stop は第一段の排除を尊重し、
+         pair 一括 include の対象から除外する (codex round 2 / Issue #85)。
 
-      第三段 (start ↔ stop pair): 第一段で残った `subagent_start` を起点に、
-         同バケット内で `start.ts <= stop.ts` を満たし、間に他の start が挟まらない
-         直近の `subagent_stop` (第一段で cutoff より過去に落ちたもの) を再 include。
-         逆経路: 第一段で残った `subagent_stop` を起点に、`stop.ts >= start.ts` かつ
-         間に他の start が挟まらない直近の `subagent_start` を再 include。
-         これは `subagent_metrics._pair_invocations_with_stops` の
-         `start_ts <= stop_ts < next_start_ts` semantics を尊重する補完で、
-         `failure_rate` / `avg_duration_ms` / pXX duration が period boundary 跨ぎで
-         silent drift しないことを保証する。
-
-    Mirrors subagent_metrics._pair_invocations_with_stops pairing semantics. Keep in sync.
+    Mirrors subagent_metrics._build_invocations + _pair_invocations_with_stops
+    semantics. Keep in sync.
     """
     if now is None:
         now = datetime.now(timezone.utc)
@@ -178,78 +177,113 @@ def _filter_events_by_period(
     for indices in bucket_indices.values():
         indices.sort(key=lambda idx: parsed_idx[idx])
 
-    # 第二段: kept start/lifecycle ↔ dropped sibling (異なる source)
+    # 第二段 + 第三段: 各 bucket を `_build_invocations` の canonical pairing で再構成し、
+    # kept event を含む invocation/pair に属する全 event を再 include。
+    #
+    # Round 2 fix (codex): 旧実装は kept anchor ごとに「sibling/stop を距離 1s 以内で 1 件
+    # 引っ張る」素朴版だったが、隣接 invocation の sibling を不当に pull してしまう
+    # ケース (start_A/lifecycle_A @ cutoff-0.4s + start_B/lifecycle_B @ cutoff+0.4s)
+    # と、未来日付 stop (clock skew で第一段で `ts > now` と drop されたもの) を
+    # 第三段が pull-back するケース両方を検出。canonical pairing に揃えて
+    # 構造的に塞ぐ。
+    _START_ETS = ("subagent_start", "subagent_lifecycle_start")
     for indices in bucket_indices.values():
-        for pos, i in enumerate(indices):
-            if i not in kept:
-                continue
-            ev = events[i]
-            et = ev.get("event_type")
-            if et not in ("subagent_start", "subagent_lifecycle_start"):
-                continue
-            sibling_et = (
-                "subagent_lifecycle_start" if et == "subagent_start" else "subagent_start"
-            )
+        # `_build_invocations` を mirror: source 重複を merge せず、近接 sibling を 1 invocation 化
+        invocations: list[list[int]] = []  # 各 invocation は event index list
+        last_ts: Optional[datetime] = None
+        last_sources: set[str] = set()
+        for i in indices:
+            et = events[i].get("event_type")
+            if et == "subagent_stop":
+                continue  # 第二段は start/lifecycle のみで pairing
+            source = "start" if et == "subagent_start" else "lifecycle"
             ts_i = parsed_idx[i]
-            for j in indices:
-                if j in kept:
+            merged = False
+            if (
+                invocations
+                and last_ts is not None
+                and source not in last_sources
+                and abs((ts_i - last_ts).total_seconds()) <= INVOCATION_MERGE_WINDOW_SECONDS
+            ):
+                invocations[-1].append(i)
+                last_sources.add(source)
+                merged = True
+            if not merged:
+                invocations.append([i])
+                last_sources = {source}
+            last_ts = ts_i
+
+        # invocation 境界 (anchor.ts) を求めて stops を canonical pairing で配り当て。
+        # `subagent_metrics._pair_invocations_with_stops` の semantics を mirror:
+        #   - 件数一致 (`len(invocations) == len(stops)`) → sequential 1:1 zip
+        #     (重複発火扱い、timestamp 検査なし。delayed/overlapping stops を許容)
+        #   - 件数不一致:
+        #     - `start.success=False` (start 由来 invocation) → stop プール非消費 / paired=None
+        #     - その他 → timestamp-window: `[anchor_ts, next_anchor_ts)` で最初の未消費 stop
+        inv_anchor_ts: list[datetime] = []
+        for inv_idx_list in invocations:
+            # anchor = subagent_start 優先, 無ければ lifecycle (canonical rep 選択)
+            anchor_idx = next(
+                (j for j in inv_idx_list if events[j].get("event_type") == "subagent_start"),
+                inv_idx_list[0],
+            )
+            inv_anchor_ts.append(parsed_idx[anchor_idx])
+
+        stops_in_bucket = sorted(
+            (j for j in indices if events[j].get("event_type") == "subagent_stop"),
+            key=lambda j: parsed_idx[j],
+        )
+        inv_paired_stop: list[Optional[int]] = [None] * len(invocations)
+        if len(invocations) == len(stops_in_bucket):
+            # 件数一致 → sequential 1:1 (canonical の "重複発火扱い" 分岐)
+            for i in range(len(invocations)):
+                inv_paired_stop[i] = stops_in_bucket[i]
+        else:
+            # 件数不一致 → timestamp-window pairing
+            # start.success=False の invocation は stop プールを消費しない。
+            stop_consumed = [False] * len(stops_in_bucket)
+            for i, anchor_ts in enumerate(inv_anchor_ts):
+                # canonical も start.success=False は stop パスを消費しない
+                start_idx = next(
+                    (j for j in invocations[i] if events[j].get("event_type") == "subagent_start"),
+                    None,
+                )
+                if start_idx is not None and events[start_idx].get("success") is False:
                     continue
-                if events[j].get("event_type") != sibling_et:
-                    continue
-                ts_j = parsed_idx[j]
-                if abs((ts_j - ts_i).total_seconds()) <= INVOCATION_MERGE_WINDOW_SECONDS:
+                next_anchor_ts = inv_anchor_ts[i + 1] if i + 1 < len(inv_anchor_ts) else None
+                for j_pos, stop_idx in enumerate(stops_in_bucket):
+                    if stop_consumed[j_pos]:
+                        continue
+                    stop_ts = parsed_idx[stop_idx]
+                    if stop_ts < anchor_ts:
+                        continue
+                    if next_anchor_ts is not None and stop_ts >= next_anchor_ts:
+                        continue
+                    stop_consumed[j_pos] = True
+                    inv_paired_stop[i] = stop_idx
+                    break
+
+        # canonical invocation/pair 単位で kept 伝播:
+        #   pair 内のいずれかの event が kept なら全員 kept
+        # ただし stop 第一段 drop 理由が `ts > now` (= future-dated, clock skew)
+        # の場合は pull-back せず — 第一段の `ts > now` 排除を尊重する。
+        for i, inv_idx_list in enumerate(invocations):
+            paired_stop_idx = inv_paired_stop[i]
+            members = list(inv_idx_list)
+            if paired_stop_idx is not None and parsed_idx[paired_stop_idx] <= now:
+                members.append(paired_stop_idx)
+            if any(j in kept for j in members):
+                for j in members:
                     kept.add(j)
-
-    # 第三段: kept start ↔ dropped stop (直後 / 直前 paired)
-    for indices in bucket_indices.values():
-        # 順経路: kept_start → 直後 stop (start.ts <= stop.ts, 間に他 start が挟まらない)
-        for pos, i in enumerate(indices):
-            if i not in kept:
-                continue
-            if events[i].get("event_type") != "subagent_start":
-                continue
-            ts_start = parsed_idx[i]
-            # 直後の stop を探す: pos より後ろを順に見て、次の start が来る前に登場した stop
-            for k in range(pos + 1, len(indices)):
-                cand = indices[k]
-                cand_et = events[cand].get("event_type")
-                if cand_et == "subagent_start":
-                    break  # next start; stop search 終了
-                if cand_et != "subagent_stop":
-                    continue
-                if parsed_idx[cand] < ts_start:
-                    continue  # 念のため (sort 済みだが defensive)
-                kept.add(cand)
-                break  # 直後の paired stop は 1 件のみ
-
-        # 逆経路: kept_stop → 直前 start (stop.ts >= start.ts, 間に他 start が挟まらない)
-        for pos in range(len(indices) - 1, -1, -1):
-            i = indices[pos]
-            if i not in kept:
-                continue
-            if events[i].get("event_type") != "subagent_stop":
-                continue
-            ts_stop = parsed_idx[i]
-            # 直前の start を探す: pos の前を逆順に見る
-            for k in range(pos - 1, -1, -1):
-                cand = indices[k]
-                cand_et = events[cand].get("event_type")
-                if cand_et == "subagent_stop":
-                    # 別 invocation の stop が間に挟まる → search 継続不能ではないが、
-                    # `_pair_invocations_with_stops` の semantics 上、間に stop が居ても OK。
-                    # (start↔stop の pair は次の start が境界。stop は単独で挟まれる)
-                    continue
-                if cand_et != "subagent_start":
-                    continue
-                if parsed_idx[cand] > ts_stop:
-                    continue  # defensive
-                kept.add(cand)
-                break
 
     return [ev for i, ev in enumerate(events) if i in kept]
 
 
-def _filter_usage_events(events: list[dict]) -> list[dict]:
+def _filter_usage_events(
+    events: list[dict],
+    *,
+    period_cutoff: Optional[datetime] = None,
+) -> list[dict]:
     """headline 集計用に usage 系イベントを返す。subagent は invocation 単位 dedup。
 
     `subagent_start` (PostToolUse 由来) と `subagent_lifecycle_start` (SubagentStart 由来) は
@@ -257,9 +291,52 @@ def _filter_usage_events(events: list[dict]) -> list[dict]:
     `usage_invocation_events()` で `aggregate_subagent_metrics()` と同じ invocation 同定を行い、
     各 invocation の代表イベント 1 件だけを採用することで、subagent_ranking と
     total_events / daily_trend / project_breakdown を必ず一致させる。
+
+    period_cutoff: 指定時、rep event の timestamp が cutoff より過去 (= 第二段で
+    pull-back された boundary-straddling lifecycle-only invocation の rep) の場合、
+    headline metrics (`daily_trend` / `hourly_heatmap` / `project_breakdown`) に
+    pre-cutoff 日付が leak しないよう同 invocation の paired stop の timestamp で
+    上書きした synthetic rep を返す (codex round 4 / Issue #85)。
+    `aggregate_subagent_metrics` 側は別経路で raw events を受けるため影響なし。
     """
     skill_events = [ev for ev in events if ev.get("event_type") in _SKILL_USAGE_EVENT_TYPES]
-    return skill_events + usage_invocation_events(events)
+    rep_events = usage_invocation_events(events)
+    if period_cutoff is None:
+        return skill_events + rep_events
+
+    # rep の timestamp が cutoff より過去なら同 (session_id, subagent_type) バケットの
+    # 直後 stop の timestamp で synthesize し直す
+    stops_by_key: dict[tuple[str, str], list[dict]] = {}
+    for ev in events:
+        if ev.get("event_type") != "subagent_stop":
+            continue
+        key = (ev.get("session_id", ""), ev.get("subagent_type", ""))
+        stops_by_key.setdefault(key, []).append(ev)
+    for stops in stops_by_key.values():
+        stops.sort(key=lambda e: e.get("timestamp", ""))
+
+    adjusted: list[dict] = []
+    for rep in rep_events:
+        rep_ts = _parse_iso_utc(rep.get("timestamp", ""))
+        if rep_ts is None or rep_ts >= period_cutoff:
+            adjusted.append(rep)
+            continue
+        # cutoff より過去 → 同バケットで rep.ts 以降の最初の stop を探す
+        key = (rep.get("session_id", ""), rep.get("subagent_type", ""))
+        stop_match: Optional[dict] = None
+        for stop in stops_by_key.get(key, []):
+            stop_ts = _parse_iso_utc(stop.get("timestamp", ""))
+            if stop_ts is not None and stop_ts >= rep_ts and stop_ts >= period_cutoff:
+                stop_match = stop
+                break
+        if stop_match is not None:
+            # rep の timestamp のみ stop の timestamp で上書き (project / subagent_type 等は維持)
+            adjusted.append({**rep, "timestamp": stop_match["timestamp"]})
+        else:
+            # paired stop が見つからない → そのまま (defensive: stage 2 で pull-back されたなら
+            # 必ず paired stop が同バケットに居るはずだが、想定外データ形にも壊れない)
+            adjusted.append(rep)
+    return skill_events + adjusted
 
 
 def _now_iso() -> str:
@@ -1050,7 +1127,17 @@ def build_dashboard_data(
     # (INVOCATION_MERGE_WINDOW_SECONDS = 1.0s) と同じ window で動くので再脱落しない
     # (TestFilterEventsByPeriod::test_three_stage_filter_survives_filter_usage_events).
     period_events_raw = _filter_events_by_period(events, period, now=now)
-    period_events_usage = _filter_usage_events(period_events_raw)
+    # codex round 4 / Issue #85: boundary-straddling lifecycle-only invocation で
+    # rep event (= subagent_lifecycle_start) が pre-cutoff な場合、headline metrics
+    # (`daily_trend` / `hourly_heatmap` / `project_breakdown`) に pre-cutoff 日付が
+    # leak しないよう、_filter_usage_events に period cutoff を渡して rep ts を
+    # paired stop で上書きする。`period == "all"` / 不正値 → cutoff=None で無効。
+    _period_days = _PERIOD_DELTAS.get(period)
+    _now_ref = now if now is not None else datetime.now(timezone.utc)
+    _period_cutoff = (
+        _now_ref - timedelta(days=_period_days) if _period_days is not None else None
+    )
+    period_events_usage = _filter_usage_events(period_events_raw, period_cutoff=_period_cutoff)
 
     # Quality / Surface 系は常に全期間。permission_breakdowns は raw events に適用。
     permission_breakdowns = aggregate_permission_breakdowns(events)

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1140,6 +1140,7 @@ _CSS_FILES = (
     "60_surface.css",       # Surface 3 panel + tooltip border colors (Issue #74)
 )
 _MAIN_JS_FILES = (
+    "05_period.js",               # period toggle closure + getCurrentPeriod / wirePeriodToggle (Issue #85)
     "10_helpers.js",              # esc / fmtN / pad / STATUS_LABEL / setConnStatus
     "15_heartbeat.js",            # live heartbeat sparkline (Issue #83)
     "20_load_and_render.js",      # async loadAndRender (KPI / ranking / sparkline / projects)

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1154,6 +1154,22 @@ _MAIN_JS_FILES = (
 )
 
 
+def _concat_main_js() -> str:
+    """`_MAIN_JS_FILES` を順に読んで 1 つの JS bundle 文字列に連結する.
+
+    `_concat_main_js()` is a test seam exposed for `tests/test_dashboard_period_toggle.py`;
+    not a public API.
+
+    `"".join(...)` (= no separator) で連結する: byte-identical to pre-refactor `_HTML_TEMPLATE`;
+    do not introduce separators (改行など) — assembled `_HTML_TEMPLATE` の bytes が変わって
+    `EXPECTED_TEMPLATE_SHA256` の drift detection が壊れる。
+    """
+    return "".join(
+        (_TEMPLATE_DIR / "scripts" / name).read_text(encoding="utf-8")
+        for name in _MAIN_JS_FILES
+    )
+
+
 def _build_html_template() -> str:
     """`template/` 配下を起動時に 1 度だけ concat して `_HTML_TEMPLATE` を作る。
 
@@ -1162,7 +1178,7 @@ def _build_html_template() -> str:
     """
     styles = "".join((_TEMPLATE_DIR / "styles" / name).read_text(encoding="utf-8") for name in _CSS_FILES)
     router_js = (_TEMPLATE_DIR / "scripts" / "00_router.js").read_text(encoding="utf-8")
-    main_js = "".join((_TEMPLATE_DIR / "scripts" / name).read_text(encoding="utf-8") for name in _MAIN_JS_FILES)
+    main_js = _concat_main_js()
     shell = (_TEMPLATE_DIR / "shell.html").read_text(encoding="utf-8")
     return (shell
             .replace("__INCLUDE_STYLES__\n", styles)

--- a/dashboard/template/scripts/05_period.js
+++ b/dashboard/template/scripts/05_period.js
@@ -47,8 +47,17 @@
         });
         // call-time lookup: 05_period.js 評価時に __liveDiff 未定義のため。
         // optional chaining で no-op safe (IIFE 評価中の captured 参照を取らない)。
-        if (typeof window !== "undefined" && window.__liveDiff && typeof window.__liveDiff.scheduleLoadAndRender === "function") {
-          window.__liveDiff.scheduleLoadAndRender();
+        if (typeof window !== "undefined" && window.__liveDiff) {
+          // codex round 4 / Issue #85: period 切替時は __livePrev を reset。
+          // 前 period の snapshot が新 period の snapshot と diff されると false
+          // burst (skill / project / event 数の正の delta) が立って toast / highlight
+          // が誤発火するため、scheduleLoadAndRender の前に必ず clear する。
+          if (typeof window.__liveDiff.resetLiveSnapshot === "function") {
+            window.__liveDiff.resetLiveSnapshot();
+          }
+          if (typeof window.__liveDiff.scheduleLoadAndRender === "function") {
+            window.__liveDiff.scheduleLoadAndRender();
+          }
         }
       });
     });

--- a/dashboard/template/scripts/05_period.js
+++ b/dashboard/template/scripts/05_period.js
@@ -63,16 +63,44 @@
     });
   }
 
+  // Issue #85 follow-up: トグル DOM (1 つだけ) を active page の header slot に
+  // move する。router (00_router.js) の hashchange listener が body.dataset.activePage
+  // を先に更新してから、本 listener が走る (登録順 = 評価順)。Quality / Surface には
+  // slot が無いので move せず、page-scoped CSS rule で display:none に倒す。
+  function movePeriodToggleToActivePage() {
+    if (typeof document === "undefined") return;
+    const toggle = document.getElementById("periodToggle");
+    if (!toggle) return;
+    const activePage = (document.body && document.body.dataset)
+      ? (document.body.dataset.activePage || "overview")
+      : "overview";
+    if (activePage !== "overview" && activePage !== "patterns") return;
+    const slot = document.querySelector('[data-period-slot="' + activePage + '"]');
+    if (slot && toggle.parentNode !== slot) {
+      slot.appendChild(toggle);
+    }
+  }
+
   if (typeof window !== "undefined") {
     window.__period = {
       getCurrentPeriod: getCurrentPeriod,
       setCurrentPeriod: setCurrentPeriod,
       wirePeriodToggle: wirePeriodToggle,
+      movePeriodToggleToActivePage: movePeriodToggleToActivePage,
     };
+    // hashchange は router IIFE (00_router.js) の listener と同 phase だが
+    // addEventListener 順 = 発火順なので、router が body.dataset.activePage を
+    // 先に更新する → 本 listener が新 active page を読んで slot に move する。
+    if (typeof window.addEventListener === "function") {
+      window.addEventListener("hashchange", movePeriodToggleToActivePage);
+    }
   }
 
   // shell.html の DOM が読み込まれた後に wire する。70_init_eventsource.js の
   // 初回 scheduleLoadAndRender() より早く動かす必要があるが、wrapping IIFE 内
   // は同期評価で進むので 70 番までに wirePeriodToggle が呼ばれていれば OK。
   wirePeriodToggle();
+  // 初回も active page に応じた slot に置く (Overview slot が初期配置だが、
+  // hash が #/patterns で起動した場合は Patterns slot に move する)。
+  movePeriodToggleToActivePage();
 

--- a/dashboard/template/scripts/05_period.js
+++ b/dashboard/template/scripts/05_period.js
@@ -1,0 +1,69 @@
+  // Issue #85: Dashboard period toggle (Overview / Patterns 限定).
+  //
+  // closure-private state は wrapping IIFE 直下に置く。`__period` prefix で名前空間
+  // 隔離 (25_live_diff.js の `__live*` 慣習踏襲)。
+  //
+  // 注意: 05_period.js は concat order 05 で評価される → IIFE 評価時点で
+  // `window.__liveDiff` (concat order 25) は **未定義**。click handler 内では
+  // `window.__liveDiff?.scheduleLoadAndRender?.()` の **property lookup を呼び出し時に
+  // 毎回行う** 形で書く (concat order 上位の依存先は call-time lookup する rule)。
+  let __periodCurrent = "all";
+  const __PERIOD_VALUES = ["7d", "30d", "90d", "all"];
+
+  function getCurrentPeriod() {
+    return __periodCurrent;
+  }
+
+  function setCurrentPeriod(p) {
+    if (typeof p === "string" && __PERIOD_VALUES.indexOf(p) !== -1) {
+      __periodCurrent = p;
+    }
+  }
+
+  function wirePeriodToggle() {
+    if (typeof document === "undefined") return;
+    // 静的 export 経路 (window.__DATA__ 既存) では toggle UI を非表示にして click bind を skip。
+    // server を経由しないので period 切り替え自体に意味がない。
+    if (typeof window !== "undefined" && typeof window.__DATA__ !== "undefined") {
+      const el = document.getElementById("periodToggle");
+      if (el && typeof el.setAttribute === "function") {
+        el.setAttribute("hidden", "");
+      }
+      return;
+    }
+    const buttons = document.querySelectorAll('#periodToggle button[data-period]');
+    if (!buttons || typeof buttons.length !== "number" || buttons.length === 0) return;
+    buttons.forEach(function (btn) {
+      btn.addEventListener("click", function (ev) {
+        const target = ev && ev.currentTarget ? ev.currentTarget : btn;
+        const period = target && target.dataset ? target.dataset.period : null;
+        if (!period || __PERIOD_VALUES.indexOf(period) === -1) return;
+        setCurrentPeriod(period);
+        // aria-pressed の付け替え (active 表現)
+        buttons.forEach(function (other) {
+          if (typeof other.setAttribute === "function") {
+            other.setAttribute("aria-pressed", other === target ? "true" : "false");
+          }
+        });
+        // call-time lookup: 05_period.js 評価時に __liveDiff 未定義のため。
+        // optional chaining で no-op safe (IIFE 評価中の captured 参照を取らない)。
+        if (typeof window !== "undefined" && window.__liveDiff && typeof window.__liveDiff.scheduleLoadAndRender === "function") {
+          window.__liveDiff.scheduleLoadAndRender();
+        }
+      });
+    });
+  }
+
+  if (typeof window !== "undefined") {
+    window.__period = {
+      getCurrentPeriod: getCurrentPeriod,
+      setCurrentPeriod: setCurrentPeriod,
+      wirePeriodToggle: wirePeriodToggle,
+    };
+  }
+
+  // shell.html の DOM が読み込まれた後に wire する。70_init_eventsource.js の
+  // 初回 scheduleLoadAndRender() より早く動かす必要があるが、wrapping IIFE 内
+  // は同期評価で進むので 70 番までに wirePeriodToggle が呼ばれていれば OK。
+  wirePeriodToggle();
+

--- a/dashboard/template/scripts/20_load_and_render.js
+++ b/dashboard/template/scripts/20_load_and_render.js
@@ -15,6 +15,11 @@
   }
   const ss = data.session_stats || {};
 
+  // Issue #85: period_applied !== 'all' のとき、Overview/Patterns sub に
+  // '<period> 集計 · ' を additive prefix で連結する。'all' のときは prefix 空 = 現状互換。
+  const __periodApplied = (data && typeof data.period_applied === 'string') ? data.period_applied : 'all';
+  const __periodBadge = (__periodApplied !== 'all') ? (__periodApplied + ' 集計 · ') : '';
+
   // header (Issue #65: local TZ 表記に統一)
   document.getElementById('lastRx').textContent = formatLocalTimestamp(data.last_updated);
   document.getElementById('sessVal').textContent = (ss.total_sessions || 0) + ' sessions';
@@ -120,8 +125,8 @@
   }
   renderRank('skillBody', data.skill_ranking || [], 'skill');
   renderRank('subBody', data.subagent_ranking || [], 'subagent');
-  document.getElementById('skillSub').textContent = 'top ' + (data.skill_ranking||[]).length + ' · max ' + (((data.skill_ranking||[])[0]||{}).count || 0);
-  document.getElementById('subSub').textContent = 'top ' + (data.subagent_ranking||[]).length + ' · max ' + (((data.subagent_ranking||[])[0]||{}).count || 0);
+  document.getElementById('skillSub').textContent = __periodBadge + 'top ' + (data.skill_ranking||[]).length + ' · max ' + (((data.skill_ranking||[])[0]||{}).count || 0);
+  document.getElementById('subSub').textContent = __periodBadge + 'top ' + (data.subagent_ranking||[]).length + ' · max ' + (((data.subagent_ranking||[])[0]||{}).count || 0);
 
   // ---- sparkline (Issue #65: local TZ 集約) ----
   // localDays は localDailyFromHourly で sort 済 / local 日付 key。
@@ -221,7 +226,7 @@
     document.getElementById('sparkStats').innerHTML = sparkStats.map(r =>
       '<div class="row"><span class="k">' + r.k + '</span><span class="v">' + r.v + '</span></div>'
     ).join('');
-    document.getElementById('dailySub').textContent = days.length + ' days · ' + active + ' active';
+    document.getElementById('dailySub').textContent = __periodBadge + days.length + ' days · ' + active + ' active';
   }
 
   // ---- projects ----
@@ -248,16 +253,16 @@
       '<div class="pp">' + pct + '</div>' +
     '</div>';
   }).join('');
-  document.getElementById('projSub').textContent = projs.length + ' projects · Σ ' + fmtN(projTotal);
+  document.getElementById('projSub').textContent = __periodBadge + projs.length + ' projects · Σ ' + fmtN(projTotal);
 
   // ---- hourly heatmap (Issue #58) ----
-  renderHourlyHeatmap(data.hourly_heatmap);
+  renderHourlyHeatmap(data.hourly_heatmap, __periodBadge);
 
   // ---- skill cooccurrence (Issue #59 / B1) ----
-  renderSkillCooccurrence(data.skill_cooccurrence);
+  renderSkillCooccurrence(data.skill_cooccurrence, __periodBadge);
 
   // ---- project × skill heatmap (Issue #59 / B2) ----
-  renderProjectSkillMatrix(data.project_skill_matrix);
+  renderProjectSkillMatrix(data.project_skill_matrix, __periodBadge);
 
   // ---- subagent percentile table (Issue #60 / A5) ----
   renderSubagentPercentile(data.subagent_ranking);

--- a/dashboard/template/scripts/20_load_and_render.js
+++ b/dashboard/template/scripts/20_load_and_render.js
@@ -1,9 +1,14 @@
   async function loadAndRender() {
   let data;
   try {
+    // Issue #85: period toggle 値を毎 fetch 時に評価して URL に載せる。
+    // 関数参照を IIFE 評価時に capture せず call-time lookup する形なので、
+    // toggle 切替直後の SSE refresh も新 period で fetch される (race-free)。
+    const __periodVal = (typeof getCurrentPeriod === 'function') ? getCurrentPeriod() : 'all';
+    const __apiUrl = '/api/data?period=' + encodeURIComponent(__periodVal);
     data = (typeof window.__DATA__ !== 'undefined')
       ? window.__DATA__
-      : await (await fetch('/api/data', { cache: 'no-store' })).json();
+      : await (await fetch(__apiUrl, { cache: 'no-store' })).json();
   } catch (e) {
     console.error('データの読み込みに失敗しました:', e);
     return;

--- a/dashboard/template/scripts/25_live_diff.js
+++ b/dashboard/template/scripts/25_live_diff.js
@@ -238,6 +238,14 @@
     __livePrev = next;
   }
 
+  // codex round 4 / Issue #85: period 切り替え時に呼んで、次の loadAndRender で
+  // diff/toast/highlight が「前 period の snapshot vs 新 period の snapshot」を比較
+  // しないようにする。reset 後初回の render は __livePrev=null なので diff/toast
+  // が抑止される (= 通常の初回 load と同じ no-noise 経路)。
+  function resetLiveSnapshot() {
+    __livePrev = null;
+  }
+
   // loadAndRender の overlap を直列化する wrapper。
   //
   // 70_init_eventsource.js の SSE message handler / 60_hashchange_listener.js
@@ -279,6 +287,7 @@
       diffLiveSnapshot,
       formatToastSummary,
       commitLiveSnapshot,
+      resetLiveSnapshot,
       scheduleLoadAndRender,
       getLivePrev: function () { return __livePrev; },
     };

--- a/dashboard/template/scripts/30_renderers_patterns.js
+++ b/dashboard/template/scripts/30_renderers_patterns.js
@@ -5,7 +5,8 @@
   //  hashchange listener (下) が page 切替時に loadAndRender を再実行するので、
   //  navigate 直後でも空のままにはならない。
   // ============================================================
-  function renderHourlyHeatmap(payload) {
+  function renderHourlyHeatmap(payload, periodBadge) {
+    const __badge = (typeof periodBadge === 'string') ? periodBadge : '';
     if (document.body.dataset.activePage !== 'patterns') return;
     const root = document.getElementById('patterns-heatmap');
     if (!root) return;
@@ -48,7 +49,7 @@
     const sub = document.getElementById('patterns-heatmap-sub');
     if (sub) {
       const total = buckets.reduce((s, b) => s + b.count, 0);
-      sub.textContent = fmtN(total) + ' events · ' + fmtN(buckets.length) + ' hour buckets';
+      sub.textContent = __badge + fmtN(total) + ' events · ' + fmtN(buckets.length) + ' hour buckets';
     }
   }
 
@@ -57,7 +58,8 @@
   //  page-scoped early-out + 空配列時の empty state 表示。pair は server から
   //  すでに count 降順 + lexicographic 昇順で並んでおり、再 sort 不要。
   // ============================================================
-  function renderSkillCooccurrence(items) {
+  function renderSkillCooccurrence(items, periodBadge) {
+    const __badge = (typeof periodBadge === 'string') ? periodBadge : '';
     if (document.body.dataset.activePage !== 'patterns') return;
     const tbody = document.querySelector('#patterns-cooccurrence tbody');
     if (!tbody) return;
@@ -80,7 +82,7 @@
     }
     const sub = document.getElementById('patterns-cooccurrence-sub');
     if (sub) {
-      sub.textContent = list.length + ' pairs (top 100)';
+      sub.textContent = __badge + list.length + ' pairs (top 100)';
     }
   }
 
@@ -89,7 +91,8 @@
   //  server は dense matrix + covered_count + total_count を返し、ここで描画。
   //  カバー率 (covered/total) を sub label に出して top 漏れの量を可視化 (Proposal 2)。
   // ============================================================
-  function renderProjectSkillMatrix(payload) {
+  function renderProjectSkillMatrix(payload, periodBadge) {
+    const __badge = (typeof periodBadge === 'string') ? periodBadge : '';
     if (document.body.dataset.activePage !== 'patterns') return;
     const root = document.getElementById('patterns-projskill');
     if (!root) return;
@@ -150,7 +153,7 @@
         const pct = Math.round((covered / total) * 100);
         s += ' · ' + pct + '% covered (' + fmtN(covered) + '/' + fmtN(total) + ')';
       }
-      sub.textContent = s;
+      sub.textContent = __badge + s;
     }
   }
 

--- a/dashboard/template/shell.html
+++ b/dashboard/template/shell.html
@@ -19,6 +19,15 @@ __INCLUDE_STYLES__
       <a href="#/patterns" data-page-link="patterns" tabindex="0">Patterns</a>
       <a href="#/quality" data-page-link="quality" tabindex="0">Quality</a>
       <a href="#/surface" data-page-link="surface" tabindex="0">Surface</a>
+      <!-- Issue #85: 期間トグル (Overview / Patterns でのみ表示).
+           Quality / Surface 表示時は CSS で display:none に倒す (30_pages.css)。
+           static export 経路では 05_period.js 内で hidden 属性を立てる。 -->
+      <div class="period-toggle" id="periodToggle" role="group" aria-label="集計期間">
+        <button type="button" data-period="7d" aria-pressed="false">7d</button>
+        <button type="button" data-period="30d" aria-pressed="false">30d</button>
+        <button type="button" data-period="90d" aria-pressed="false">90d</button>
+        <button type="button" data-period="all" aria-pressed="true">全期間</button>
+      </div>
       <!-- Issue #83: live heartbeat sparkline。
            default `hidden` で static export 経路では非表示、live 経路で
            startHeartbeat() が hidden を解除する。 -->

--- a/dashboard/template/shell.html
+++ b/dashboard/template/shell.html
@@ -19,15 +19,6 @@ __INCLUDE_STYLES__
       <a href="#/patterns" data-page-link="patterns" tabindex="0">Patterns</a>
       <a href="#/quality" data-page-link="quality" tabindex="0">Quality</a>
       <a href="#/surface" data-page-link="surface" tabindex="0">Surface</a>
-      <!-- Issue #85: 期間トグル (Overview / Patterns でのみ表示).
-           Quality / Surface 表示時は CSS で display:none に倒す (30_pages.css)。
-           static export 経路では 05_period.js 内で hidden 属性を立てる。 -->
-      <div class="period-toggle" id="periodToggle" role="group" aria-label="集計期間">
-        <button type="button" data-period="7d" aria-pressed="false">7d</button>
-        <button type="button" data-period="30d" aria-pressed="false">30d</button>
-        <button type="button" data-period="90d" aria-pressed="false">90d</button>
-        <button type="button" data-period="all" aria-pressed="true">全期間</button>
-      </div>
       <!-- Issue #83: live heartbeat sparkline。
            default `hidden` で static export 経路では非表示、live 経路で
            startHeartbeat() が hidden を解除する。 -->
@@ -46,6 +37,19 @@ __INCLUDE_STYLES__
           <span class="num" id="ledeEvents">—</span> events ·
           <span class="num" id="ledeDays">—</span> days observed ·
           <span class="num" id="ledeProjects">—</span> projects
+        </div>
+      </div>
+      <!-- Issue #85: 期間トグル slot (Overview / Patterns 各 header に配置)。
+           toggle DOM は 1 つで、router の active page 切替に応じて
+           05_period.js が該当 slot に move する。Quality / Surface 表示時は
+           移動先が無く、page-scoped CSS rule で display:none に倒す。
+           static export 経路では 05_period.js 内で hidden 属性を立てる。 -->
+      <div class="period-toggle-slot" data-period-slot="overview">
+        <div class="period-toggle" id="periodToggle" role="group" aria-label="集計期間">
+          <button type="button" data-period="7d" aria-pressed="false">7d</button>
+          <button type="button" data-period="30d" aria-pressed="false">30d</button>
+          <button type="button" data-period="90d" aria-pressed="false">90d</button>
+          <button type="button" data-period="all" aria-pressed="true">全期間</button>
         </div>
       </div>
     </header>
@@ -138,6 +142,9 @@ __INCLUDE_STYLES__
           <h1 id="page-patterns-title"><span class="accent">Patterns</span></h1>
           <p class="lede">利用パターンを可視化します。</p>
         </div>
+        <!-- Issue #85: 期間トグル slot (空)。05_period.js が hashchange で
+             Overview slot から #periodToggle を move してくる。 -->
+        <div class="period-toggle-slot" data-period-slot="patterns"></div>
       </header>
 
       <div class="panel" id="patterns-heatmap-panel">

--- a/dashboard/template/styles/30_pages.css
+++ b/dashboard/template/styles/30_pages.css
@@ -38,6 +38,43 @@
   /* `<section data-page="...">` は hidden 切替で常駐。 */
   .page[hidden] { display: none; }
 
+  /* Issue #85: 期間トグル (Overview / Patterns 限定). */
+  .period-toggle {
+    display: inline-flex;
+    gap: 4px;
+    margin-left: auto;
+    align-self: center;
+  }
+  .period-toggle button {
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--ink-soft);
+    background: transparent;
+    border: 1px solid var(--line);
+    border-radius: var(--r-sm);
+    cursor: pointer;
+    transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+  }
+  .period-toggle button:hover {
+    color: var(--ink);
+    background: var(--bg-panel);
+  }
+  .period-toggle button[aria-pressed="true"] {
+    color: var(--mint);
+    background: var(--bg-panel);
+    border-color: var(--mint);
+  }
+  .period-toggle button:focus-visible {
+    outline: 2px solid var(--peri);
+    outline-offset: 2px;
+  }
+  /* Quality / Surface 表示時は toggle 非表示 (router の body.dataset.activePage 既存契約). */
+  body[data-active-page="quality"] #periodToggle,
+  body[data-active-page="surface"] #periodToggle {
+    display: none;
+  }
+
   /* Patterns / Quality / Surface タブの連続する panel 間マージン (Issue #71)。
      Overview は `.two-up` gap + 後続 panel の inline `margin-top:14px` で既に
      間隔が確保されている。adjacent-sibling combinator なので 1 件目の panel

--- a/dashboard/template/styles/30_pages.css
+++ b/dashboard/template/styles/30_pages.css
@@ -38,12 +38,18 @@
   /* `<section data-page="...">` は hidden 切替で常駐。 */
   .page[hidden] { display: none; }
 
-  /* Issue #85: 期間トグル (Overview / Patterns 限定). */
+  /* Issue #85: 期間トグル (Overview / Patterns 限定).
+     header (display: grid; grid-template-columns: 1fr auto) の 2 列目 slot に
+     入るので右端に来る。slot 自体は flex で末尾揃えにしておき、トグル DOM が
+     垂直中央に来るようにする (header の lede 行高さに揃える)。 */
+  .period-toggle-slot {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
   .period-toggle {
     display: inline-flex;
     gap: 4px;
-    margin-left: auto;
-    align-self: center;
   }
   .period-toggle button {
     padding: 4px 10px;

--- a/docs/spec/dashboard-api.md
+++ b/docs/spec/dashboard-api.md
@@ -8,6 +8,49 @@
 > `dashboard/server.py:_filter_usage_events()` で一括管理。本仕様で「usage 系」と
 > 書いたフィールドはすべてこの helper を経由している。
 
+## Query parameters (Issue #85, v0.7.3〜)
+
+### `period` (optional)
+
+- 値: `"7d"` / `"30d"` / `"90d"` / `"all"` (default `"all"`)
+- `"all"` 以外を渡すと、Overview / Patterns / KPI counter の **11 field** が
+  rolling window (`now - timedelta(days=N) <= ts <= now`) で切られた events から
+  集計される。Quality / Surface / `session_stats` の **8 field** は **常に全期間**
+  (period 不変)。
+- 不正値 / 空値 / 不在 → `"all"` に fallback (lenient: 400 を返さない)。
+- 三段 pair-straddling filter: timestamp 第一段 cut 後、`subagent_start ↔ subagent_lifecycle_start` の
+  `INVOCATION_MERGE_WINDOW_SECONDS = 1.0s` 以内 sibling、および
+  `subagent_start ↔ subagent_stop` の paired 直近を再 include する。これは
+  `subagent_metrics._pair_invocations_with_stops` の `start_ts <= stop_ts < next_start_ts`
+  pairing semantics を尊重し、`failure_rate` / `avg_duration_ms` / pXX duration が
+  period boundary 跨ぎで silent drift しないことを保証するため。
+
+### Period 適用 scope (11 field)
+
+- KPI counter: `total_events` / `skill_kinds_total` / `subagent_kinds_total` / `project_total`
+- Overview: `skill_ranking` / `subagent_ranking` / `daily_trend` / `project_breakdown`
+- Patterns: `hourly_heatmap` / `skill_cooccurrence` / `project_skill_matrix`
+
+### 全期間 (period 不変) scope (8 field)
+
+- Quality: `subagent_failure_trend` / `permission_prompt_skill_breakdown` /
+  `permission_prompt_subagent_breakdown` / `compact_density`
+- Surface: `skill_invocation_breakdown` / `skill_lifecycle` / `skill_hibernating`
+- `session_stats` (lifetime metric)
+
+### Filter 対象外 (3 field)
+
+- `last_updated` (常に server clock)
+- `health_alerts` (独立 log 読み出し)
+- `period_applied` (echo)
+
+### `period_applied` (response field)
+
+- server で正規化した period 文字列を additive に echo する。frontend は
+  `period_applied !== 'all'` のとき Overview/Patterns sub に `<period> 集計 · ` の
+  badge prefix を出す (例: `7d 集計 · top 10 · max 42`)。
+- 古い frontend (period unaware) は読まないので backward-compat。
+
 ## トップレベル形
 
 ```json
@@ -29,7 +72,8 @@
   "health_alerts":           [...],
   "skill_invocation_breakdown":  [...],
   "skill_lifecycle":             [...],
-  "skill_hibernating":           { ... }
+  "skill_hibernating":           { ... },
+  "period_applied":          "all" | "7d" | "30d" | "90d"
 }
 ```
 

--- a/docs/spec/dashboard-runtime.md
+++ b/docs/spec/dashboard-runtime.md
@@ -136,12 +136,18 @@ hashchange listener を 1 本持つ。router IIFE は先に登録されている
 
 ### Period toggle (Issue #85, v0.7.3〜)
 
-- **配置**: `<nav class="page-nav">` 内、4 タブの後・heartbeat の前に
-  `<div class="period-toggle" id="periodToggle">` を置く。4 ボタン
-  (`data-period="7d|30d|90d|all"`) で `aria-pressed` で active 表現。
-- **可視範囲**: Overview / Patterns 表示時のみ可視。Quality / Surface 表示時は
-  CSS rule `body[data-active-page="quality"|"surface"] #periodToggle { display: none }`
-  で非表示 (router の `body.dataset.activePage` 既存契約に乗っかる)。
+- **配置**: 各 page header の右端 slot に表示。`<header class="header">` は
+  `display: grid; grid-template-columns: 1fr auto;` の 2 カラム構成で、
+  右側 (auto) カラムに `<div class="period-toggle-slot" data-period-slot="<page>">` を置く。
+  toggle DOM (`<div id="periodToggle">`) は **1 つだけ** で、初期配置は Overview slot に居る。
+  4 ボタン (`data-period="7d|30d|90d|all"`) で `aria-pressed` で active 表現。
+- **Page 切替時の DOM move**: `05_period.js` の `movePeriodToggleToActivePage()` が
+  hashchange listener で active page slot に DOM を `appendChild` で move する
+  (1 DOM 維持 / state sync 不要)。router IIFE (`00_router.js`) の hashchange listener
+  で `body.dataset.activePage` が先に更新されてから本 listener が走る (登録順 = 発火順)。
+- **可視範囲**: Overview / Patterns 表示時のみ可視。Quality / Surface には slot が
+  存在しないので move 先が無く、`body[data-active-page="quality"|"surface"] #periodToggle { display: none }`
+  の page-scoped CSS rule で隠す (toggle DOM は前 page の slot に残る)。
 - **State**: `05_period.js` の closure-private `__periodCurrent` で持ち、
   `window.__period.{getCurrentPeriod, setCurrentPeriod, wirePeriodToggle}` を expose。
   click handler で `aria-pressed` 付け替え + `setCurrentPeriod(p)` + 再 fetch を呼ぶ。

--- a/docs/spec/dashboard-runtime.md
+++ b/docs/spec/dashboard-runtime.md
@@ -133,3 +133,26 @@ page-scoped early-out (`if (document.body.dataset.activePage !== '<page>') retur
 hashchange listener を 1 本持つ。router IIFE は先に登録されているため
 `body.dataset.activePage` が更新されてから main IIFE の listener が走り、新 page
 の renderer が正しく動く。
+
+### Period toggle (Issue #85, v0.7.3〜)
+
+- **配置**: `<nav class="page-nav">` 内、4 タブの後・heartbeat の前に
+  `<div class="period-toggle" id="periodToggle">` を置く。4 ボタン
+  (`data-period="7d|30d|90d|all"`) で `aria-pressed` で active 表現。
+- **可視範囲**: Overview / Patterns 表示時のみ可視。Quality / Surface 表示時は
+  CSS rule `body[data-active-page="quality"|"surface"] #periodToggle { display: none }`
+  で非表示 (router の `body.dataset.activePage` 既存契約に乗っかる)。
+- **State**: `05_period.js` の closure-private `__periodCurrent` で持ち、
+  `window.__period.{getCurrentPeriod, setCurrentPeriod, wirePeriodToggle}` を expose。
+  click handler で `aria-pressed` 付け替え + `setCurrentPeriod(p)` + 再 fetch を呼ぶ。
+- **Fetch 経路**: `20_load_and_render.js` の fetch URL は毎呼び出し時に
+  `'/api/data?period=' + encodeURIComponent(getCurrentPeriod())` で組み立てる
+  (call-time lookup で SSE refresh も新 period で走る = race-free)。
+- **永続化なし**: reload で `'all'` にリセットされる仕様 (URL hash 同期 / localStorage
+  保存は本 issue scope 外、将来 issue で再検討)。
+- **Static export**: `render_static_html` 経路 (`window.__DATA__` 既存) では
+  `wirePeriodToggle()` の冒頭で toggle に `hidden` 属性を立てて click bind を skip
+  する (server を経由しないので period 切り替え自体に意味がない)。
+- **Badge 表示**: response の `period_applied !== 'all'` のとき Overview の
+  `dailySub` / `skillSub` / `subSub` / `projSub` と Patterns 3 sub に
+  `<period> 集計 · ` を additive prefix。`'all'` のときは prefix なし (現状互換)。

--- a/subagent_metrics.py
+++ b/subagent_metrics.py
@@ -210,6 +210,9 @@ def _pair_invocations_with_stops(
         sequential 1:1 だと「2 succeeded starts (W1, W2) + 1 failed stop (W2)」のような
         入力で stop[0] が start[0] にマッチし failure が earlier 週へ shift する
         cross-week 誤 attribute が起きるため、timestamp で window を切って防ぐ
+
+    Note: dashboard/server.py:_filter_events_by_period 第三段 mirrors this pairing rule.
+          Keep in sync.
     """
     paired_stops = len(invocations) == len(stops_sorted)
     if paired_stops:

--- a/tests/test_dashboard_cross_tabs_template.py
+++ b/tests/test_dashboard_cross_tabs_template.py
@@ -77,8 +77,9 @@ class TestPatternsCrossTabsDOM:
 
     def test_loadAndRender_invokes_cross_tab_renderers(self):
         template = _load_template()
-        assert 'renderSkillCooccurrence(data.skill_cooccurrence)' in template
-        assert 'renderProjectSkillMatrix(data.project_skill_matrix)' in template
+        # Issue #85: 第 2 引数で period badge を渡すようになった
+        assert 'renderSkillCooccurrence(data.skill_cooccurrence' in template
+        assert 'renderProjectSkillMatrix(data.project_skill_matrix' in template
 
     def test_cooccurrence_table_has_thead(self):
         # Proposal 1: count 単位は sessions

--- a/tests/test_dashboard_heatmap_template.py
+++ b/tests/test_dashboard_heatmap_template.py
@@ -74,7 +74,8 @@ class TestPatternsHeatmapDOM:
     def test_loadAndRender_invokes_heatmap_renderer(self):
         """loadAndRender 経路から renderHourlyHeatmap が呼ばれる。"""
         template = _load_template()
-        assert 'renderHourlyHeatmap(data.hourly_heatmap)' in template, \
+        # Issue #85: 第 2 引数で period badge を渡すようになった
+        assert 'renderHourlyHeatmap(data.hourly_heatmap' in template, \
             "renderHourlyHeatmap call from loadAndRender missing"
 
 # ============================================================

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -484,6 +484,283 @@ class TestApiDataPeriodQuery:
             self._stop(server)
 
 
+class TestPeriodToggleTemplate:
+    """Step 4b: assembled template の DOM / CSS / concat 順 / static-export 早期 return."""
+
+    def _mod(self, tmp_path):
+        return load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+    def test_period_toggle_dom_present_in_template(self, tmp_path):
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        assert 'id="periodToggle"' in template, "shell に #periodToggle が無い"
+
+    def test_period_toggle_has_four_buttons(self, tmp_path):
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        for value in ("7d", "30d", "90d", "all"):
+            assert f'data-period="{value}"' in template, f"button data-period={value!r} が無い"
+
+    def test_period_toggle_initial_active_is_all(self, tmp_path):
+        """初期状態の aria-pressed=true が data-period='all' に付く."""
+        import re
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        # `data-period="all"` を含む button タグ周辺に aria-pressed="true" があること
+        m = re.search(
+            r'<button[^>]*data-period="all"[^>]*aria-pressed="true"[^>]*>'
+            r'|<button[^>]*aria-pressed="true"[^>]*data-period="all"[^>]*>',
+            template,
+        )
+        assert m is not None, "data-period='all' のボタンに aria-pressed='true' が無い"
+
+    def test_period_toggle_role_group(self, tmp_path):
+        """`role="group"` + aria-label が付いている (a11y)."""
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        assert 'role="group"' in template
+        assert 'aria-label="集計期間"' in template
+
+    def test_period_toggle_inside_page_nav(self, tmp_path):
+        """toggle が `<nav class="page-nav">` 内に配置 (router 契約に乗っかる)."""
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        # nav 開始から toggle までが nav 終了より前
+        nav_start = template.find('<nav class="page-nav"')
+        toggle_pos = template.find('id="periodToggle"')
+        nav_end = template.find('</nav>', nav_start)
+        assert nav_start != -1 and toggle_pos != -1 and nav_end != -1
+        assert nav_start < toggle_pos < nav_end, "#periodToggle が page-nav の外にある"
+
+    def test_period_toggle_hidden_on_quality_and_surface_pages_via_css(self, tmp_path):
+        """page-scoped CSS 非表示 rule が assembled template に含まれる."""
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        # 'body[data-active-page="quality"] #periodToggle' / 'surface' 両方
+        assert 'body[data-active-page="quality"] #periodToggle' in template
+        assert 'body[data-active-page="surface"] #periodToggle' in template
+        assert 'display: none' in template or 'display:none' in template
+
+    def test_period_05_js_concatted_before_10_helpers(self, tmp_path):
+        """`05_period.js` が `10_helpers.js` より前に concat されること."""
+        mod = self._mod(tmp_path)
+        files = mod._MAIN_JS_FILES
+        idx_period = files.index("05_period.js")
+        idx_helpers = files.index("10_helpers.js")
+        assert idx_period < idx_helpers
+
+    def test_window_period_namespace_exposed(self, tmp_path):
+        """`window.__period = { ... }` で getCurrentPeriod / setCurrentPeriod / wirePeriodToggle を expose."""
+        mod = self._mod(tmp_path)
+        bundle = mod._concat_main_js()
+        assert "window.__period" in bundle, "window.__period namespace が定義されていない"
+        assert "getCurrentPeriod" in bundle
+        assert "setCurrentPeriod" in bundle
+        assert "wirePeriodToggle" in bundle
+
+    def test_period_calls_live_diff_via_call_time_lookup(self, tmp_path):
+        """plan §3 Step 4 lazy-lookup behavioral pin (iter3 #2 / iter4 #2 / iter5 #2):
+
+        05_period.js (concat order 05) は 25_live_diff.js (concat order 25) より早く評価される →
+        IIFE 評価時に `window.__liveDiff` は **未定義**。
+        click handler 内では call-time lookup する形であることを behavior 面で pin する。
+
+        手段: Node + 手書き window/document stub で
+          (1) 評価直後 (= window.__liveDiff 未定義) で handler を呼ぶ → 何も走らない
+          (2) `window.__liveDiff` を後から定義 → handler 再 invoke → mock が呼ばれる
+        """
+        import subprocess
+        import shutil
+        node = shutil.which("node")
+        if node is None:
+            import pytest as _pytest
+            _pytest.skip("node not available; skipping behavioral lazy-lookup test")
+        mod = self._mod(tmp_path)
+        bundle = mod._concat_main_js()
+        # Node script: 手書き stub + 05_period.js の wirePeriodToggle() のみを評価したい。
+        # 一番安全なのは bundle 全体を実行できる stub を整えて wirePeriodToggle を呼ぶこと。
+        # ただし bundle 内には fetch / EventSource 等の I/O も含まれるので、minimal stub を入れる。
+        script = r"""
+const calls = [];
+let savedHandler = null;
+
+// minimal global stubs
+globalThis.window = { addEventListener: () => {}, removeEventListener: () => {}, location: { hash: "" } };
+globalThis.document = {
+  body: { dataset: {}, classList: { add: () => {}, remove: () => {}, contains: () => false } },
+  getElementById: () => null,
+  querySelectorAll: (sel) => {
+    if (typeof sel === "string" && sel.indexOf("data-period") !== -1) {
+      return [{
+        addEventListener: (_evt, fn) => { savedHandler = fn; },
+        getAttribute: (k) => k === "data-period" ? "7d" : null,
+        dataset: { period: "7d" },
+        setAttribute: () => {},
+      }];
+    }
+    return [];
+  },
+  querySelector: () => null,
+  addEventListener: () => {},
+};
+globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+globalThis.EventSource = undefined;
+
+// bundle を IIFE で評価。05_period.js は IIFE 直後に動いて window.__period を expose
+const bundle = process.env.BUNDLE;
+try {
+  // bundle 全体は async IIFE 前提なので await できないが、05_period.js / 10_helpers.js は同期評価される。
+  // 評価エラーを silent にしないため try/catch 表示。
+  // bundle は wrapping IIFE 無しなので、ここで wrapper を巻く。
+  // production shell.html では `(async function(){...})();` で wrap されているので
+  // top-level await を含む bundle はそのままだと SyntaxError。同じ async IIFE で巻く。
+  // ただし非同期に走る loadAndRender() は stub 環境では deref で reject する
+  // (本 test の関心は 05_period.js の sync 部分 = wirePeriodToggle のみ) ため、
+  // unhandledRejection を抑制する。
+  process.on("unhandledRejection", () => {});
+  const wrapped = "(async function(){" + bundle + "})();";
+  // 注: loadAndRender を含むが top-level await 部分は 70_init_eventsource.js の await。
+  // wirePeriodToggle 呼び出しが top-level であれば savedHandler が捕まる。
+  eval(wrapped);
+} catch (e) {
+  // 70_init_eventsource.js の await scheduleLoadAndRender() は async 関数内なので
+  // top-level eval では SyntaxError になる可能性 → fallback: wirePeriodToggle 単独 call
+  // この path に落ちた場合も savedHandler が無いと test fail するので分岐 print のみ
+  console.error("EVAL_ERROR:", e.message);
+}
+
+// step (1): window.__liveDiff 未定義 でも handler を呼んで no-throw + calls 0
+if (typeof savedHandler !== "function") {
+  console.log(JSON.stringify({error: "no_handler"}));
+  process.exit(0);
+}
+try { savedHandler({ currentTarget: { dataset: { period: "7d" } } }); }
+catch (e) { console.log(JSON.stringify({error: "step1_threw", msg: e.message})); process.exit(0); }
+const callsAfterStep1 = calls.length;
+
+// step (2): window.__liveDiff を後から定義 → 再 invoke
+globalThis.window.__liveDiff = { scheduleLoadAndRender: () => { calls.push(1); } };
+try { savedHandler({ currentTarget: { dataset: { period: "7d" } } }); }
+catch (e) { console.log(JSON.stringify({error: "step2_threw", msg: e.message})); process.exit(0); }
+const callsAfterStep2 = calls.length;
+
+console.log(JSON.stringify({ callsAfterStep1, callsAfterStep2 }));
+"""
+        result = subprocess.run(
+            [node, "-e", script],
+            env={**os.environ, "BUNDLE": bundle},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"node failed: stderr={result.stderr}"
+        # 最後の JSON 行をパース
+        import json as _json
+        lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+        assert lines, f"no JSON output: stdout={result.stdout!r} stderr={result.stderr!r}"
+        out = _json.loads(lines[-1])
+        assert "error" not in out, f"node script error: {out}"
+        # call-time lookup なら step1 (liveDiff 未定義) で 0 件、step2 (liveDiff 後付け) で 1 件
+        assert out["callsAfterStep1"] == 0, "callsAfterStep1 must be 0 (liveDiff 未定義時に呼ばれてしまっている)"
+        assert out["callsAfterStep2"] == 1, "callsAfterStep2 must be 1 (call-time lookup なら liveDiff 後付け後 invoke で 1)"
+
+    def test_static_export_hides_toggle(self, tmp_path):
+        """plan §3 Step 4 (reviewer iter1 #2): static export では toggle を hidden にする.
+
+        wirePeriodToggle() の冒頭で `window.__DATA__` の存在を check し、setAttribute('hidden', '') を呼んで return する。
+        substring grep でも pin できるが、ここでは Node round-trip で hidden 属性が立つことを assert.
+        """
+        import subprocess
+        import shutil
+        node = shutil.which("node")
+        if node is None:
+            import pytest as _pytest
+            _pytest.skip("node not available; skipping static-export test")
+        mod = self._mod(tmp_path)
+        bundle = mod._concat_main_js()
+        script = r"""
+let toggleEl = { _attrs: {}, setAttribute: function(k, v) { this._attrs[k] = v; } };
+let savedHandler = null;
+globalThis.window = { __DATA__: { foo: 1 }, addEventListener: () => {}, location: { hash: "" } };
+globalThis.document = {
+  body: { dataset: {}, classList: { add: () => {}, remove: () => {}, contains: () => false } },
+  getElementById: (id) => id === "periodToggle" ? toggleEl : null,
+  querySelectorAll: (sel) => {
+    if (typeof sel === "string" && sel.indexOf("data-period") !== -1) {
+      return [{ addEventListener: (_evt, fn) => { savedHandler = fn; }, dataset: { period: "7d" }, setAttribute: () => {}, getAttribute: () => null }];
+    }
+    return [];
+  },
+  querySelector: () => null,
+  addEventListener: () => {},
+};
+globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+globalThis.EventSource = undefined;
+process.on("unhandledRejection", () => {});
+try {
+  const wrapped = "(async function(){" + process.env.BUNDLE + "})();";
+  eval(wrapped);
+} catch (e) {
+  // some downstream js may throw; only check toggleEl state here
+}
+console.log(JSON.stringify({ hidden: toggleEl._attrs.hidden, savedHandlerWired: typeof savedHandler === "function" }));
+"""
+        result = subprocess.run(
+            [node, "-e", script],
+            env={**os.environ, "BUNDLE": bundle},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"node failed: stderr={result.stderr}"
+        import json as _json
+        lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip()]
+        assert lines
+        out = _json.loads(lines[-1])
+        # static export 経路で hidden 属性が立つこと
+        assert out["hidden"] == "", f"static export で toggle に hidden 属性が立っていない: {out}"
+
+    def test_get_current_period_initial_value_is_all(self, tmp_path):
+        """plan §3 Step 4 (iter1 question #1): window.__period.getCurrentPeriod() で初期値 'all' が読める."""
+        import subprocess
+        import shutil
+        node = shutil.which("node")
+        if node is None:
+            import pytest as _pytest
+            _pytest.skip("node not available")
+        mod = self._mod(tmp_path)
+        bundle = mod._concat_main_js()
+        script = r"""
+globalThis.window = { addEventListener: () => {}, location: { hash: "" } };
+globalThis.document = {
+  body: { dataset: {}, classList: { add: () => {}, remove: () => {}, contains: () => false } },
+  getElementById: () => null,
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  addEventListener: () => {},
+};
+globalThis.fetch = async () => ({ ok: true, json: async () => ({}) });
+globalThis.EventSource = undefined;
+process.on("unhandledRejection", () => {});
+try { eval("(async function(){" + process.env.BUNDLE + "})();"); } catch (e) {}
+const initial = (typeof window.__period === "object" && typeof window.__period.getCurrentPeriod === "function")
+  ? window.__period.getCurrentPeriod()
+  : null;
+console.log(JSON.stringify({ initial }));
+"""
+        result = subprocess.run(
+            [node, "-e", script],
+            env={**os.environ, "BUNDLE": bundle},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"node failed: stderr={result.stderr}"
+        import json as _json
+        out = _json.loads(result.stdout.strip().splitlines()[-1])
+        assert out["initial"] == "all", f"getCurrentPeriod() の初期値が 'all' でない: {out}"
+
+
 class TestConcatMainJsByteInvariant:
     """Step 4a: `_concat_main_js()` helper 切り出し refactor の byte-identical 不変条件."""
 

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -914,6 +914,52 @@ setImmediate(() => {
                     f"{sub_id} に period=all で {not_expected!r} が出ている: {text!r}"
 
 
+class TestPeriodDriftGuardAndStaticExport:
+    """Step 7: drift guard (period 適用 11 field と全期間 8 field の boundary) + static export 不在 pin."""
+
+    def _mod(self, tmp_path):
+        return load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+    def test_period_change_observably_shrinks_period_applied_set(self, tmp_path):
+        """period 切り替えで period 適用 11 field 側に差分が観測される (drift 観測点)."""
+        mod = self._mod(tmp_path)
+        events = _make_event_set_for_period_test(_FIXED_NOW)
+        data_all = mod.build_dashboard_data(events, period="all", now=_FIXED_NOW)
+        data_7d = mod.build_dashboard_data(events, period="7d", now=_FIXED_NOW)
+        # 少なくとも 1 つの period 適用 field が縮む (= 切り替え効果が観測される)
+        assert data_all["total_events"] != data_7d["total_events"], \
+            "period 切替で total_events に差分が出ない (filter が効いていない疑い)"
+
+    def test_static_export_html_has_no_period_query(self, tmp_path):
+        """`render_static_html` の HTML に `?period=` literal が含まれない.
+
+        static export は period unaware の証跡。period query が入る fetch path も
+        `<script>window.__DATA__ = ...</script>` で打ち消されるが、URL literal が
+        export 文字列に乗っていないことを構造的に pin する。
+
+        ただし render_static_html は `_HTML_TEMPLATE` を base にしているので
+        '/api/data?period=' という substring 自体は HTML 内に残る (script 文字列内)。
+        ここで pin したいのは「export 経路が period unaware で動くこと」なので、
+        実装側は `window.__DATA__` 経路で fetch を skip することを保証する形になる。
+        従って本 test は status assertion のみ: static export が JSON inline で動き、
+        `__apiUrl` 変数が定義されている JS bundle 自体は同じ形で残る。
+        → "static export の Surface ページや Quality ページが period 切替の影響を
+           受けない" は build_dashboard_data 側の drift guard で既にカバー済み。
+
+        ここでは `<script>window.__DATA__` inline が `</head>` 直前に置かれていること
+        だけ pin (期間 toggle が無くても export が壊れないことの構造保証).
+        """
+        mod = self._mod(tmp_path)
+        events = _make_event_set_for_period_test(_FIXED_NOW)
+        data = mod.build_dashboard_data(events, period="all", now=_FIXED_NOW)
+        html = mod.render_static_html(data)
+        # window.__DATA__ inline が </head> 直前に存在
+        assert '<script>window.__DATA__' in html
+        # static export の inline data は period_applied = 'all' を持つ
+        assert '"period_applied"' in html
+        assert '"period_applied": "all"' in html or '"period_applied":"all"' in html
+
+
 class TestConcatMainJsByteInvariant:
     """Step 4a: `_concat_main_js()` helper 切り出し refactor の byte-identical 不変条件."""
 

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -1,0 +1,255 @@
+"""tests/test_dashboard_period_toggle.py — Issue #85 Dashboard Period Toggle テスト集約。
+
+Step 1〜7 の test class を 1 ファイルに集める (plan §4 dispersion 削減方針)。
+"""
+# pylint: disable=line-too-long
+import importlib.util
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
+
+
+def load_dashboard_module(usage_jsonl: Path, alerts_jsonl: Path | None = None):
+    """USAGE_JSONL をパッチした状態で dashboard モジュールを読み込む (test_dashboard.py 流用)。"""
+    os.environ["USAGE_JSONL"] = str(usage_jsonl)
+    if alerts_jsonl is not None:
+        os.environ["HEALTH_ALERTS_JSONL"] = str(alerts_jsonl)
+    try:
+        spec = importlib.util.spec_from_file_location("dashboard_server", _DASHBOARD_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    finally:
+        del os.environ["USAGE_JSONL"]
+        if alerts_jsonl is not None:
+            del os.environ["HEALTH_ALERTS_JSONL"]
+    return mod
+
+
+_FIXED_NOW = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ts(now: datetime, *, days: float = 0, seconds: float = 0) -> str:
+    """fixed now から相対 timestamp を ISO 文字列で返す (UTC 固定)。"""
+    dt = now - timedelta(days=days, seconds=seconds)
+    return dt.isoformat()
+
+
+class TestFilterEventsByPeriod:
+    """Step 1: `_filter_events_by_period` helper の境界・三段 filter 仕様 (plan §3 Step 1)."""
+
+    def _mod(self, tmp_path):
+        return load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+    def test_period_7d_drops_8_days_old_event(self, tmp_path):
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "skill_tool", "skill": "a", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=8)},
+            {"event_type": "skill_tool", "skill": "b", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=6)},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        assert [e["skill"] for e in out] == ["b"]
+
+    def test_period_30d_boundary_includes_30_days_old(self, tmp_path):
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "skill_tool", "skill": "boundary", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=30)},
+            {"event_type": "skill_tool", "skill": "old", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=31)},
+        ]
+        out = mod._filter_events_by_period(events, "30d", now=_FIXED_NOW)
+        assert [e["skill"] for e in out] == ["boundary"]
+
+    def test_period_90d_keeps_within_window(self, tmp_path):
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "skill_tool", "skill": "a", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=89)},
+            {"event_type": "skill_tool", "skill": "b", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=91)},
+        ]
+        out = mod._filter_events_by_period(events, "90d", now=_FIXED_NOW)
+        assert [e["skill"] for e in out] == ["a"]
+
+    def test_period_all_returns_events_unchanged(self, tmp_path):
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "skill_tool", "skill": "ancient", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=365)},
+            {"event_type": "skill_tool", "skill": "missing_ts"},
+            {"event_type": "skill_tool", "skill": "broken_ts", "timestamp": "not-a-date"},
+        ]
+        out = mod._filter_events_by_period(events, "all", now=_FIXED_NOW)
+        assert out == events  # element-wise equality (not identity)
+
+    def test_period_unparseable_timestamps_silently_dropped_when_not_all(self, tmp_path):
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "skill_tool", "skill": "good", "session_id": "s", "timestamp": _ts(_FIXED_NOW, days=1)},
+            {"event_type": "skill_tool", "skill": "no_ts", "session_id": "s"},
+            {"event_type": "skill_tool", "skill": "bad_ts", "session_id": "s", "timestamp": "garbage"},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        assert [e["skill"] for e in out] == ["good"]
+
+    def test_period_naive_timestamp_treated_as_utc(self, tmp_path):
+        mod = self._mod(tmp_path)
+        # naive datetime (no tz) で 1 日前
+        naive_ts = (_FIXED_NOW.replace(tzinfo=None) - timedelta(days=1)).isoformat()
+        events = [
+            {"event_type": "skill_tool", "skill": "a", "session_id": "s", "timestamp": naive_ts},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        assert len(out) == 1
+
+    def test_period_default_now_uses_wall_clock(self, tmp_path):
+        """now= 省略時に internal default の datetime.now(UTC) を使う (production code path)."""
+        mod = self._mod(tmp_path)
+        # 現在時刻基準で 1 秒前 → 必ず 7d 内
+        events = [
+            {"event_type": "skill_tool", "skill": "a", "session_id": "s",
+             "timestamp": (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d")
+        assert len(out) == 1
+
+    # === 第二段: subagent_start ↔ subagent_lifecycle_start pair-straddling ===
+
+    def test_filter_period_includes_lifecycle_pair_when_start_outside_window(self, tmp_path):
+        """第二段: kept lifecycle@(now-7d+0.4s) の paired start@(now-7d-0.4s) を再 include."""
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tu1",
+             "timestamp": (cutoff - timedelta(seconds=0.4)).isoformat()},
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.4)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        types = sorted(e["event_type"] for e in out)
+        assert types == ["subagent_lifecycle_start", "subagent_start"]
+
+    def test_filter_period_includes_start_pair_when_lifecycle_outside_window(self, tmp_path):
+        """第二段 (対称): kept start@cutoff+0.4s の paired lifecycle@cutoff-0.4s を再 include."""
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff - timedelta(seconds=0.4)).isoformat()},
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tu1",
+             "timestamp": (cutoff + timedelta(seconds=0.4)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        types = sorted(e["event_type"] for e in out)
+        assert types == ["subagent_lifecycle_start", "subagent_start"]
+
+    # === 第三段: subagent_start ↔ subagent_stop pair-straddling ===
+
+    def test_filter_period_includes_subagent_stop_paired_with_kept_start(self, tmp_path):
+        """第三段: kept start@cutoff+0.4s の paired stop@cutoff-0.5s を再 include しない。
+
+        plan: 順経路は kept_start から `start.ts <= stop.ts < next_start.ts` の直後 stop を拾う。
+        逆経路は kept_stop から start.ts <= stop.ts の直前 start を拾う。
+        cutoff より過去の stop で start の前にある (= start_A の paired stop ではない) ものは引っ張らない。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        # ここで test するのは「kept stop が外側 start を引っ張る」ケース。
+        # kept stop@cutoff+0.5s, paired start@cutoff-0.5s → start を再 include
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tu1",
+             "timestamp": (cutoff - timedelta(seconds=0.5)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.5)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        types = sorted(e["event_type"] for e in out)
+        assert types == ["subagent_start", "subagent_stop"]
+
+    def test_filter_period_includes_subagent_start_pulls_outside_paired_stop(self, tmp_path):
+        """第三段 (順経路): kept start@cutoff+0.3s が直後の paired stop@cutoff-0.2s ... ではなく、
+        cutoff+0.8s の stop を拾う (両方 inside の通常ケース)。
+
+        inside-only 構成だが、第三段が stop を 取りこぼさない sanity check。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tu1",
+             "timestamp": (cutoff + timedelta(seconds=0.3)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.8)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        types = sorted(e["event_type"] for e in out)
+        assert types == ["subagent_start", "subagent_stop"]
+
+    def test_filter_period_does_not_pull_unrelated_stop_from_prior_invocation(self, tmp_path):
+        """plan §3 Step 1 反例 test (iter5 #1): 同 (session_id, subagent_type) バケットで連続 2 invocation:
+
+            start_A @ now-7d-2.0s   (cutoff 外, 第一段 drop)
+            stop_A  @ now-7d-1.5s   (cutoff 外, 第一段 drop)
+            start_B @ now-7d+0.3s   (cutoff 内, 保持)
+            stop_B  @ now-7d+0.8s   (cutoff 内, 保持)
+
+        期待: stop_A は再 include されない (start_B の paired stop は stop_B で確定)。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tuA",
+             "timestamp": (cutoff - timedelta(seconds=2.0)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff - timedelta(seconds=1.5)).isoformat()},
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tuB",
+             "timestamp": (cutoff + timedelta(seconds=0.3)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.8)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        # tuB の start と stop_B のみ。stop_A も start_A も再 include されない
+        kept_starts = [e for e in out if e["event_type"] == "subagent_start"]
+        kept_stops = [e for e in out if e["event_type"] == "subagent_stop"]
+        assert len(kept_starts) == 1
+        assert kept_starts[0]["tool_use_id"] == "tuB"
+        assert len(kept_stops) == 1
+        # stop は cutoff+0.8s のもの (stop_B)
+        kept_stop_ts = datetime.fromisoformat(kept_stops[0]["timestamp"])
+        assert kept_stop_ts > cutoff
+
+    def test_three_stage_filter_survives_filter_usage_events(self, tmp_path):
+        """plan §3 Step 2 invariant (iter5 advisory #4):
+        三段で再 include された stop event が `_filter_usage_events` 通過後も残る (= dedup window と同一なので脱落しない)."""
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tu1",
+             "timestamp": (cutoff - timedelta(seconds=0.5)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.5)).isoformat()},
+        ]
+        period_events_raw = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        period_events_usage = mod._filter_usage_events(period_events_raw)
+        # stop event 自体は usage_events に含まれないが (filter は subagent_start 系を 1 件代表に絞る)、
+        # 再 include された start が 1 件として残ることを assert
+        et_set = {e["event_type"] for e in period_events_usage}
+        # `_filter_usage_events` は skill_tool / user_slash_command + invocation 代表 (subagent_start) を返す
+        assert "subagent_start" in et_set
+
+    def test_filter_period_invalid_value_falls_back_to_all(self, tmp_path):
+        """`period` allow-list 外 → 'all' 相当 (= 全イベント保持) として扱う。
+
+        plan §3 Step 3 で _serve_api 側 fallback も持つが、helper 単体でも防御的に
+        unknown period は 'all' 相当に倒す (誤動作 silent drift 回避)。
+        """
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "skill_tool", "skill": "a", "session_id": "s",
+             "timestamp": _ts(_FIXED_NOW, days=365)},
+        ]
+        out = mod._filter_events_by_period(events, "wat", now=_FIXED_NOW)
+        assert out == events

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -847,6 +847,10 @@ console.log(JSON.stringify({ callsAfterStep1, callsAfterStep2 }));
             env={**os.environ, "BUNDLE": bundle},
             capture_output=True,
             text=True,
+            # Windows: default cp1252 decode は Node UTF-8 出力 (絵文字 / 日本語) を
+            # charmap で扱えず stdout=None になるため、UTF-8 を明示する。
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         assert result.returncode == 0, f"node failed: stderr={result.stderr}"
@@ -951,6 +955,10 @@ console.log(JSON.stringify({ hidden: toggleEl._attrs.hidden, savedHandlerWired: 
             env={**os.environ, "BUNDLE": bundle},
             capture_output=True,
             text=True,
+            # Windows: default cp1252 decode は Node UTF-8 出力 (絵文字 / 日本語) を
+            # charmap で扱えず stdout=None になるため、UTF-8 を明示する。
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         assert result.returncode == 0, f"node failed: stderr={result.stderr}"
@@ -994,6 +1002,10 @@ console.log(JSON.stringify({ initial }));
             env={**os.environ, "BUNDLE": bundle},
             capture_output=True,
             text=True,
+            # Windows: default cp1252 decode は Node UTF-8 出力 (絵文字 / 日本語) を
+            # charmap で扱えず stdout=None になるため、UTF-8 を明示する。
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         assert result.returncode == 0, f"node failed: stderr={result.stderr}"
@@ -1126,6 +1138,10 @@ setImmediate(() => {
             env={**os.environ, "BUNDLE": bundle, "DATA": _json.dumps(data)},
             capture_output=True,
             text=True,
+            # Windows: default cp1252 decode は Node UTF-8 出力 (絵文字 / 日本語) を
+            # charmap で扱えず stdout=None になるため、UTF-8 を明示する。
+            encoding="utf-8",
+            errors="replace",
             timeout=10,
         )
         assert result.returncode == 0, f"node failed: stderr={result.stderr}"

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -717,16 +717,42 @@ class TestPeriodToggleTemplate:
         assert 'role="group"' in template
         assert 'aria-label="集計期間"' in template
 
-    def test_period_toggle_inside_page_nav(self, tmp_path):
-        """toggle が `<nav class="page-nav">` 内に配置 (router 契約に乗っかる)."""
+    def test_period_toggle_initial_in_overview_header(self, tmp_path):
+        """toggle DOM の初期配置は Overview の `<header class="header">` 内 (右端 slot)。
+
+        Issue #85 follow-up: トグルは各 page header と同じ行の右端に表示する仕様.
+        DOM は 1 つで、JS が hashchange で active page slot へ move する。
+        """
         mod = self._mod(tmp_path)
         template = mod._build_html_template()
-        # nav 開始から toggle までが nav 終了より前
-        nav_start = template.find('<nav class="page-nav"')
+        # Overview slot anchor が存在し、その近傍に toggle が居ること
+        overview_slot_pos = template.find('data-period-slot="overview"')
         toggle_pos = template.find('id="periodToggle"')
-        nav_end = template.find('</nav>', nav_start)
-        assert nav_start != -1 and toggle_pos != -1 and nav_end != -1
-        assert nav_start < toggle_pos < nav_end, "#periodToggle が page-nav の外にある"
+        assert overview_slot_pos != -1, "Overview header の data-period-slot=overview slot が無い"
+        assert toggle_pos != -1, "#periodToggle DOM が無い"
+        # toggle は Overview slot の中 (近傍) に居る
+        assert overview_slot_pos < toggle_pos, \
+            "toggle が Overview slot より前にある (slot 内に入っていない可能性)"
+        # かつ Overview の `<section data-page="overview">` 終端より前
+        overview_section_end = template.find('</section><!-- /data-page="overview"')
+        assert overview_section_end != -1, "Overview section 終端コメントが無い"
+        assert toggle_pos < overview_section_end, \
+            "#periodToggle が Overview section の外 (header 配置に失敗している)"
+
+    def test_patterns_header_has_empty_period_slot(self, tmp_path):
+        """Patterns header に `data-period-slot="patterns"` の空 slot が居る (move 先)."""
+        mod = self._mod(tmp_path)
+        template = mod._build_html_template()
+        assert 'data-period-slot="patterns"' in template, \
+            "Patterns header に data-period-slot=patterns slot が無い"
+
+    def test_period_toggle_moved_via_hashchange_listener(self, tmp_path):
+        """05_period.js が hashchange listener で active page slot に DOM を move する."""
+        mod = self._mod(tmp_path)
+        bundle = mod._concat_main_js()
+        # listener 登録があること + slot selector を使っていること
+        assert "hashchange" in bundle, "05_period.js に hashchange listener が無い"
+        assert "data-period-slot" in bundle, "data-period-slot selector が JS に無い"
 
     def test_period_toggle_hidden_on_quality_and_surface_pages_via_css(self, tmp_path):
         """page-scoped CSS 非表示 rule が assembled template に含まれる."""

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -392,6 +392,98 @@ class TestBuildDashboardDataWithPeriod:
         assert data["last_updated"] == _FIXED_NOW.isoformat()
 
 
+class TestApiDataPeriodQuery:
+    """Step 3: `/api/data?period=<v>` query param routing + fallback."""
+
+    def _start_server(self, tmp_path, events: list[dict]):
+        """ThreadingHTTPServer をエフェメラルポートで上げて (server, base_url) を返す."""
+        import json as _json
+        import socket
+        import threading
+        usage = tmp_path / "usage.jsonl"
+        usage.parent.mkdir(parents=True, exist_ok=True)
+        with usage.open("w", encoding="utf-8") as f:
+            for ev in events:
+                f.write(_json.dumps(ev) + "\n")
+        mod = load_dashboard_module(usage)
+
+        # find free port (avoid race with bind to 0)
+        s = socket.socket()
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        s.close()
+
+        from http.server import ThreadingHTTPServer
+        server = ThreadingHTTPServer(("127.0.0.1", port), mod.DashboardHandler)
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        return mod, server, f"http://127.0.0.1:{port}"
+
+    def _stop(self, server):
+        server.shutdown()
+        server.server_close()
+
+    def test_api_data_with_period_7d(self, tmp_path):
+        import json as _json
+        import urllib.request
+        events = [
+            {"event_type": "skill_tool", "skill": "fresh", "session_id": "s",
+             "timestamp": (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()},
+        ]
+        mod, server, base = self._start_server(tmp_path, events)
+        try:
+            with urllib.request.urlopen(f"{base}/api/data?period=7d", timeout=2) as resp:
+                data = _json.loads(resp.read())
+            assert data["period_applied"] == "7d"
+        finally:
+            self._stop(server)
+
+    def test_api_data_invalid_period_falls_back_to_all(self, tmp_path):
+        import json as _json
+        import urllib.request
+        mod, server, base = self._start_server(tmp_path, [])
+        try:
+            with urllib.request.urlopen(f"{base}/api/data?period=garbage", timeout=2) as resp:
+                data = _json.loads(resp.read())
+            assert data["period_applied"] == "all"
+        finally:
+            self._stop(server)
+
+    def test_api_data_empty_period_value_falls_back_to_all(self, tmp_path):
+        import json as _json
+        import urllib.request
+        mod, server, base = self._start_server(tmp_path, [])
+        try:
+            with urllib.request.urlopen(f"{base}/api/data?period=", timeout=2) as resp:
+                data = _json.loads(resp.read())
+            assert data["period_applied"] == "all"
+        finally:
+            self._stop(server)
+
+    def test_api_data_no_period_query_defaults_to_all(self, tmp_path):
+        """plan §3 Step 3 backward-compat: 既存 frontend (period unaware) との互換."""
+        import json as _json
+        import urllib.request
+        mod, server, base = self._start_server(tmp_path, [])
+        try:
+            with urllib.request.urlopen(f"{base}/api/data", timeout=2) as resp:
+                data = _json.loads(resp.read())
+            assert data["period_applied"] == "all"
+        finally:
+            self._stop(server)
+
+    def test_api_data_period_all_explicit(self, tmp_path):
+        import json as _json
+        import urllib.request
+        mod, server, base = self._start_server(tmp_path, [])
+        try:
+            with urllib.request.urlopen(f"{base}/api/data?period=all", timeout=2) as resp:
+                data = _json.loads(resp.read())
+            assert data["period_applied"] == "all"
+        finally:
+            self._stop(server)
+
+
 class TestPeriodSentinelDocstring:
     """Issue #85 sentinel pin (plan §3 Step 2 iter5 advisory #3).
 

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -484,6 +484,39 @@ class TestApiDataPeriodQuery:
             self._stop(server)
 
 
+class TestConcatMainJsByteInvariant:
+    """Step 4a: `_concat_main_js()` helper 切り出し refactor の byte-identical 不変条件."""
+
+    def test_concat_main_js_returns_str(self, tmp_path):
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        out = mod._concat_main_js()
+        assert isinstance(out, str)
+        assert len(out) > 0
+
+    def test_concat_main_js_used_in_build_html_template(self, tmp_path):
+        """`_build_html_template()` の出力に `_concat_main_js()` の結果が含まれる (DRY)."""
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        main_js = mod._concat_main_js()
+        template = mod._build_html_template()
+        assert main_js in template, "_build_html_template() の出力に _concat_main_js() の連結結果が含まれていない"
+
+    def test_concat_main_js_no_separator_between_files(self, tmp_path):
+        """plan §3 Step 4a iter6 #2: 改行などの separator を入れず byte-identical を維持する.
+
+        現行 inline 形は `"".join(...)` で書かれている (dashboard/server.py:990 履歴) ので、
+        helper 切り出し後も "".join (= no separator) であることを assert。
+        """
+        mod = load_dashboard_module(tmp_path / "nonexistent.jsonl")
+        from pathlib import Path as _P
+        template_dir = _P(mod.__file__).parent / "template"
+        expected = "".join(
+            (template_dir / "scripts" / name).read_text(encoding="utf-8")
+            for name in mod._MAIN_JS_FILES
+        )
+        actual = mod._concat_main_js()
+        assert actual == expected, "concat に separator が混入している (byte-identical 違反)"
+
+
 class TestPeriodSentinelDocstring:
     """Issue #85 sentinel pin (plan §3 Step 2 iter5 advisory #3).
 

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -253,3 +253,153 @@ class TestFilterEventsByPeriod:
         ]
         out = mod._filter_events_by_period(events, "wat", now=_FIXED_NOW)
         assert out == events
+
+
+def _make_event_set_for_period_test(now: datetime) -> list[dict]:
+    """Step 2 / 7 で再利用する mixed events.
+
+    - 8 日前 skill_tool (period=7d で消える)
+    - 1 日前 skill_tool (period=7d でも残る)
+    - 8 日前 subagent_start + paired stop (period=7d で消える)
+    - 1 日前 subagent_start + paired stop (period=7d でも残る)
+    - 60 日前 skill_tool (compact_density / lifecycle 入力用 = 全期間 field 側)
+    - 90 日前 compact_start (compact_density / session_stats 用 = 全期間)
+    """
+    return [
+        {"event_type": "skill_tool", "skill": "old", "project": "p1", "session_id": "s_old",
+         "timestamp": _ts(now, days=8)},
+        {"event_type": "skill_tool", "skill": "fresh", "project": "p1", "session_id": "s_fresh",
+         "timestamp": _ts(now, days=1)},
+        {"event_type": "subagent_start", "subagent_type": "Old", "project": "p1", "session_id": "s_old",
+         "tool_use_id": "t_old", "timestamp": _ts(now, days=8, seconds=-1), "duration_ms": 1000,
+         "success": True},
+        {"event_type": "subagent_stop", "subagent_type": "Old", "project": "p1", "session_id": "s_old",
+         "timestamp": _ts(now, days=8)},
+        {"event_type": "subagent_start", "subagent_type": "Fresh", "project": "p1", "session_id": "s_fresh",
+         "tool_use_id": "t_fresh", "timestamp": _ts(now, days=1, seconds=-1), "duration_ms": 1000,
+         "success": True},
+        {"event_type": "subagent_stop", "subagent_type": "Fresh", "project": "p1", "session_id": "s_fresh",
+         "timestamp": _ts(now, days=1)},
+        {"event_type": "skill_tool", "skill": "skill60d", "project": "p2", "session_id": "s60",
+         "timestamp": _ts(now, days=60)},
+        {"event_type": "compact_start", "trigger": "auto", "project": "p1", "session_id": "s_c",
+         "timestamp": _ts(now, days=90)},
+        {"event_type": "session_start", "source": "startup", "project": "p1", "session_id": "s_old",
+         "timestamp": _ts(now, days=8, seconds=-2)},
+    ]
+
+
+class TestBuildDashboardDataWithPeriod:
+    """Step 2: build_dashboard_data(period=...) — 11 field period 適用 / 8 field 不変 / period_applied echo."""
+
+    def _mod(self, tmp_path):
+        return load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+    def test_period_applied_echo_in_response(self, tmp_path):
+        mod = self._mod(tmp_path)
+        data = mod.build_dashboard_data([], period="7d", now=_FIXED_NOW)
+        assert data["period_applied"] == "7d"
+
+    def test_period_all_legacy_signature_equivalence(self, tmp_path):
+        """period 引数省略 (= legacy) と period='all' が完全一致すること (last_updated 込み)."""
+        mod = self._mod(tmp_path)
+        events = _make_event_set_for_period_test(_FIXED_NOW)
+        legacy = mod.build_dashboard_data(events, now=_FIXED_NOW)
+        explicit_all = mod.build_dashboard_data(events, period="all", now=_FIXED_NOW)
+        # period_applied は legacy にも出る (= "all" がデフォルト)
+        assert legacy == explicit_all
+
+    def test_period_7d_shrinks_period_applied_fields(self, tmp_path):
+        """period=7d で period 適用 11 field 全てから 8 日前 event が消える."""
+        mod = self._mod(tmp_path)
+        events = _make_event_set_for_period_test(_FIXED_NOW)
+        data_all = mod.build_dashboard_data(events, period="all", now=_FIXED_NOW)
+        data_7d = mod.build_dashboard_data(events, period="7d", now=_FIXED_NOW)
+
+        # 1) total_events: all=2 skill + 2 subagent invocation = 4 (60d / 90d 系は除外); 7d=1 skill + 1 subagent = 2
+        assert data_all["total_events"] > data_7d["total_events"]
+        assert data_7d["total_events"] == 2
+
+        # 2) skill_ranking: 7d 側に "old" / "skill60d" が含まれない
+        skill_names_7d = {r["name"] for r in data_7d["skill_ranking"]}
+        assert "old" not in skill_names_7d
+        assert "skill60d" not in skill_names_7d
+        assert "fresh" in skill_names_7d
+
+        # 3) subagent_ranking: 7d 側に "Old" が含まれない
+        sub_names_7d = {r["name"] for r in data_7d["subagent_ranking"]}
+        assert "Old" not in sub_names_7d
+        assert "Fresh" in sub_names_7d
+
+        # 4) skill_kinds_total
+        assert data_all["skill_kinds_total"] > data_7d["skill_kinds_total"]
+        assert data_7d["skill_kinds_total"] == 1
+
+        # 5) subagent_kinds_total
+        assert data_all["subagent_kinds_total"] > data_7d["subagent_kinds_total"]
+        assert data_7d["subagent_kinds_total"] == 1
+
+        # 6) project_total: 7d で p2 (60d skill) が消える
+        assert data_7d["project_total"] == 1
+
+        # 7) daily_trend: 7d で 8d 前の bucket が消える
+        dates_7d = {r["date"] for r in data_7d["daily_trend"]}
+        eight_days_ago = (_FIXED_NOW - timedelta(days=8)).isoformat()[:10]
+        assert eight_days_ago not in dates_7d
+
+        # 8) project_breakdown
+        projs_7d = {r["project"] for r in data_7d["project_breakdown"]}
+        assert "p2" not in projs_7d
+
+        # 9) hourly_heatmap: 7d 適用後の bucket 件数が all より少ない
+        # (heatmap は events を rebucket するので長さでなく合計 count で比較)
+        assert sum(b["count"] for b in data_7d["hourly_heatmap"]["buckets"]) < \
+            sum(b["count"] for b in data_all["hourly_heatmap"]["buckets"])
+
+        # 10) skill_cooccurrence: 7d / all で差が出ない場合 (events 構成上 pair が無い) は両方 [] でも OK
+        assert isinstance(data_7d["skill_cooccurrence"], list)
+
+        # 11) project_skill_matrix: 7d で p2 が消える
+        if isinstance(data_7d["project_skill_matrix"], dict) and "rows" in data_7d["project_skill_matrix"]:
+            projects_in_matrix = {r["project"] for r in data_7d["project_skill_matrix"]["rows"]}
+            assert "p2" not in projects_in_matrix
+
+    def test_full_period_fields_unchanged_across_periods(self, tmp_path):
+        """全期間 8 field は period に関わらず同一 (drift guard)."""
+        mod = self._mod(tmp_path)
+        events = _make_event_set_for_period_test(_FIXED_NOW)
+        data_all = mod.build_dashboard_data(events, period="all", now=_FIXED_NOW)
+        data_7d = mod.build_dashboard_data(events, period="7d", now=_FIXED_NOW)
+
+        full_period_fields = [
+            "subagent_failure_trend",
+            "permission_prompt_skill_breakdown",
+            "permission_prompt_subagent_breakdown",
+            "compact_density",
+            "session_stats",
+            "skill_invocation_breakdown",
+            "skill_lifecycle",
+            "skill_hibernating",
+        ]
+        for field in full_period_fields:
+            assert data_all[field] == data_7d[field], \
+                f"全期間 field {field} が period 切替で drift している"
+
+    def test_now_kwarg_overrides_last_updated(self, tmp_path):
+        """now= 引数を渡したとき last_updated もそれで override される (Step 7 drift guard 用)."""
+        mod = self._mod(tmp_path)
+        data = mod.build_dashboard_data([], period="all", now=_FIXED_NOW)
+        assert data["last_updated"] == _FIXED_NOW.isoformat()
+
+
+class TestPeriodSentinelDocstring:
+    """Issue #85 sentinel pin (plan §3 Step 2 iter5 advisory #3).
+
+    `aggregate_daily(period_events_usage)` 呼び出し直前のコメントが残ることを保証する。
+    rebase / refactor で削除されると detection 不可になるリスクを test で塞ぐ。
+    """
+
+    def test_issue_85_daily_trend_sentinel(self):
+        source = (Path(__file__).parent.parent / "dashboard" / "server.py").read_text(encoding="utf-8")
+        assert "Issue #85: daily_trend stays in period-applied set" in source, \
+            "Issue #85 sentinel comment が dashboard/server.py から消えている"

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -220,6 +220,168 @@ class TestFilterEventsByPeriod:
         kept_stop_ts = datetime.fromisoformat(kept_stops[0]["timestamp"])
         assert kept_stop_ts > cutoff
 
+    def test_filter_period_lifecycle_only_invocation_pulls_outside_paired_start(self, tmp_path):
+        """第三段 (codex round 1 / Issue #85): lifecycle-only invocation の cutoff 跨ぎ。
+
+        PostToolUse(Task|Agent) が flaky な環境では `subagent_lifecycle_start` のみが
+        発火し `subagent_start` が記録されない (lifecycle-only invocation)。
+        この場合 `_pair_invocations_with_stops` は lifecycle.timestamp を anchor に
+        stop を pair するため、第三段も lifecycle を anchor として stop ↔ lifecycle の
+        cutoff 跨ぎを再 include する必要がある。
+
+        構成:
+            lifecycle_A @ cutoff-5s   (cutoff 外, 第一段 drop)
+            stop_A      @ cutoff+5s   (cutoff 内, 保持)
+
+        期待: 逆経路で stop_A → lifecycle_A を再 include (subagent_start なしで動作する)。
+        これにより `aggregate_subagent_metrics` の `failure_count` / `avg_duration_ms` /
+        pXX が period filter 後も full-data と一致する。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff - timedelta(seconds=5)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=5)).isoformat(),
+             "duration_ms": 10000, "success": False},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        types = sorted(e["event_type"] for e in out)
+        assert types == ["subagent_lifecycle_start", "subagent_stop"]
+
+        # 集計値も full と一致する (failure_count / avg_duration_ms drift しない)
+        full = mod.aggregate_subagent_metrics(events)
+        filtered = mod.aggregate_subagent_metrics(out)
+        assert filtered == full
+
+    def test_filter_period_lifecycle_only_does_not_pull_unrelated_stop(self, tmp_path):
+        """第三段 reverse 経路: 連続 2 lifecycle-only invocation で stop_A を不当に再 include しない。
+
+        構成 (同 (session_id, subagent_type) バケット):
+            lifecycle_A @ cutoff-2.0s  (cutoff 外, drop)
+            stop_A      @ cutoff-1.5s  (cutoff 外, drop)
+            lifecycle_B @ cutoff+0.3s  (cutoff 内, kept)
+            stop_B      @ cutoff+0.8s  (cutoff 内, kept)
+
+        期待: stop_A も lifecycle_A も再 include されない (lifecycle_B の paired stop は stop_B で確定)。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff - timedelta(seconds=2.0)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff - timedelta(seconds=1.5)).isoformat()},
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.3)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.8)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        kept_lifecycle = [e for e in out if e["event_type"] == "subagent_lifecycle_start"]
+        kept_stops = [e for e in out if e["event_type"] == "subagent_stop"]
+        assert len(kept_lifecycle) == 1
+        assert len(kept_stops) == 1
+        # 残存 lifecycle / stop は B 側 (cutoff 以降)
+        assert datetime.fromisoformat(kept_lifecycle[0]["timestamp"]) > cutoff
+        assert datetime.fromisoformat(kept_stops[0]["timestamp"]) > cutoff
+
+    def test_filter_period_does_not_cross_invocation_sibling_pull(self, tmp_path):
+        """第二段 (codex round 2 / Issue #85): 隣接 invocation の sibling を不当に再 include しない。
+
+        構成 (同 (session_id, subagent_type) バケット, INVOCATION_MERGE_WINDOW_SECONDS=1.0s):
+            start_A     @ cutoff-0.6s  (drop)
+            lifecycle_A @ cutoff-0.4s  (drop)
+            start_B     @ cutoff+0.4s  (kept)
+            lifecycle_B @ cutoff+0.6s  (kept)
+
+        canonical pairing (`_build_invocations` 同等): inv_A=(A,A), inv_B=(B,B).
+        kept_B が dropped lifecycle_A (start_B から 0.8s, 1s 以内) を pull する旧バグの guard。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tuA", "timestamp": (cutoff - timedelta(seconds=0.6)).isoformat()},
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff - timedelta(seconds=0.4)).isoformat()},
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tuB", "timestamp": (cutoff + timedelta(seconds=0.4)).isoformat()},
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=0.6)).isoformat()},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        # 期待: inv_B のみ (= 2 event)。inv_A の sibling は引かれない。
+        assert len(out) == 2
+        for e in out:
+            ts = datetime.fromisoformat(e["timestamp"])
+            assert ts > cutoff, f"unexpected pre-cutoff event re-included: {e}"
+
+    def test_filter_period_does_not_pull_back_future_dated_stop(self, tmp_path):
+        """第三段 (codex round 2 / Issue #85): clock skew で `ts > now` の stop を pull-back しない。
+
+        第一段は `cutoff <= ts <= now` の event のみ keep する (`ts > now` も drop)。
+        この排除を尊重し、kept_start の forward path で future-dated stop を再 include しないこと。
+
+        構成:
+            start_A @ now-0.1s     (kept)
+            stop_A  @ now+1day     (drop: ts > now, clock skew)
+        """
+        mod = self._mod(tmp_path)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tu1",
+             "timestamp": (_FIXED_NOW - timedelta(seconds=0.1)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (_FIXED_NOW + timedelta(days=1)).isoformat(),
+             "duration_ms": 9999, "success": False},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        ets = [e["event_type"] for e in out]
+        assert "subagent_stop" not in ets, f"future-dated stop pulled back: {out}"
+        assert ets == ["subagent_start"]
+
+    def test_filter_period_delayed_stop_equal_count_pairs_sequentially(self, tmp_path):
+        """第二段 (codex round 3 / Issue #85): 件数一致 bucket は sequential 1:1 pairing.
+
+        `_pair_invocations_with_stops` は `len(invocations) == len(stops)` のとき
+        sequential 1:1 zip で pair する (delayed/overlapping stops の慣習許容)。
+        period filter もこの semantics を mirror して、delayed stop_A が start_B より
+        後に届くケースで start_A を canonical pair で再 include しなければならない。
+
+        構成:
+            start_A @ cutoff-2s   (drop, 第一段)
+            start_B @ cutoff+2s   (kept)
+            stop_A  @ cutoff+5s   (kept, delayed: start_B より後に発火)
+            stop_B  @ cutoff+10s  (kept)
+
+        canonical (full) pair: A→stop_A (success), B→stop_B (failure) → count=2/failure=1
+        期待: 第二段で start_A を再 include し、period 集計が full と一致。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tuA", "timestamp": (cutoff - timedelta(seconds=2)).isoformat()},
+            {"event_type": "subagent_start", "subagent_type": "Explore", "session_id": "s",
+             "tool_use_id": "tuB", "timestamp": (cutoff + timedelta(seconds=2)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=5)).isoformat(),
+             "duration_ms": 7000, "success": True},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=10)).isoformat(),
+             "duration_ms": 8000, "success": False},
+        ]
+        out = mod._filter_events_by_period(events, "7d", now=_FIXED_NOW)
+        # start_A は再 include される (sequential pair で stop_A と pair)
+        kept_starts = [e for e in out if e["event_type"] == "subagent_start"]
+        assert {e["tool_use_id"] for e in kept_starts} == {"tuA", "tuB"}
+        # 集計値が full と一致
+        full = mod.aggregate_subagent_metrics(events)
+        filt = mod.aggregate_subagent_metrics(out)
+        assert filt == full, f"metrics drift: full={full} filt={filt}"
+
     def test_three_stage_filter_survives_filter_usage_events(self, tmp_path):
         """plan §3 Step 2 invariant (iter5 advisory #4):
         三段で再 include された stop event が `_filter_usage_events` 通過後も残る (= dedup window と同一なので脱落しない)."""
@@ -239,6 +401,40 @@ class TestFilterEventsByPeriod:
         et_set = {e["event_type"] for e in period_events_usage}
         # `_filter_usage_events` は skill_tool / user_slash_command + invocation 代表 (subagent_start) を返す
         assert "subagent_start" in et_set
+
+    def test_build_dashboard_data_lifecycle_only_pre_cutoff_rep_does_not_leak_date(self, tmp_path):
+        """build_dashboard_data (codex round 4 / Issue #85): boundary-straddling
+        lifecycle-only invocation で rep ts が pre-cutoff の場合、headline metrics
+        (daily_trend / hourly_heatmap) に pre-cutoff 日付が leak しないこと。
+
+        構成 (period=7d):
+            lifecycle @ now-8d (drop, 第一段; 第二段の canonical pair で kept に格上げ)
+            stop      @ now-7d+10s (kept, paired stop)
+
+        canonical: lifecycle-only invocation の rep は usage_invocation_events で
+        lifecycle event が選ばれるが、ts が pre-cutoff のままだと daily_trend に
+        8 日前の bucket が leak する。修正後: rep ts を paired stop ts で synthesize し、
+        daily_trend に pre-cutoff 日付が出ないこと。
+        """
+        mod = self._mod(tmp_path)
+        cutoff = _FIXED_NOW - timedelta(days=7)
+        events = [
+            {"event_type": "subagent_lifecycle_start", "subagent_type": "Explore", "session_id": "s",
+             "project": "p1",
+             "timestamp": (cutoff - timedelta(days=1)).isoformat()},
+            {"event_type": "subagent_stop", "subagent_type": "Explore", "session_id": "s",
+             "timestamp": (cutoff + timedelta(seconds=10)).isoformat(),
+             "duration_ms": 86410000, "success": False},
+        ]
+        data = mod.build_dashboard_data(events, period="7d", now=_FIXED_NOW)
+        # 8 日前の date が daily_trend に出ない
+        eight_days_ago = (_FIXED_NOW - timedelta(days=8)).isoformat()[:10]
+        dates = {r["date"] for r in data["daily_trend"]}
+        assert eight_days_ago not in dates, f"pre-cutoff date leaked into daily_trend: {dates}"
+        # subagent_ranking は full と同じ (canonical pairing で count=1, failure=1)
+        sub = {r["name"]: r for r in data["subagent_ranking"]}
+        assert sub["Explore"]["count"] == 1
+        assert sub["Explore"]["failure_count"] == 1
 
     def test_filter_period_invalid_value_falls_back_to_all(self, tmp_path):
         """`period` allow-list 外 → 'all' 相当 (= 全イベント保持) として扱う。
@@ -663,6 +859,51 @@ console.log(JSON.stringify({ callsAfterStep1, callsAfterStep2 }));
         # call-time lookup なら step1 (liveDiff 未定義) で 0 件、step2 (liveDiff 後付け) で 1 件
         assert out["callsAfterStep1"] == 0, "callsAfterStep1 must be 0 (liveDiff 未定義時に呼ばれてしまっている)"
         assert out["callsAfterStep2"] == 1, "callsAfterStep2 must be 1 (call-time lookup なら liveDiff 後付け後 invoke で 1)"
+
+    def test_period_resets_live_snapshot_before_load_and_render(self, tmp_path):
+        """codex round 4 / Issue #85: period 切替時に __livePrev を reset。
+
+        構造的 pin: 25_live_diff.js が `resetLiveSnapshot` を `window.__liveDiff` に
+        export し、05_period.js click handler が scheduleLoadAndRender の前に
+        resetLiveSnapshot を呼ぶこと。
+
+        この順序が満たされない (= reset 無しで scheduleLoadAndRender) と、
+        前 period の snapshot と新 period の snapshot で diff が走り、toast / highlight
+        に skill / project / event 数の正の delta が誤って報告される。
+        """
+        live_diff_js = (Path(__file__).parent.parent /
+                        "dashboard" / "template" / "scripts" / "25_live_diff.js").read_text(encoding="utf-8")
+        period_js = (Path(__file__).parent.parent /
+                     "dashboard" / "template" / "scripts" / "05_period.js").read_text(encoding="utf-8")
+
+        # 1) 25_live_diff.js が resetLiveSnapshot を定義し、window.__liveDiff に export している
+        assert "function resetLiveSnapshot" in live_diff_js, \
+            "25_live_diff.js に resetLiveSnapshot 関数が無い"
+        # window.__liveDiff = {...} に resetLiveSnapshot プロパティが含まれる
+        assert "resetLiveSnapshot" in live_diff_js.split("window.__liveDiff")[1].split("};")[0], \
+            "window.__liveDiff に resetLiveSnapshot を export していない"
+        # __livePrev = null にする実装である
+        import re as _re
+        m = _re.search(r"function\s+resetLiveSnapshot\s*\(\s*\)\s*\{[^}]*\}", live_diff_js)
+        assert m is not None, "resetLiveSnapshot の関数 body が読めない"
+        assert "__livePrev" in m.group(0) and "null" in m.group(0), \
+            "resetLiveSnapshot は __livePrev = null を実行すべき"
+
+        # 2) 05_period.js click handler 内で resetLiveSnapshot が scheduleLoadAndRender より先に呼ばれる。
+        # 注: ファイル先頭の comment block にも scheduleLoadAndRender 言及があるため、
+        # comment block を行ベースに stripping した body 上で順序を検査する。
+        assert "resetLiveSnapshot" in period_js, \
+            "05_period.js に resetLiveSnapshot 呼出が無い (period 切替時の false-burst diff 抑止)"
+        # 行頭が `//` の単行 comment を除外 (block comment は本ファイル内に無い)
+        code_lines = [ln for ln in period_js.splitlines() if not ln.strip().startswith("//")]
+        code_only = "\n".join(code_lines)
+        # 検査対象は実際に呼出が現れる箇所のみ。最初の resetLiveSnapshot() / scheduleLoadAndRender() を見る。
+        reset_idx = code_only.find("resetLiveSnapshot()")
+        sched_idx = code_only.find("scheduleLoadAndRender()")
+        assert reset_idx != -1, "code-only 領域に resetLiveSnapshot() 呼出が無い"
+        assert sched_idx != -1, "code-only 領域に scheduleLoadAndRender() 呼出が無い"
+        assert reset_idx < sched_idx, \
+            "resetLiveSnapshot() は scheduleLoadAndRender() より前に呼ぶ必要がある (順序が逆だと reset が間に合わない)"
 
     def test_static_export_hides_toggle(self, tmp_path):
         """plan §3 Step 4 (reviewer iter1 #2): static export では toggle を hidden にする.

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -761,6 +761,23 @@ console.log(JSON.stringify({ initial }));
         assert out["initial"] == "all", f"getCurrentPeriod() の初期値が 'all' でない: {out}"
 
 
+class TestPeriodAwareFetch:
+    """Step 5: fetch 経路で period query を載せる."""
+
+    def _mod(self, tmp_path):
+        return load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+    def test_load_and_render_uses_period_query(self, tmp_path):
+        """20_load_and_render.js の concat 結果に '/api/data?period=' + getCurrentPeriod() (or 等価) が含まれる."""
+        mod = self._mod(tmp_path)
+        bundle = mod._concat_main_js()
+        # 現状の 'fetch(\'/api/data\'' / "fetch('/api/data'" は無く、period query を含む形であること
+        assert "fetch('/api/data'," not in bundle and 'fetch("/api/data",' not in bundle, \
+            "period 不在の fetch('/api/data', ...) が残っている"
+        assert "/api/data?period=" in bundle, "fetch URL に '?period=' が無い"
+        assert "getCurrentPeriod" in bundle
+
+
 class TestConcatMainJsByteInvariant:
     """Step 4a: `_concat_main_js()` helper 切り出し refactor の byte-identical 不変条件."""
 

--- a/tests/test_dashboard_period_toggle.py
+++ b/tests/test_dashboard_period_toggle.py
@@ -778,6 +778,142 @@ class TestPeriodAwareFetch:
         assert "getCurrentPeriod" in bundle
 
 
+class TestPeriodAppliedBadge:
+    """Step 6: period_applied !== 'all' のとき該当 sub に '<period> 集計' badge prefix."""
+
+    def _mod(self, tmp_path):
+        return load_dashboard_module(tmp_path / "nonexistent.jsonl")
+
+    def _render_sub_via_node(self, mod, period_applied: str) -> dict:
+        """build_dashboard_data 結果を window.__DATA__ に注入し loadAndRender を Node で走らせて、
+        Overview/Patterns sub の textContent を回収する."""
+        import subprocess
+        import shutil
+        import json as _json
+        node = shutil.which("node")
+        if node is None:
+            import pytest as _pytest
+            _pytest.skip("node not available")
+        bundle = mod._concat_main_js()
+        # 適当な dummy data。period_applied のみ test-relevant.
+        data = {
+            "last_updated": "2026-05-01T00:00:00+00:00",
+            "total_events": 1,
+            "skill_ranking": [{"name": "x", "count": 1, "failure_count": 0, "failure_rate": 0.0}],
+            "subagent_ranking": [],
+            "skill_kinds_total": 1,
+            "subagent_kinds_total": 0,
+            "project_total": 1,
+            "daily_trend": [{"date": "2026-05-01", "count": 1}],
+            "project_breakdown": [{"project": "p", "count": 1}],
+            "hourly_heatmap": {"buckets": [], "max": 0, "total": 0},
+            "skill_cooccurrence": [],
+            "project_skill_matrix": {"projects": [], "skills": [], "rows": [], "covered": 0, "total": 0},
+            "subagent_failure_trend": {"weeks": [], "series": []},
+            "permission_prompt_skill_breakdown": [],
+            "permission_prompt_subagent_breakdown": [],
+            "compact_density": {"hist": [], "worst": []},
+            "session_stats": {"total_sessions": 1, "resume_rate": 0, "compact_count": 0, "permission_prompt_count": 0},
+            "health_alerts": [],
+            "skill_invocation_breakdown": [],
+            "skill_lifecycle": [],
+            "skill_hibernating": {"items": [], "active_excluded_count": 0, "scope_note": ""},
+            "period_applied": period_applied,
+        }
+
+        # element store: id -> { textContent, _html }
+        script = r"""
+process.on("unhandledRejection", () => {});
+const store = {};
+function makeEl(id) {
+  if (!store[id]) {
+    store[id] = {
+      id,
+      textContent: "",
+      innerHTML: "",
+      hidden: false,
+      classList: { add: () => {}, remove: () => {}, contains: () => false, toggle: () => {} },
+      _attrs: {},
+      dataset: {},
+      style: {},
+      setAttribute: function(k, v) { this._attrs[k] = v; },
+      getAttribute: function(k) { return this._attrs[k] || null; },
+      removeAttribute: function(k) { delete this._attrs[k]; },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      appendChild: () => {},
+      insertBefore: () => {},
+      remove: () => {},
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      contains: () => false,
+      closest: () => null,
+      offsetWidth: 0,
+    };
+  }
+  return store[id];
+}
+globalThis.window = { __DATA__: JSON.parse(process.env.DATA), addEventListener: () => {}, location: { hash: "" } };
+globalThis.document = {
+  body: { dataset: {}, classList: { add: () => {}, remove: () => {}, contains: () => false } },
+  getElementById: (id) => makeEl(id),
+  querySelectorAll: () => [],
+  querySelector: () => null,
+  createElement: (tag) => makeEl("__el_" + Math.random()),
+  createElementNS: (ns, tag) => makeEl("__el_" + Math.random()),
+  addEventListener: () => {},
+};
+globalThis.fetch = async () => ({ ok: true, json: async () => JSON.parse(process.env.DATA) });
+globalThis.EventSource = undefined;
+try { eval("(async function(){" + process.env.BUNDLE + "})();"); } catch (e) {}
+
+// 同期評価で 70_init_eventsource.js は await 待ちするので、ここで明示的に少し待つ必要は無く、
+// loadAndRender は scheduleLoadAndRender → microtask で動く。一度 process.nextTick を使って flush。
+setImmediate(() => {
+  setImmediate(() => {
+    const out = {};
+    for (const id of Object.keys(store)) {
+      out[id] = store[id].textContent || "";
+    }
+    console.log(JSON.stringify(out));
+    process.exit(0);
+  });
+});
+"""
+        result = subprocess.run(
+            [node, "-e", script],
+            env={**os.environ, "BUNDLE": bundle, "DATA": _json.dumps(data)},
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, f"node failed: stderr={result.stderr}"
+        lines = [ln for ln in result.stdout.strip().splitlines() if ln.strip().startswith("{")]
+        assert lines, f"no JSON output: stdout={result.stdout!r}"
+        return _json.loads(lines[-1])
+
+    def test_badge_appears_when_period_applied_is_7d(self, tmp_path):
+        mod = self._mod(tmp_path)
+        out = self._render_sub_via_node(mod, "7d")
+        # Overview の sub 4 つ + Patterns sub 3 つに '7d' badge 文字列が prefix される
+        for sub_id in ("dailySub", "skillSub", "subSub", "projSub",
+                       "patterns-heatmap-sub"):
+            text = out.get(sub_id, "")
+            # 何らかのテキストがあり、かつ '7d' が含まれる (badge format は plan §3 Step 8 で <period> 集計)
+            if text:
+                assert "7d" in text, f"{sub_id} に '7d' badge が無い: {text!r}"
+
+    def test_badge_absent_when_period_applied_is_all(self, tmp_path):
+        mod = self._mod(tmp_path)
+        out = self._render_sub_via_node(mod, "all")
+        for sub_id in ("dailySub", "skillSub", "subSub", "projSub"):
+            text = out.get(sub_id, "")
+            # 'all' のとき "7d" / "30d" / "90d" のような badge 文字列は付かない
+            for not_expected in ("7d 集計", "30d 集計", "90d 集計"):
+                assert not_expected not in text, \
+                    f"{sub_id} に period=all で {not_expected!r} が出ている: {text!r}"
+
+
 class TestConcatMainJsByteInvariant:
     """Step 4a: `_concat_main_js()` helper 切り出し refactor の byte-identical 不変条件."""
 

--- a/tests/test_dashboard_router.py
+++ b/tests/test_dashboard_router.py
@@ -158,6 +158,7 @@ class TestBackwardCompatibility:
         """static export 経路: window.__DATA__ は fetch より先に参照される"""
         template = _load_template()
         window_data_pos = template.index('window.__DATA__')
-        fetch_pos = template.index("fetch('/api/data'")
+        # Issue #85: fetch URL に period query が乗ったため substring を変更
+        fetch_pos = template.index("fetch(__apiUrl")
         assert window_data_pos < fetch_pos, \
-            "window.__DATA__ must be checked before fetch('/api/data') for static export compat"
+            "window.__DATA__ must be checked before fetch for static export compat"

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -47,7 +47,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 5883a091...: Issue #83 user follow-up tweak / 明滅周期を 1s → 3s に調整 (呼吸テンポ感 / ambient indicator として落ち着いた pulse)
 #   - 28745c0d...: v0.7.2 release / footer の version 表記 v0.7.1 → v0.7.2 に bump
 #   - 7b1575a2...: Issue #85 / Dashboard period toggle (05_period.js + period-toggle DOM/CSS / shell.html nav に periodToggle / 30_pages.css に .period-toggle + page-scoped hide / 20_load_and_render.js fetch URL に period query + sub badge prefix / 30_renderers_patterns.js renderer 第 2 引数で badge 受領)
-EXPECTED_TEMPLATE_SHA256 = "7b1575a2a19c87cb0afbdbb9fa28d4635db83b519e633c7dab09183a08f34718"
+#   - 043e5666...: Issue #85 codex Round 4 fix-up / 25_live_diff.js に resetLiveSnapshot を追加 + 05_period.js click handler で period 切替時に resetLiveSnapshot 呼出 (前 period snapshot と新 period snapshot の false-burst diff 抑止)
+EXPECTED_TEMPLATE_SHA256 = "043e56662b7f756fa3497607e0b009eab3c27a31cd021ab78f49aa7dccc13710"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -48,7 +48,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 28745c0d...: v0.7.2 release / footer の version 表記 v0.7.1 → v0.7.2 に bump
 #   - 7b1575a2...: Issue #85 / Dashboard period toggle (05_period.js + period-toggle DOM/CSS / shell.html nav に periodToggle / 30_pages.css に .period-toggle + page-scoped hide / 20_load_and_render.js fetch URL に period query + sub badge prefix / 30_renderers_patterns.js renderer 第 2 引数で badge 受領)
 #   - 043e5666...: Issue #85 codex Round 4 fix-up / 25_live_diff.js に resetLiveSnapshot を追加 + 05_period.js click handler で period 切替時に resetLiveSnapshot 呼出 (前 period snapshot と新 period snapshot の false-burst diff 抑止)
-EXPECTED_TEMPLATE_SHA256 = "043e56662b7f756fa3497607e0b009eab3c27a31cd021ab78f49aa7dccc13710"
+#   - 34734785...: Issue #85 follow-up / トグルを各 page header の右端に移動 (shell.html nav から除去 + Overview/Patterns 各 header に data-period-slot / 30_pages.css に .period-toggle-slot 追加 / 05_period.js に movePeriodToggleToActivePage + hashchange listener)
+EXPECTED_TEMPLATE_SHA256 = "34734785b10c9b9cb25090c1a20777a8fd281f03c858d1e136b0c47ab8934dcb"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -46,7 +46,8 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 #   - 4b429ad2...: Issue #83 user follow-up / heartbeat 線そのものを常時明滅 (CSS @keyframes heartbeat-pulse で stroke-opacity を 1.0 ↔ 0.4 で 1s 周期、state 別 opacity と独立軸)
 #   - 5883a091...: Issue #83 user follow-up tweak / 明滅周期を 1s → 3s に調整 (呼吸テンポ感 / ambient indicator として落ち着いた pulse)
 #   - 28745c0d...: v0.7.2 release / footer の version 表記 v0.7.1 → v0.7.2 に bump
-EXPECTED_TEMPLATE_SHA256 = "28745c0d8e0cc540f9ec2a6d75ff154a21ed1f1bcfd226f94b43a2eabca13567"
+#   - 7b1575a2...: Issue #85 / Dashboard period toggle (05_period.js + period-toggle DOM/CSS / shell.html nav に periodToggle / 30_pages.css に .period-toggle + page-scoped hide / 20_load_and_render.js fetch URL に period query + sub badge prefix / 30_renderers_patterns.js renderer 第 2 引数で badge 受領)
+EXPECTED_TEMPLATE_SHA256 = "7b1575a2a19c87cb0afbdbb9fa28d4635db83b519e633c7dab09183a08f34718"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -83,14 +83,16 @@ class TestHtmlTemplateFallback:
     def test_template_has_dynamic_fallback_fetch(self):
         """動的ダッシュボードとしても機能するよう fetch フォールバックが残っていることを確認。"""
         m = self._import()
-        assert "fetch('/api/data'" in m._HTML_TEMPLATE
+        # Issue #85: fetch URL は `'/api/data?period=' + ...` に変わった (period query が常に乗る)
+        assert "/api/data?period=" in m._HTML_TEMPLATE
 
     def test_template_prefers_window_data_over_fetch(self):
         """window.__DATA__ が fetch より先に参照されることを確認。"""
         m = self._import()
         tmpl = m._HTML_TEMPLATE
         window_data_pos = tmpl.index("window.__DATA__")
-        fetch_pos = tmpl.index("fetch('/api/data'")
+        # Issue #85: fetch 直接ではなく __apiUrl 変数経由 (period query を組み立てる)
+        fetch_pos = tmpl.index("fetch(__apiUrl")
         assert window_data_pos < fetch_pos
 
     def test_template_uses_static_badge_for_window_data(self):


### PR DESCRIPTION
## Summary

- Dashboard の Overview / Patterns ページに **`7d / 30d / 90d / 全期間` の期間トグル** を導入。Quality / Surface / `session_stats` は常に全期間。
- `/api/data?period=<v>` で server-side filter → response に `period_applied` を additive echo。古い frontend は読まないので backward-compat。
- `_filter_events_by_period` の三段 pair-straddling filter は `subagent_metrics._pair_invocations_with_stops` の canonical pairing semantics に完全準拠 (codex review 5 ラウンド経由で構造的 drift を塞いだ)。

Closes #85

## Period 適用 scope

| Bucket | Field |
|---|---|
| **Period 適用 (11)** | KPI 4 (`total_events` / `skill_kinds_total` / `subagent_kinds_total` / `project_total`) + Overview 4 (`skill_ranking` / `subagent_ranking` / `daily_trend` / `project_breakdown`) + Patterns 3 (`hourly_heatmap` / `skill_cooccurrence` / `project_skill_matrix`) |
| **全期間 (8)** | Quality 4 (`subagent_failure_trend` / `permission_prompt_skill_breakdown` / `permission_prompt_subagent_breakdown` / `compact_density`) + Surface 3 (`skill_invocation_breakdown` / `skill_lifecycle` / `skill_hibernating`) + `session_stats` |
| **filter 対象外 (3)** | `last_updated` / `health_alerts` / `period_applied` |

## Commit 構成

TDD で 11 commits に分割:

| Commit | Step | 内容 |
|---|---|---|
| `261fdc0` | 1 | `_filter_events_by_period` helper (rolling window + 三段 pair-straddling) |
| `70c80ce` | 2 | `build_dashboard_data(period=, now=)` 拡張 + Issue #85 sentinel + `period_applied` echo |
| `199f273` | 3 | `/api/data?period=` query parsing + allow-list fallback |
| `b9ab4d7` | 4a | `_concat_main_js()` helper 切り出し refactor (byte-identical) |
| `bf33a3d` | 4b | `05_period.js` + toggle DOM + page-scoped CSS hide + static-export 隠蔽 |
| `f486556` | 5 | fetch URL に `?period=` query を載せる (call-time lookup で SSE refresh も新 period 反映) |
| `068048d` | 6 | Overview/Patterns sub に `<period> 集計 ·` badge prefix |
| `9113b38` | 7 | drift guard test + static export `?period=` 不在 pin |
| `9c99d6b` | 8 | docs (`dashboard-api.md` / `dashboard-runtime.md`) |
| `7c76f12` | 9 | `EXPECTED_TEMPLATE_SHA256` 累積 bump |
| `ba0492e` | – | **codex review 5 ラウンドの 6 findings 修正** (P1×3 / P2×3 / P3×1) |

## Codex review fixes (`ba0492e`)

5 ラウンドで収束。各 finding に regression test 追加:

- **R1 P2** lifecycle-only invocation の anchor 拡張
- **R2 P2** 隣接 invocation の sibling cross-pull 防止
- **R2 P3** clock-skew future-dated stop pull-back 防止
- **R3 P1** sequential 1:1 pairing 分岐の canonical 移植
- **R4 P1** boundary-straddling lifecycle の rep ts を paired stop ts で synthesize
- **R4 P2** period 切替時の false-burst toast 抑止 (`resetLiveSnapshot()` API)

Round 5: in-code bug 0 件 → converged。

## 設計判断 (plan §5 抜粋)

- **UI 配置**: 案 A (`<nav class="page-nav">` 内に 1 DOM + page-scoped CSS hide) を採用。実装複雑度が低く router 既存契約 (`body.dataset.activePage`) に乗る。
- **Rolling vs calendar window**: rolling (`now - timedelta(days=N)`) を採用。`aggregate_skill_lifecycle` / `aggregate_skill_hibernating` の既存慣習と一貫。
- **永続化なし**: reload で `'all'` リセット仕様 (URL hash 同期 / localStorage は将来 issue)。
- **Static export**: `wirePeriodToggle()` 冒頭で `window.__DATA__` 検出 → toggle 隠蔽 + click bind skip (server を経由しないので意味がない)。

## Out of scope (将来 issue で再検討)

- Quality / Surface ページに period 適用
- Period 選択の永続化 (localStorage / URL hash)
- `reports/export_html.py` への period 対応 (常に全期間)
- archive/*.jsonl.gz opt-in との連携
- Calendar window (sparkline 境界が partial day 気になるフィードバック出たら)

## Test plan

- [x] `python3 -m pytest tests/` 全 1031 件 passed (1 skipped)
- [x] codex-review 5 ラウンドで converged (0 findings)
- [x] `EXPECTED_TEMPLATE_SHA256` bump 済み (`043e5666...`)
- [ ] 手元で dashboard を起動して 7d/30d/90d/all を切り替え、Overview/Patterns sub に badge prefix が出ることを目視確認
- [ ] Quality / Surface ページに切り替えると toggle が CSS で隠れることを確認
- [ ] static export (`/usage-export-html`) で toggle が hidden 属性付きで生成されることを確認
- [ ] period 切替直後の SSE refresh で false-burst toast が出ないことを確認 (R4 P2 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)