### PR TITLE
feat(dashboard): Sessions ページ (5番目タブ + 推計コスト) (#103)

### DIFF
--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -1158,6 +1158,7 @@ _CSS_FILES = (
     "30_pages.css",         # multipage shell (Issue #57)
     "40_patterns.css",      # hourly heatmap + skill cooccurrence + project×skill (Issue #58/59)
     "50_quality.css",       # subagent percentile/failure + permission breakdown + compact density (Issue #60/61)
+    "55_sessions.css",      # Sessions table + KPI 4 枚 + cost meter / model chip / tier chip (Issue #103)
     "60_surface.css",       # Surface 3 panel + tooltip border colors (Issue #74)
 )
 _MAIN_JS_FILES = (
@@ -1168,6 +1169,7 @@ _MAIN_JS_FILES = (
     "25_live_diff.js",            # live mode 差分 highlight + toast (Issue #69)
     "30_renderers_patterns.js",   # heatmap / cooccurrence / project×skill matrix renderers
     "40_renderers_quality.js",    # subagent percentile / failure / permission / compact renderers
+    "45_renderers_sessions.js",   # Sessions table renderer + KPI 4 cards (Issue #103)
     "50_renderers_surface.js",    # Surface invocation / lifecycle / hibernating + fmtDur
     "60_hashchange_listener.js",  # hashchange → loadAndRender 再実行 (Issue #58 Q2)
     "70_init_eventsource.js",     # 初回描画 + EventSource (live refresh)

--- a/dashboard/template/scripts/00_router.js
+++ b/dashboard/template/scripts/00_router.js
@@ -12,6 +12,7 @@
     '#/patterns': 'patterns',
     '#/quality': 'quality',
     '#/surface': 'surface',
+    '#/sessions': 'sessions',
   };
   function applyRoute(rawHash) {
     // 未知 hash (`#/foo`, `#bar`, percent-encoded など) は overview に倒す

--- a/dashboard/template/scripts/20_load_and_render.js
+++ b/dashboard/template/scripts/20_load_and_render.js
@@ -281,6 +281,13 @@
   renderSkillLifecycle(data.skill_lifecycle);
   renderSkillHibernating(data.skill_hibernating);
 
+  // ---- Sessions page (Issue #103) ----
+  // window.__sessions に IIFE が expose した renderSessions を call-time lookup する。
+  // 45_renderers_sessions.js は concat 順 45 で評価済 → 本 call 時には常に存在。
+  if (typeof window !== 'undefined' && window.__sessions && typeof window.__sessions.renderSessions === 'function') {
+    window.__sessions.renderSessions(data);
+  }
+
   // dynamic re-render 後の help-pop 再配置 (Issue #41)。kpiRow を含む全 popup を
   // walk して、右端 KPI tooltip の viewport overflow を防ぐ。
   placeAllPops();

--- a/dashboard/template/scripts/45_renderers_sessions.js
+++ b/dashboard/template/scripts/45_renderers_sessions.js
@@ -98,7 +98,12 @@
       const costs = list.map(function(s){ return Number(s.estimated_cost_usd) || 0; });
       const totalCost = costs.reduce(function(a,b){ return a + b; }, 0);
       const sorted = costs.slice().sort(function(a,b){ return a - b; });
-      const median = sorted[Math.floor(sorted.length / 2)];
+      // 偶数件では中央 2 値の平均、奇数件では中央値そのもの (= true median)。
+      // TOP_N_SESSIONS = 20 (偶数) が常用ケースなので、偶数の正しさが UX 上 load-bearing。
+      const n = sorted.length;
+      const median = (n % 2 === 0)
+        ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2
+        : sorted[Math.floor(n / 2)];
       const avg = totalCost / list.length;
 
       let inputSum = 0;

--- a/dashboard/template/scripts/45_renderers_sessions.js
+++ b/dashboard/template/scripts/45_renderers_sessions.js
@@ -1,0 +1,251 @@
+  // ============================================================
+  //  Sessions ページ renderer (Issue #103)
+  //  ----------------------------------------------------------
+  //  data.session_breakdown (cost_metrics.aggregate_session_breakdown 由来) を
+  //  受け取り、KPI 行 4 枚 + 12 列の table を描画する。
+  //
+  //  pure helpers (formatCostUsd / fmtTokens / inferModelFamily /
+  //  buildModelChips / buildTierChips / buildSessionRow / computeKpi /
+  //  buildKpiHTML) は window.__sessions に expose し、Node round-trip
+  //  test (tests/test_dashboard_sessions_ui.py) から個別呼び出して検証する。
+  //
+  //  page-scoped early-out: body[data-active-page="sessions"] 以外では
+  //  DOM を触らない (Surface / Quality 系 renderer 慣習踏襲)。
+  // ============================================================
+  (function(){
+    function formatCostUsd(n) {
+      const v = Number(n);
+      if (!isFinite(v)) return '$0.0000';
+      return '$' + v.toFixed(4);
+    }
+
+    function fmtTokens(n) {
+      const v = Number(n);
+      if (!isFinite(v) || v <= 0) return '0';
+      if (v >= 1000000) return (v / 1000000).toFixed(1) + 'M';
+      if (v >= 1000) return (v / 1000).toFixed(1) + 'k';
+      return String(Math.round(v));
+    }
+
+    // 未知 model 名 → sonnet fallback (cost_metrics.calculate_message_cost と整合)
+    function inferModelFamily(model) {
+      const m = String(model || '').toLowerCase();
+      if (m.indexOf('opus') !== -1) return 'opus';
+      if (m.indexOf('haiku') !== -1) return 'haiku';
+      if (m.indexOf('sonnet') !== -1) return 'sonnet';
+      return 'sonnet';
+    }
+
+    function buildModelChips(models) {
+      if (!models || typeof models !== 'object') return '<span class="dim">—</span>';
+      const entries = Object.keys(models).map(k => [k, Number(models[k]) || 0])
+                          .filter(e => e[1] > 0)
+                          .sort((a, b) => b[1] - a[1]);
+      if (entries.length === 0) return '<span class="dim">—</span>';
+      return '<div class="model-chips">' + entries.map(function(pair) {
+        const name = pair[0];
+        const count = pair[1];
+        const family = inferModelFamily(name);
+        return '<span class="model-chip m-' + family + '">' +
+          esc(family) + ' <span class="ct">' + count + '</span></span>';
+      }).join('') + '</div>';
+    }
+
+    function buildTierChips(tiers) {
+      if (!tiers || typeof tiers !== 'object') return '<span class="dim">—</span>';
+      const KNOWN = { priority: 1, standard: 1, batch: 1 };
+      const entries = Object.keys(tiers).map(k => [k, Number(tiers[k]) || 0])
+                          .filter(e => e[1] > 0)
+                          .sort((a, b) => b[1] - a[1]);
+      if (entries.length === 0) return '<span class="dim">—</span>';
+      return '<div class="tier-chips">' + entries.map(function(pair) {
+        const name = pair[0];
+        const count = pair[1];
+        const cls = KNOWN[name] ? name : 'standard';
+        return '<span class="tier-chip t-' + cls + '">' +
+          esc(name) + ' <span class="ct">' + count + '</span></span>';
+      }).join('') + '</div>';
+    }
+
+    // 開始時刻を local TZ で "MM/DD HH:mm" 形式に整形
+    function formatStartedAt(iso) {
+      if (!iso) return '';
+      const dt = new Date(iso);
+      if (isNaN(dt.getTime())) return '';
+      return pad(dt.getMonth() + 1, 2) + '/' + pad(dt.getDate(), 2) + ' ' +
+        pad(dt.getHours(), 2) + ':' + pad(dt.getMinutes(), 2);
+    }
+
+    function formatDuration(secs) {
+      if (secs == null) return '—';
+      const v = Number(secs);
+      if (!isFinite(v)) return '—';
+      const s = Math.max(0, Math.floor(v));
+      const h = Math.floor(s / 3600);
+      const m = Math.floor((s % 3600) / 60);
+      if (h > 0) return h + 'h ' + m + 'm';
+      if (m > 0) return m + 'm';
+      return s + 's';
+    }
+
+    function computeKpi(sessions) {
+      const list = Array.isArray(sessions) ? sessions : [];
+      if (list.length === 0) {
+        return { totalCost: 0, medianCost: 0, avgCost: 0, cacheEfficiency: 0,
+                 topCost: 0, minCost: 0, sessionCount: 0,
+                 totalInputTokens: 0, totalCacheReadTokens: 0 };
+      }
+      const costs = list.map(function(s){ return Number(s.estimated_cost_usd) || 0; });
+      const totalCost = costs.reduce(function(a,b){ return a + b; }, 0);
+      const sorted = costs.slice().sort(function(a,b){ return a - b; });
+      const median = sorted[Math.floor(sorted.length / 2)];
+      const avg = totalCost / list.length;
+
+      let inputSum = 0;
+      let cacheReadSum = 0;
+      for (let i = 0; i < list.length; i++) {
+        const t = list[i].tokens || {};
+        inputSum += Number(t.input || 0);
+        cacheReadSum += Number(t.cache_read || 0);
+      }
+      const denom = inputSum + cacheReadSum;
+      const cacheEfficiency = denom > 0 ? (cacheReadSum / denom) : 0;
+
+      return {
+        totalCost: totalCost,
+        medianCost: median,
+        avgCost: avg,
+        cacheEfficiency: cacheEfficiency,
+        topCost: sorted[sorted.length - 1] || 0,
+        minCost: sorted[0] || 0,
+        sessionCount: list.length,
+        totalInputTokens: inputSum,
+        totalCacheReadTokens: cacheReadSum,
+      };
+    }
+
+    function buildSessionRow(s, maxCost) {
+      const isActive = !s.ended_at;
+      const cost = Number(s.estimated_cost_usd) || 0;
+      const isWhale = (maxCost > 0) && (cost === maxCost);
+      const costPct = maxCost > 0 ? Math.round((cost / maxCost) * 100) : 0;
+
+      const classes = [];
+      if (isActive) classes.push('is-active');
+      if (isWhale) classes.push('is-whale');
+
+      const startCell = formatStartedAt(s.started_at);
+      const durHtml = isActive
+        ? '<span class="live-pill">進行中</span>'
+        : esc(formatDuration(s.duration_seconds));
+      const durTdCls = isActive ? '' : ' class="sess-dur"';
+
+      const tokens = s.tokens || {};
+      const skillCount = Number(s.skill_count || 0);
+      const subagentCount = Number(s.subagent_count || 0);
+      const skillCls = skillCount > 0 ? 'count-pos' : 'count-zero';
+      const subCls = subagentCount > 0 ? 'count-pos' : 'count-zero';
+
+      const classAttr = classes.length ? ' class="' + classes.join(' ') + '"' : '';
+
+      return '<tr' + classAttr + ' tabindex="0">' +
+        '<td class="sess-time">' + esc(startCell) + '</td>' +
+        '<td' + durTdCls + '>' + durHtml + '</td>' +
+        '<td class="sess-proj">' + esc(s.project || '') + '</td>' +
+        '<td>' + buildModelChips(s.models) + '</td>' +
+        '<td class="num">' + esc(fmtTokens(tokens.input)) + '</td>' +
+        '<td class="num">' + esc(fmtTokens(tokens.output)) + '</td>' +
+        '<td class="num tok-cr sess-tok-cache">' + esc(fmtTokens(tokens.cache_read)) + '</td>' +
+        '<td class="num tok-cc sess-tok-cache">' + esc(fmtTokens(tokens.cache_creation)) + '</td>' +
+        '<td>' +
+          '<div class="cost-cell" style="--cost-pct: ' + costPct + '%;">' +
+            '<span class="cost-val">' + formatCostUsd(cost) + '</span>' +
+            '<span class="cost-bar"></span>' +
+          '</div>' +
+        '</td>' +
+        '<td>' + buildTierChips(s.service_tier_breakdown) + '</td>' +
+        '<td class="num ' + skillCls + '">' + skillCount + '</td>' +
+        '<td class="num ' + subCls + '">' + subagentCount + '</td>' +
+        '</tr>';
+    }
+
+    function buildKpiHTML(kpi) {
+      // 直近 N 件 合計コスト / 中央値 / 平均 / Cache 効率 — mock の決定通り 4 枚
+      const totalLabel = '直近' + (kpi.sessionCount || 0) + '件 合計コスト';
+      const cacheRead = kpi.totalCacheReadTokens || 0;
+      const cacheDenom = (kpi.totalInputTokens || 0) + cacheRead;
+      const cacheSubText = (cacheDenom > 0)
+        ? 'cache_read <em>' + esc(fmtTokens(cacheRead)) + '</em> / 入力合計 <em>' +
+          esc(fmtTokens(cacheDenom)) + '</em> tokens'
+        : 'no data';
+      const cards = [
+        { id: 'kpi-sess-total', cls: '', k: totalLabel, v: formatCostUsd(kpi.totalCost), s: '' },
+        { id: 'kpi-sess-median', cls: 'c-coral', k: 'セッション中央値', v: formatCostUsd(kpi.medianCost), s: '最大 <em>' + formatCostUsd(kpi.topCost) + '</em> · 最小 <em>' + formatCostUsd(kpi.minCost) + '</em>' },
+        { id: 'kpi-sess-avg', cls: 'c-peri', k: 'セッション平均', v: formatCostUsd(kpi.avgCost), s: '' },
+        { id: 'kpi-sess-cache', cls: 'c-peach', k: 'Cache 効率', v: Math.round((kpi.cacheEfficiency || 0) * 100) + '%', s: cacheSubText },
+      ];
+      return cards.map(function(g){
+        return '<div class="kpi ' + g.cls + '" id="' + g.id + '">' +
+          '<div class="k-row"><span class="k">' + esc(g.k) + '</span></div>' +
+          '<div class="v sm">' + g.v + '</div>' +
+          (g.s ? '<div class="s">' + g.s + '</div>' : '<div class="s">&nbsp;</div>') +
+        '</div>';
+      }).join('');
+    }
+
+    function renderSessions(data) {
+      if (typeof document === 'undefined') return;
+      if (document.body && document.body.dataset.activePage !== 'sessions') return;
+
+      const sessions = (data && Array.isArray(data.session_breakdown)) ? data.session_breakdown : [];
+      const tbody = document.querySelector('#sessionsTable tbody');
+      const kpiRow = document.getElementById('sessionsKpi');
+      const sub = document.getElementById('sessionsSub');
+
+      const kpi = computeKpi(sessions);
+      const maxCost = kpi.topCost;
+
+      if (kpiRow) {
+        kpiRow.innerHTML = buildKpiHTML(kpi);
+      }
+
+      if (tbody) {
+        if (sessions.length === 0) {
+          tbody.innerHTML = '<tr><td colspan="12" class="empty" style="text-align:center;color:var(--ink-faint);padding:20px;">no data</td></tr>';
+        } else {
+          tbody.innerHTML = sessions.map(function(s){ return buildSessionRow(s, maxCost); }).join('');
+        }
+      }
+
+      if (sub) {
+        const projectSet = {};
+        for (let i = 0; i < sessions.length; i++) {
+          const p = sessions[i].project || '';
+          if (p) projectSet[p] = 1;
+        }
+        const projCount = Object.keys(projectSet).length;
+        sub.textContent = sessions.length + ' sessions · ' + projCount + ' projects';
+      }
+
+      // help-pop の位置調整 (右端の help-pop が viewport を溢れないよう)
+      if (typeof placeAllPops === 'function') {
+        placeAllPops();
+      }
+    }
+
+    if (typeof window !== 'undefined') {
+      window.__sessions = {
+        renderSessions: renderSessions,
+        formatCostUsd: formatCostUsd,
+        fmtTokens: fmtTokens,
+        inferModelFamily: inferModelFamily,
+        buildModelChips: buildModelChips,
+        buildTierChips: buildTierChips,
+        formatStartedAt: formatStartedAt,
+        formatDuration: formatDuration,
+        buildSessionRow: buildSessionRow,
+        buildKpiHTML: buildKpiHTML,
+        computeKpi: computeKpi,
+      };
+    }
+  })();

--- a/dashboard/template/scripts/45_renderers_sessions.js
+++ b/dashboard/template/scripts/45_renderers_sessions.js
@@ -215,10 +215,15 @@
         '</em> · 最小 <em>' + formatCostUsd(kpi.minCost) + '</em>';
 
       // 3 枚目 (平均) の sub: 中央値倍率 + 上位 1 件寄与率 (whale 偏りの可視化)。
-      // median = 0 のとき (中央値が 0 USD) は倍率が無限大になるので非表示。
-      const avgSubText = (kpi.medianCost > 0 && kpi.totalCost > 0)
-        ? '中央値の <em>' + (kpi.medianMultiple).toFixed(1) +
-          '×</em> · 上位 1 件で <em>' + Math.round((kpi.topCostShare || 0) * 100) + '%</em> 寄与'
+      // totalCost > 0 ならば必ず sub を出す。median = 0 (= cost=0 session が半数以上)
+      // の degenerate case では倍率が定義不可なので「—×」で dash fallback、上位 1 件
+      // 比率は totalCost で常に計算可能なので並べて表示する。
+      const avgMultText = (kpi.medianMultiple > 0)
+        ? kpi.medianMultiple.toFixed(1) + '×'
+        : '—';
+      const avgSubText = (kpi.totalCost > 0)
+        ? '中央値の <em>' + avgMultText + '</em> · 上位 1 件で <em>' +
+          Math.round((kpi.topCostShare || 0) * 100) + '%</em> 寄与'
         : '';
 
       // 4 枚目 (Cache 効率) の sub: cache_read と入力合計の内訳

--- a/dashboard/template/scripts/45_renderers_sessions.js
+++ b/dashboard/template/scripts/45_renderers_sessions.js
@@ -93,7 +93,9 @@
       if (list.length === 0) {
         return { totalCost: 0, medianCost: 0, avgCost: 0, cacheEfficiency: 0,
                  topCost: 0, minCost: 0, sessionCount: 0,
-                 totalInputTokens: 0, totalCacheReadTokens: 0 };
+                 totalInputTokens: 0, totalCacheReadTokens: 0,
+                 opusCost: 0, opusShare: 0,
+                 medianMultiple: 0, topCostShare: 0 };
       }
       const costs = list.map(function(s){ return Number(s.estimated_cost_usd) || 0; });
       const totalCost = costs.reduce(function(a,b){ return a + b; }, 0);
@@ -105,27 +107,51 @@
         ? (sorted[n / 2 - 1] + sorted[n / 2]) / 2
         : sorted[Math.floor(n / 2)];
       const avg = totalCost / list.length;
+      const topCost = sorted[sorted.length - 1] || 0;
 
       let inputSum = 0;
       let cacheReadSum = 0;
+      // opus 系 model が含まれる session の cost を別集計 (1 枚目 KPI sub 用):
+      //   "うち opus セッション $X.XX (Y%)"
+      // 同 session 内に opus / sonnet 混在しても按分はしない (= "opus が使われた session"
+      // 単位の合計)。mock との文言整合を優先。
+      let opusCost = 0;
       for (let i = 0; i < list.length; i++) {
         const t = list[i].tokens || {};
         inputSum += Number(t.input || 0);
         cacheReadSum += Number(t.cache_read || 0);
+
+        const models = list[i].models || {};
+        let hasOpus = false;
+        for (const m in models) {
+          if (Object.prototype.hasOwnProperty.call(models, m) &&
+              inferModelFamily(m) === 'opus' && (Number(models[m]) || 0) > 0) {
+            hasOpus = true;
+            break;
+          }
+        }
+        if (hasOpus) opusCost += Number(list[i].estimated_cost_usd) || 0;
       }
       const denom = inputSum + cacheReadSum;
       const cacheEfficiency = denom > 0 ? (cacheReadSum / denom) : 0;
+      const opusShare = totalCost > 0 ? (opusCost / totalCost) : 0;
+      const medianMultiple = median > 0 ? (avg / median) : 0;
+      const topCostShare = totalCost > 0 ? (topCost / totalCost) : 0;
 
       return {
         totalCost: totalCost,
         medianCost: median,
         avgCost: avg,
         cacheEfficiency: cacheEfficiency,
-        topCost: sorted[sorted.length - 1] || 0,
+        topCost: topCost,
         minCost: sorted[0] || 0,
         sessionCount: list.length,
         totalInputTokens: inputSum,
         totalCacheReadTokens: cacheReadSum,
+        opusCost: opusCost,
+        opusShare: opusShare,
+        medianMultiple: medianMultiple,
+        topCostShare: topCostShare,
       };
     }
 
@@ -177,22 +203,45 @@
     function buildKpiHTML(kpi) {
       // 直近 N 件 合計コスト / 中央値 / 平均 / Cache 効率 — mock の決定通り 4 枚
       const totalLabel = '直近' + (kpi.sessionCount || 0) + '件 合計コスト';
+
+      // 1 枚目 (合計コスト) の sub: opus セッションの cost 比率。0 のときは空表示。
+      const opusSubText = (kpi.opusCost > 0 && kpi.totalCost > 0)
+        ? 'うち opus セッション <em>' + formatCostUsd(kpi.opusCost) +
+          '</em> (' + Math.round((kpi.opusShare || 0) * 100) + '%)'
+        : '';
+
+      // 2 枚目 (中央値) の sub: 最大 / 最小
+      const medianSubText = '最大 <em>' + formatCostUsd(kpi.topCost) +
+        '</em> · 最小 <em>' + formatCostUsd(kpi.minCost) + '</em>';
+
+      // 3 枚目 (平均) の sub: 中央値倍率 + 上位 1 件寄与率 (whale 偏りの可視化)。
+      // median = 0 のとき (中央値が 0 USD) は倍率が無限大になるので非表示。
+      const avgSubText = (kpi.medianCost > 0 && kpi.totalCost > 0)
+        ? '中央値の <em>' + (kpi.medianMultiple).toFixed(1) +
+          '×</em> · 上位 1 件で <em>' + Math.round((kpi.topCostShare || 0) * 100) + '%</em> 寄与'
+        : '';
+
+      // 4 枚目 (Cache 効率) の sub: cache_read と入力合計の内訳
       const cacheRead = kpi.totalCacheReadTokens || 0;
       const cacheDenom = (kpi.totalInputTokens || 0) + cacheRead;
       const cacheSubText = (cacheDenom > 0)
         ? 'cache_read <em>' + esc(fmtTokens(cacheRead)) + '</em> / 入力合計 <em>' +
           esc(fmtTokens(cacheDenom)) + '</em> tokens'
         : 'no data';
+
+      // mock の決定: 1 枚目 (合計コスト) は headline metric として `<div class="v">` (sm 無し / 26px)、
+      // 残り 3 枚は補助メトリックとして `<div class="v sm">` (20px) で size hierarchy を作る。
       const cards = [
-        { id: 'kpi-sess-total', cls: '', k: totalLabel, v: formatCostUsd(kpi.totalCost), s: '' },
-        { id: 'kpi-sess-median', cls: 'c-coral', k: 'セッション中央値', v: formatCostUsd(kpi.medianCost), s: '最大 <em>' + formatCostUsd(kpi.topCost) + '</em> · 最小 <em>' + formatCostUsd(kpi.minCost) + '</em>' },
-        { id: 'kpi-sess-avg', cls: 'c-peri', k: 'セッション平均', v: formatCostUsd(kpi.avgCost), s: '' },
-        { id: 'kpi-sess-cache', cls: 'c-peach', k: 'Cache 効率', v: Math.round((kpi.cacheEfficiency || 0) * 100) + '%', s: cacheSubText },
+        { id: 'kpi-sess-total',  cls: '',        k: totalLabel,            v: formatCostUsd(kpi.totalCost),                                       s: opusSubText,   big: true  },
+        { id: 'kpi-sess-median', cls: 'c-coral', k: 'セッション中央値',    v: formatCostUsd(kpi.medianCost),                                      s: medianSubText, big: false },
+        { id: 'kpi-sess-avg',    cls: 'c-peri',  k: 'セッション平均',      v: formatCostUsd(kpi.avgCost),                                         s: avgSubText,    big: false },
+        { id: 'kpi-sess-cache',  cls: 'c-peach', k: 'Cache 効率',          v: Math.round((kpi.cacheEfficiency || 0) * 100) + '%',                 s: cacheSubText,  big: false },
       ];
       return cards.map(function(g){
+        const vClass = g.big ? 'v' : 'v sm';
         return '<div class="kpi ' + g.cls + '" id="' + g.id + '">' +
           '<div class="k-row"><span class="k">' + esc(g.k) + '</span></div>' +
-          '<div class="v sm">' + g.v + '</div>' +
+          '<div class="' + vClass + '">' + g.v + '</div>' +
           (g.s ? '<div class="s">' + g.s + '</div>' : '<div class="s">&nbsp;</div>') +
         '</div>';
       }).join('');

--- a/dashboard/template/shell.html
+++ b/dashboard/template/shell.html
@@ -13,12 +13,13 @@ __INCLUDE_STYLES__
 </head>
 <body>
   <div class="app">
-    <!-- 共通: 4 ページ切替 nav (Issue #57) -->
+    <!-- 共通: 5 ページ切替 nav (Issue #57 / #103 で Sessions 追加) -->
     <nav class="page-nav" role="navigation" aria-label="ダッシュボードページ">
       <a href="#/" data-page-link="overview" tabindex="0">Overview</a>
       <a href="#/patterns" data-page-link="patterns" tabindex="0">Patterns</a>
       <a href="#/quality" data-page-link="quality" tabindex="0">Quality</a>
       <a href="#/surface" data-page-link="surface" tabindex="0">Surface</a>
+      <a href="#/sessions" data-page-link="sessions" tabindex="0">Sessions</a>
       <!-- Issue #83: live heartbeat sparkline。
            default `hidden` で static export 経路では非表示、live 経路で
            startHeartbeat() が hidden を解除する。 -->
@@ -475,6 +476,105 @@ __INCLUDE_STYLES__
                 <th>更新日時</th>
                 <th>最終呼び出し</th>
                 <th class="num">経過</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- Sessions ページ (Issue #103): session 単位の token / cost / model / service_tier 内訳 -->
+    <section data-page="sessions" class="page" aria-labelledby="page-sessions-title" hidden>
+      <header class="header">
+        <div>
+          <h1 id="page-sessions-title"><span class="accent">Sessions</span></h1>
+          <p class="lede">
+            最新 20 セッションのトークン消費・推計コスト・モデル構成を一覧。
+            実測トークン × モデル別公開価格表の掛け算による参考値。
+          </p>
+        </div>
+      </header>
+
+      <!-- KPI 行 (4 枚): 合計コスト / 中央値 / 平均 / Cache 効率 -->
+      <div class="kpi-row" id="sessionsKpi"></div>
+
+      <div class="panel" id="sessions-table-panel">
+        <div class="panel-head c-mint">
+          <div class="ttl-wrap">
+            <span class="ttl"><span class="dot"></span>セッション一覧 (直近 20 件)</span>
+            <span class="help-host">
+              <button class="help-btn" type="button" aria-label="説明を表示" aria-expanded="false" aria-describedby="hp-sessions" data-help-id="hp-sessions">?</button>
+              <span class="help-pop" id="hp-sessions" role="tooltip" data-place="right">
+                <span class="pop-ttl">セッション一覧</span>
+                <span class="pop-body"><code>session_start</code> イベントを起点に、同 <code>session_id</code> 内の <code>assistant_usage</code> から model 別 token 数 / service_tier を集計。開始時刻降順で 20 件。<code>ended_at</code> が未観測のものは「進行中」として表示する。</span>
+              </span>
+            </span>
+          </div>
+          <span class="sub" id="sessionsSub"></span>
+        </div>
+        <div class="panel-body" style="padding: 0 12px 4px;">
+          <table class="sessions-table" id="sessionsTable">
+            <colgroup>
+              <col class="col-start">
+              <col class="col-dur">
+              <col class="col-project">
+              <col class="col-models">
+              <col class="col-tok-in">
+              <col class="col-tok-out">
+              <col class="col-tok-cr">
+              <col class="col-tok-cc">
+              <col class="col-cost">
+              <col class="col-tier">
+              <col class="col-skills">
+              <col class="col-sub">
+            </colgroup>
+            <thead>
+              <tr class="group-row">
+                <th class="empty" colspan="4"></th>
+                <th colspan="4">
+                  Tokens
+                  <span class="help-host">
+                    <button class="help-btn" type="button" aria-label="トークン種別の説明" aria-expanded="false" aria-describedby="hp-tokens" data-help-id="hp-tokens">?</button>
+                    <span class="help-pop" id="hp-tokens" role="tooltip" data-place="bottom">
+                      <span class="pop-ttl">トークン種別</span>
+                      <span class="pop-body"><code>Input</code>: ユーザープロンプト + システムプロンプト + tool 結果 (cache 経由を除く)。<code>Output</code>: assistant 生成 (一番高い単価)。<code>Cache R</code>: prompt cache から読み出した token (input の 1/10 程度の単価)。<code>Cache C</code>: prompt cache に書き込まれた token (input の 1.25 倍の単価)。</span>
+                    </span>
+                  </span>
+                </th>
+                <th class="empty" colspan="4"></th>
+              </tr>
+              <tr class="data-row">
+                <th>開始時刻</th>
+                <th>期間</th>
+                <th>プロジェクト</th>
+                <th>Models</th>
+                <th class="num">Input</th>
+                <th class="num">Output</th>
+                <th class="num tok-cr">Cache R</th>
+                <th class="num tok-cc">Cache C</th>
+                <th class="num">
+                  推計コスト
+                  <span class="help-host">
+                    <button class="help-btn" type="button" aria-label="コストの説明" aria-expanded="false" aria-describedby="hp-cost" data-help-id="hp-cost">?</button>
+                    <span class="help-pop" id="hp-cost" role="tooltip" data-place="left">
+                      <span class="pop-ttl">推計コスト</span>
+                      <span class="pop-body">実測 token × モデル別公開価格表の掛け算による<strong>参考値</strong>。Anthropic が価格改定すると過去値も再計算で動く。cache create / read / input / output で単価が異なるため、token 4 種を分けて積算している。</span>
+                    </span>
+                  </span>
+                </th>
+                <th>
+                  Service tier
+                  <span class="help-host">
+                    <button class="help-btn" type="button" aria-label="Service tier の説明" aria-expanded="false" aria-describedby="hp-tier" data-help-id="hp-tier">?</button>
+                    <span class="help-pop" id="hp-tier" role="tooltip" data-place="left">
+                      <span class="pop-ttl">Service tier</span>
+                      <span class="pop-body"><code>priority</code> / <code>standard</code> / <code>batch</code> は Anthropic API 側で記録される料金ティア。<code>priority</code>: 優先度確約枠 (割増)。<code>standard</code>: 通常 (Claude Code デフォルト)。<code>batch</code>: Batch API (50% 割引)。1 session 内で混在し得る。</span>
+                    </span>
+                  </span>
+                </th>
+                <th class="num">Skills</th>
+                <th class="num">Subagents</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/dashboard/template/styles/55_sessions.css
+++ b/dashboard/template/styles/55_sessions.css
@@ -1,0 +1,215 @@
+  /* ========================================================================
+     Sessions ページ (Issue #103) — 12 列テーブル + KPI 4 枚 + cost meter bar.
+     既存の .surface-table grammar (mono / 12px / hover-row) を踏襲しつつ
+     sessions-* namespace で slot in。color tokens は :root の既存 palette
+     (mint / peach / coral / peri) を再利用してデザインの一貫性を保つ。
+     ======================================================================== */
+  .sessions-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    font-family: var(--ff-mono);
+    table-layout: fixed;
+  }
+
+  .sessions-table thead .data-row th {
+    text-align: left;
+    color: var(--ink-faint);
+    font-weight: 500;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--line);
+    white-space: nowrap;
+    position: relative;
+  }
+  .sessions-table thead .data-row th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .sessions-table thead .data-row th .help-host { vertical-align: -2px; margin-left: 4px; }
+
+  /* Tokens super-group row: 4 token 列 (Input/Output/Cache R/Cache C) を
+     1 ラベルにまとめる。peri tint で「カラム束」感を出す。 */
+  .sessions-table thead .group-row th {
+    padding: 4px 8px 5px;
+    border-bottom: 1px solid var(--line);
+    color: var(--peri);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-align: center;
+    background: rgba(138, 166, 255, 0.05);
+  }
+  .sessions-table thead .group-row th.empty {
+    background: transparent;
+    border-bottom: 1px solid transparent;
+  }
+  .sessions-table thead .group-row th .help-host { vertical-align: -1px; margin-left: 4px; }
+
+  .sessions-table tbody tr {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  }
+  .sessions-table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.025);
+  }
+  .sessions-table tbody tr.is-active {
+    background: rgba(111, 227, 200, 0.04);
+  }
+  .sessions-table tbody tr.is-active:hover {
+    background: rgba(111, 227, 200, 0.07);
+  }
+  .sessions-table tbody tr.is-whale {
+    box-shadow: inset 3px 0 0 var(--peach);
+  }
+  .sessions-table tbody tr:focus-visible {
+    outline: 2px solid var(--peri);
+    outline-offset: -1px;
+  }
+  .sessions-table td {
+    padding: 8px 8px;
+    color: var(--ink);
+    vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .sessions-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .sessions-table td.dim { color: var(--ink-faint); }
+
+  /* Specific column widths — table-layout: fixed で load-bearing。
+     cost 列は $X.XXXX + 64px bar が収まる幅、Models / Tier は 2 chip 折り返し可。 */
+  .sessions-table col.col-start   { width: 88px; }
+  .sessions-table col.col-dur     { width: 84px; }
+  .sessions-table col.col-project { width: 246px; }
+  .sessions-table col.col-models  { width: 140px; }
+  .sessions-table col.col-tok-in  { width: 60px; }
+  .sessions-table col.col-tok-out { width: 60px; }
+  .sessions-table col.col-tok-cr  { width: 60px; }
+  .sessions-table col.col-tok-cc  { width: 60px; }
+  .sessions-table col.col-cost    { width: 88px; }
+  .sessions-table col.col-tier    { width: 134px; }
+  .sessions-table col.col-skills  { width: 52px; }
+  .sessions-table col.col-sub     { width: 56px; }
+
+  .sess-proj { color: var(--ink); }
+  .sess-time { color: var(--ink-soft); }
+  .sess-dur  { color: var(--ink-soft); }
+  .sess-tok-cache { color: var(--ink-faint); }
+
+  /* ---- Models chips (extends .mode-chip vocabulary) ---- */
+  .model-chips {
+    display: flex; flex-wrap: wrap; gap: 3px;
+  }
+  .model-chip {
+    display: inline-flex; align-items: baseline;
+    gap: 4px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    letter-spacing: 0.02em;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--ink-faint);
+  }
+  .model-chip .ct {
+    font-weight: 600;
+    color: var(--ink);
+    font-size: 10px;
+  }
+  /* color per family — sonnet=mint(workhorse) / opus=coral(premium) / haiku=peach(cheap) */
+  .model-chip.m-sonnet { background: rgba(111, 227, 200, 0.10); color: var(--mint); }
+  .model-chip.m-opus   { background: rgba(255, 138, 118, 0.10); color: var(--coral); }
+  .model-chip.m-haiku  { background: rgba(255, 201, 122, 0.10); color: var(--peach); }
+
+  /* ---- Service tier chips ---- */
+  .tier-chips { display: flex; flex-wrap: wrap; gap: 3px; }
+  .tier-chip {
+    display: inline-flex; align-items: baseline; gap: 4px;
+    padding: 1px 6px; border-radius: 3px;
+    font-size: 10px; letter-spacing: 0.02em;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--ink-faint);
+  }
+  .tier-chip .ct { font-weight: 600; color: var(--ink); font-size: 10px; }
+  .tier-chip.t-priority { background: rgba(138, 166, 255, 0.10); color: var(--peri); }
+  .tier-chip.t-standard { background: rgba(255, 255, 255, 0.04); color: var(--ink-soft); }
+  .tier-chip.t-batch    { background: rgba(255, 201, 122, 0.10); color: var(--peach); }
+
+  /* ---- 進行中 pill — conn-pulse keyframes 流用 ---- */
+  .live-pill {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 1px 7px;
+    border-radius: var(--r-pill);
+    background: rgba(111, 227, 200, 0.10);
+    color: var(--mint);
+    font-size: 10px;
+    font-weight: 500;
+    border: 1px solid var(--mint-soft);
+  }
+  .live-pill::before {
+    content: "";
+    width: 5px; height: 5px;
+    border-radius: 50%;
+    background: currentColor;
+    animation: conn-pulse 1.6s ease-out infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .live-pill::before { animation: none; }
+  }
+
+  /* ---- Cost cell — value + 64px magnitude bar (--cost-pct で行ごとにスケール) ---- */
+  .cost-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 5px;
+    padding: 4px 8px;
+  }
+  .cost-cell .cost-val {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+    line-height: 1.1;
+  }
+  .cost-cell .cost-bar {
+    position: relative;
+    width: 64px;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: var(--r-pill);
+    overflow: hidden;
+  }
+  .cost-cell .cost-bar::after {
+    content: "";
+    position: absolute;
+    top: 0; bottom: 0; left: 0;
+    width: var(--cost-pct, 0%);
+    background: linear-gradient(90deg, var(--mint-soft) 0%, var(--peach) 60%, var(--coral) 100%);
+    border-radius: var(--r-pill);
+  }
+  /* whale row: cost-val takes a faint peach tint */
+  .sessions-table tr.is-whale .cost-cell .cost-val { color: var(--peach); }
+
+  /* ---- Skills / subagents counts — 0 は dim、>0 は強調 ---- */
+  .sessions-table .count-zero { color: var(--ink-faint); }
+  .sessions-table .count-pos { color: var(--ink); font-weight: 600; }
+
+  /* Help-pop reset for sessions-table headers:
+     <th nowrap | text-align:right | text-align:center> 親からの継承を popup 側で
+     解除しないと、推計コスト / Tokens super-group の help-pop が 1 行に圧縮される。 */
+  .sessions-table th .help-pop {
+    white-space: normal;
+    text-align: left;
+    max-width: 420px;
+  }
+  .sessions-table th .help-pop .pop-body { display: block; }
+
+  /* Responsive — 狭いビューポートでは cache 系列を hide (full numbers は API 側に残る) */
+  @media (max-width: 1280px) {
+    .sessions-table col.col-tok-cr,
+    .sessions-table col.col-tok-cc,
+    .sessions-table th.tok-cr, .sessions-table td.tok-cr,
+    .sessions-table th.tok-cc, .sessions-table td.tok-cc {
+      display: none;
+    }
+  }

--- a/dashboard/template/styles/55_sessions.css
+++ b/dashboard/template/styles/55_sessions.css
@@ -4,6 +4,20 @@
      sessions-* namespace で slot in。color tokens は :root の既存 palette
      (mint / peach / coral / peri) を再利用してデザインの一貫性を保つ。
      ======================================================================== */
+
+  /* KPI 行は Overview 8 枚 (8 列 grid) と異なり、Sessions は 4 枚で 4 列 grid。
+     `section[data-page="sessions"]` scope で grid-template-columns を上書きする
+     (10_components.css の base `.kpi-row` には触らない)。
+     1 枚目 (合計コスト) の `<div class="v">` は base のまま 26px (= sm 無しで大きく)、
+     2/3/4 枚目は `v sm` (20px) で size hierarchy を作る。 */
+  section[data-page="sessions"] .kpi-row {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  @media (max-width: 720px) {
+    section[data-page="sessions"] .kpi-row {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
   .sessions-table {
     width: 100%;
     border-collapse: collapse;

--- a/docs/plans/sessions-ui-mock.html
+++ b/docs/plans/sessions-ui-mock.html
@@ -1,0 +1,1488 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sessions — Claude Code Usage (mock)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+<!--
+  ============================================================================
+  Sessions page — visual mock for Issue #103
+  ============================================================================
+  Purpose: design exploration. Self-contained file, no JS required (a tiny
+  inline IIFE handles `?` popup toggle so the help-pops behave like production).
+
+  REUSED tokens / classes (verbatim from production):
+    - All :root color + radius + font tokens
+    - .page-nav / .page / .panel / .panel-head / .panel-body / .ttl-wrap / .sub
+    - .help-host / .help-btn / .help-pop / .pop-ttl / .pop-body
+    - .surface-table (extended below — see "NEW")
+    - .conn-status (with [data-state="online"] pulse animation)
+    - .kpi / .kpi-row (used for the proposed KPI strip)
+    - .app-footer
+
+  NEW classes (proposed — namespaced `sessions-*` so they slot in cleanly):
+    - .sessions-table           (extends .surface-table grammar)
+    - .sessions-table .col-cost (cost column emphasis)
+    - .cost-cell / .cost-bar    (in-row magnitude bar)
+    - .model-chip / .tier-chip  (extends .mode-chip / .status-chip family)
+    - .live-pill                (進行中 — reuses conn-pulse keyframe)
+
+  REVISIONS applied (post-review feedback):
+    - Token columns: replaced visible "Tokens" supergroup label with a
+      single help-pop on the Input column header documenting all 4 token
+      types (Input / Output / Cache R / Cache C).
+    - Service tier: added a help-pop documenting priority / standard / batch.
+    - Session ID column dropped; column order now: 開始時刻 | 期間 |
+      Project | Models | tokens(4) | 推計コスト | Service tier | Skills |
+      Subagents (12 columns total).
+
+  Tradeoffs noted at bottom in <aside class="design-notes">.
+-->
+
+<style>
+  /* ------------------------------------------------------------------------
+     PRODUCTION TOKENS (verbatim from dashboard/template/styles/00_base.css)
+     Inlined so the file renders correctly with file://
+     ------------------------------------------------------------------------ */
+  :root {
+    --bg-app: #1c1d22;
+    --bg-panel: #25272d;
+    --bg-panel-2: #2b2e35;
+    --bg-elevated: #2f3239;
+
+    --line: #353841;
+    --line-strong: #404453;
+
+    --ink: #f1f2f5;
+    --ink-soft: #b6bac6;
+    --ink-faint: #7e8290;
+
+    --mint: #6fe3c8;
+    --mint-soft: #2f6f63;
+    --coral: #ff8a76;
+    --coral-soft: #803f37;
+    --peri: #8aa6ff;
+    --peri-soft: #3f4d80;
+    --peach: #ffc97a;
+    --peach-soft: #80633d;
+    --rose: #ff6f9c;
+    --rose-soft: #803757;
+
+    --r-lg: 14px;
+    --r-md: 10px;
+    --r-sm: 6px;
+    --r-pill: 8px;
+
+    --ff-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
+    --ff-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; }
+  body {
+    font-family: var(--ff-sans);
+    font-feature-settings: "ss01", "cv11";
+    background: var(--bg-app);
+    color: var(--ink);
+    min-height: 100vh;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    background-image:
+      radial-gradient(ellipse 60% 50% at 15% 0%, rgba(111,227,200,0.05), transparent 60%),
+      radial-gradient(ellipse 40% 40% at 90% 10%, rgba(138,166,255,0.045), transparent 60%);
+  }
+  .app {
+    max-width: 1480px;
+    margin: 0 auto;
+    padding: 22px 22px 32px;
+  }
+
+  /* ----- page-nav (verbatim from 30_pages.css) ----- */
+  .page-nav {
+    display: flex; gap: 4px;
+    padding: 0 0 14px; margin-bottom: 18px;
+    border-bottom: 1px solid var(--line);
+    flex-wrap: wrap; align-items: center;
+  }
+  .page-nav a {
+    padding: 8px 14px;
+    font-size: 13px; font-weight: 500;
+    color: var(--ink-soft); text-decoration: none;
+    border-radius: var(--r-md) var(--r-md) 0 0;
+    transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+    border: 1px solid transparent;
+    border-bottom: none;
+    margin-bottom: -1px;
+  }
+  .page-nav a:hover { color: var(--ink); background: var(--bg-panel); }
+  .page-nav a.active {
+    color: var(--mint);
+    background: var(--bg-panel);
+    border-color: var(--line);
+    border-bottom: 2px solid var(--mint);
+  }
+  /* heartbeat svg sits between Sessions and the right edge — inline SVG */
+  .heartbeat {
+    width: 80px; height: 18px;
+    margin-left: auto; margin-right: 4px;
+    color: var(--ink-faint); opacity: 0.6;
+  }
+  .heartbeat polyline { fill: none; stroke: currentColor; stroke-width: 1.4; }
+
+  /* ----- header (verbatim) ----- */
+  .header {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 24px;
+    align-items: end;
+    margin-bottom: 22px;
+    padding-bottom: 18px;
+    border-bottom: 1px solid var(--line);
+  }
+  .header h1 {
+    margin: 0 0 4px;
+    font-size: 22px; font-weight: 600;
+    letter-spacing: -0.01em; color: var(--ink);
+  }
+  .header h1 .accent { color: var(--mint); font-weight: 700; }
+  .header .lede { color: var(--ink-soft); font-size: 13px; }
+  .header .lede .num { font-family: var(--ff-mono); color: var(--ink); font-weight: 500; }
+
+  /* ----- panel (verbatim) ----- */
+  .panel {
+    background: var(--bg-panel);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+  }
+  .panel-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    padding: 14px 18px 12px;
+    border-bottom: 1px solid var(--line);
+    gap: 12px;
+  }
+  .panel-head .ttl-wrap { display: flex; align-items: center; gap: 8px; }
+  .panel-head .ttl {
+    font-size: 14px; font-weight: 600;
+    color: var(--ink); letter-spacing: -0.005em;
+  }
+  .panel-head .ttl .dot {
+    display: inline-block;
+    width: 8px; height: 8px;
+    border-radius: 50%;
+    background: var(--mint);
+    margin-right: 9px; vertical-align: 1px;
+  }
+  .panel-head.c-coral .ttl .dot { background: var(--coral); }
+  .panel-head.c-peri  .ttl .dot { background: var(--peri); }
+  .panel-head.c-peach .ttl .dot { background: var(--peach); }
+  .panel-head .sub {
+    font-size: 11.5px; color: var(--ink-faint);
+    font-family: var(--ff-mono);
+  }
+  .panel-body { padding: 14px 18px 18px; }
+
+  /* ----- KPI (verbatim, just the bits we need) ----- */
+  .kpi-row {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    margin-bottom: 22px;
+  }
+  .kpi {
+    background: var(--bg-panel);
+    border: 1px solid var(--line);
+    border-radius: var(--r-md);
+    padding: 13px 14px 14px;
+    position: relative; overflow: visible;
+  }
+  .kpi::before {
+    content: ""; position: absolute;
+    top: 0; left: 14px; right: 14px;
+    height: 2px; border-radius: 0 0 4px 4px;
+    background: var(--mint); opacity: 0.85;
+  }
+  .kpi.c-coral::before { background: var(--coral); }
+  .kpi.c-peri::before  { background: var(--peri); }
+  .kpi.c-peach::before { background: var(--peach); }
+  .kpi .k-row { display: flex; justify-content: space-between; align-items: center; gap: 6px; }
+  .kpi .k {
+    font-size: 10.5px; color: var(--ink-faint);
+    text-transform: uppercase; letter-spacing: 0.08em; font-weight: 500;
+  }
+  .kpi .v {
+    font-family: var(--ff-mono);
+    font-size: 26px; font-weight: 600;
+    color: var(--ink); margin-top: 6px;
+    line-height: 1.05; letter-spacing: -0.01em;
+  }
+  .kpi .v.sm { font-size: 20px; }
+  .kpi .s { font-size: 11px; color: var(--ink-faint); margin-top: 6px; }
+  .kpi .s em { font-style: normal; color: var(--ink-soft); font-family: var(--ff-mono); }
+
+  /* ----- help-pop (verbatim from 20_help_tooltip.css) ----- */
+  .help-host { position: relative; display: inline-flex; align-items: center; }
+  .help-btn {
+    appearance: none; -webkit-appearance: none;
+    border: 1px solid var(--line-strong);
+    background: var(--bg-elevated);
+    color: var(--ink-faint);
+    width: 16px; height: 16px;
+    border-radius: 50%; padding: 0;
+    font-family: var(--ff-sans); font-size: 10px;
+    font-weight: 600; line-height: 1;
+    cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    transition: color 120ms ease, background 120ms ease, border-color 120ms ease;
+  }
+  .help-btn:hover, .help-btn:focus-visible {
+    color: var(--ink);
+    background: var(--bg-panel-2);
+    border-color: var(--ink-faint);
+    outline: none;
+  }
+  .help-btn:focus-visible { box-shadow: 0 0 0 2px rgba(138,166,255,0.45); }
+  .help-btn[aria-expanded="true"] {
+    color: var(--peri);
+    border-color: var(--peri);
+    background: rgba(138,166,255,0.10);
+  }
+  .help-pop {
+    position: absolute;
+    top: calc(100% + 8px);
+    z-index: 50;
+    width: max-content; max-width: 420px;
+    padding: 10px 12px;
+    /* `<th white-space: nowrap>` 継承で popup 本文が 1 行に圧縮されるのを抑止。
+       max-width 420px の中で wrap させる。 */
+    white-space: normal;
+    /* `<th class="num">` の text-align: right や group-row の text-align: center
+       が popup 内の本文 / タイトルに継承して中央寄せ・右寄せになるのを抑止。 */
+    text-align: left;
+    background: var(--bg-elevated);
+    border: 1px solid var(--line-strong);
+    border-radius: var(--r-md);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.30), 0 8px 24px rgba(0,0,0,0.35);
+    color: var(--ink-soft);
+    font-size: 12px; line-height: 1.55;
+    visibility: hidden; opacity: 0;
+    transform: translateY(-2px);
+    transition: opacity 120ms ease, transform 120ms ease, visibility 120ms;
+    pointer-events: none;
+  }
+  .help-pop[data-place="right"] { left: -8px; }
+  .help-pop[data-place="left"]  { right: -8px; }
+  .help-host:hover > .help-pop,
+  .help-pop[data-open="true"] {
+    visibility: visible; opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+  .help-pop .pop-ttl {
+    display: block; color: var(--ink);
+    font-weight: 600; font-size: 12px; margin-bottom: 4px;
+  }
+  /* pop-body は <span> なのでデフォルト inline。width が効かず <br> 入りの
+     長文が popup 幅 (max-width 420px) を超えて右にはみ出る → block 化して
+     popup の幅で wrap させる。 */
+  .help-pop .pop-body { display: block; color: var(--ink-soft); }
+  .help-pop .pop-body code {
+    font-family: var(--ff-mono); font-size: 11px;
+    background: rgba(138,166,255,0.10);
+    color: var(--ink);
+    padding: 1px 5px; border-radius: 4px;
+  }
+
+  /* ----- conn-status pulse (verbatim — used by .live-pill) ----- */
+  @keyframes conn-pulse {
+    0%   { box-shadow: 0 0 0 0 currentColor; opacity: 1; }
+    70%  { box-shadow: 0 0 0 6px transparent; opacity: 0.85; }
+    100% { box-shadow: 0 0 0 0 transparent; opacity: 1; }
+  }
+
+  /* ----- app-footer (verbatim) ----- */
+  .app-footer {
+    margin-top: 32px; padding-top: 16px;
+    border-top: 1px solid var(--line);
+    display: flex; justify-content: space-between; align-items: center;
+    flex-wrap: wrap; gap: 14px;
+    font-size: 11.5px; color: var(--ink-faint);
+  }
+  .app-footer .meta { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+  .app-footer .meta-item { display: inline-flex; align-items: baseline; gap: 4px; }
+  .app-footer .meta-item .k { color: var(--ink-faint); }
+  .app-footer .meta-item .v { color: var(--ink-soft); font-family: var(--ff-mono); }
+  .app-footer .credits { color: var(--ink-faint); font-size: 11px; }
+  .app-footer .credits .accent { color: var(--mint); font-weight: 600; }
+  .app-footer .credits .sep { margin: 0 8px; opacity: 0.5; }
+
+  .conn-status {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 10px;
+    font-family: var(--ff-mono); font-size: 11px;
+    border-radius: var(--r-pill);
+    border: 1px solid var(--mint-soft);
+    background: var(--bg-panel);
+    color: var(--mint);
+  }
+  .conn-status::before {
+    content: ""; width: 6px; height: 6px;
+    border-radius: 50%; background: currentColor;
+    animation: conn-pulse 1.6s ease-out infinite;
+  }
+
+  /* ========================================================================
+     NEW — Sessions table grammar
+     Extends .surface-table conventions: mono font, 12px, hover-row, num-right
+     ======================================================================== */
+  .sessions-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+    font-family: var(--ff-mono);
+    table-layout: fixed;
+  }
+
+  .sessions-table thead .data-row th {
+    text-align: left;
+    color: var(--ink-faint);
+    font-weight: 500;
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--line);
+    white-space: nowrap;
+    position: relative;
+  }
+  .sessions-table thead .data-row th.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
+  .sessions-table thead .data-row th .help-host { vertical-align: -2px; margin-left: 4px; }
+
+  /* Tokens super-group row: 4 token 列 (Input/Output/Cache R/Cache C) を
+     1 ラベルにまとめる。peri tint で「カラム束」感を出す。 */
+  .sessions-table thead .group-row th {
+    padding: 4px 8px 5px;
+    border-bottom: 1px solid var(--line);
+    color: var(--peri);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    text-align: center;
+    background: rgba(138,166,255, 0.05);
+  }
+  .sessions-table thead .group-row th.empty {
+    background: transparent;
+    border-bottom: 1px solid transparent;
+  }
+  .sessions-table thead .group-row th .help-host { vertical-align: -1px; margin-left: 4px; }
+
+  .sessions-table tbody tr {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  }
+  .sessions-table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.025);
+  }
+  .sessions-table tbody tr.is-active {
+    background: rgba(111,227,200, 0.04);
+  }
+  .sessions-table tbody tr.is-active:hover {
+    background: rgba(111,227,200, 0.07);
+  }
+  .sessions-table tbody tr.is-whale {
+    /* a soft peach left-edge for the headline-cost outlier */
+    box-shadow: inset 3px 0 0 var(--peach);
+  }
+  .sessions-table tbody tr:focus-visible {
+    outline: 2px solid var(--peri);
+    outline-offset: -1px;
+  }
+  .sessions-table td {
+    padding: 8px 8px;
+    color: var(--ink);
+    vertical-align: middle;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .sessions-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
+  .sessions-table td.dim { color: var(--ink-faint); }
+
+  /* Specific column widths — keeps cost column wide enough for $X.XXXX bar
+     and gives Models/Tier room to wrap to 2 chips. table-layout: fixed makes
+     these load-bearing. Session ID column was dropped per maintainer feedback;
+     Project absorbs the freed space (project names are the longest text). */
+  .sessions-table col.col-project { width: 246px; }
+  .sessions-table col.col-start   { width: 88px; }
+  .sessions-table col.col-dur     { width: 84px; }
+  .sessions-table col.col-models  { width: 140px; }
+  .sessions-table col.col-tok-in  { width: 60px; }
+  .sessions-table col.col-tok-out { width: 60px; }
+  .sessions-table col.col-tok-cr  { width: 60px; }
+  .sessions-table col.col-tok-cc  { width: 60px; }
+  .sessions-table col.col-cost    { width: 88px; }
+  .sessions-table col.col-tier    { width: 134px; }
+  .sessions-table col.col-skills  { width: 52px; }
+  .sessions-table col.col-sub     { width: 56px; }
+
+  /* Project / time / duration — mono cells */
+  .sess-proj  { color: var(--ink); }
+  .sess-time  { color: var(--ink-soft); }
+  .sess-dur   { color: var(--ink-soft); }
+  .sess-tok-cache { color: var(--ink-faint); } /* cache reads/creates — dimmer */
+
+  /* ---- Models chips (extends .mode-chip vocabulary) ---- */
+  .model-chips {
+    display: flex; flex-wrap: wrap; gap: 3px;
+  }
+  .model-chip {
+    display: inline-flex; align-items: baseline;
+    gap: 4px;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 10px;
+    letter-spacing: 0.02em;
+    background: rgba(255,255,255,0.05);
+    color: var(--ink-faint);
+  }
+  .model-chip .ct {
+    font-weight: 600;
+    color: var(--ink);
+    font-size: 10px;
+  }
+  /* color per family — mint = sonnet (workhorse / default), coral = opus
+     (premium), peach = haiku (cheap). Mapping reuses dashboard's
+     accent palette so cost-class is implicit. */
+  .model-chip.m-sonnet { background: rgba(111,227,200,0.10); color: var(--mint); }
+  .model-chip.m-opus   { background: rgba(255,138,118,0.10); color: var(--coral); }
+  .model-chip.m-haiku  { background: rgba(255,201,122,0.10); color: var(--peach); }
+
+  /* ---- Service tier chips (peri = priority, ink-faint = standard, peach = batch) ----
+     Note: priority maps to peri (not mint) so it doesn't compete with the
+     "active session" mint-tinted row background. */
+  .tier-chips { display: flex; flex-wrap: wrap; gap: 3px; }
+  .tier-chip {
+    display: inline-flex; align-items: baseline; gap: 4px;
+    padding: 1px 6px; border-radius: 3px;
+    font-size: 10px; letter-spacing: 0.02em;
+    background: rgba(255,255,255,0.04);
+    color: var(--ink-faint);
+  }
+  .tier-chip .ct { font-weight: 600; color: var(--ink); font-size: 10px; }
+  .tier-chip.t-priority { background: rgba(138,166,255,0.10); color: var(--peri); }
+  .tier-chip.t-standard { background: rgba(255,255,255,0.04); color: var(--ink-soft); }
+  .tier-chip.t-batch    { background: rgba(255,201,122,0.10); color: var(--peach); }
+
+  /* ---- 進行中 pill — reuses conn-pulse ---- */
+  .live-pill {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 1px 7px;
+    border-radius: var(--r-pill);
+    background: rgba(111,227,200,0.10);
+    color: var(--mint);
+    font-size: 10px;
+    font-weight: 500;
+    border: 1px solid var(--mint-soft);
+  }
+  .live-pill::before {
+    content: "";
+    width: 5px; height: 5px;
+    border-radius: 50%;
+    background: currentColor;
+    animation: conn-pulse 1.6s ease-out infinite;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .live-pill::before { animation: none; }
+  }
+
+  /* ---- Cost cell — the headline metric.
+     Layout: a horizontal magnitude bar behind the dollar value, scaled to
+     the row's `--cost-pct` (set inline). The bar is a soft peach-to-coral
+     gradient so cheap rows have a tiny mint-soft sliver and the whale
+     visually anchors the table. Value sits left of the bar (right-aligned
+     numerically), bar fills remaining width. */
+  .cost-cell {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 5px;
+    padding: 4px 8px;
+  }
+  .cost-cell .cost-val {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+    color: var(--ink);
+    letter-spacing: -0.01em;
+    line-height: 1.1;
+  }
+  .cost-cell .cost-bar {
+    position: relative;
+    width: 64px;
+    height: 4px;
+    background: rgba(255,255,255,0.04);
+    border-radius: var(--r-pill);
+    overflow: hidden;
+  }
+  .cost-cell .cost-bar::after {
+    content: "";
+    position: absolute;
+    top: 0; bottom: 0; left: 0;
+    width: var(--cost-pct, 0%);
+    background: linear-gradient(90deg, var(--mint-soft) 0%, var(--peach) 60%, var(--coral) 100%);
+    border-radius: var(--r-pill);
+  }
+  /* whale row: cost-val takes a faint peach tint so it pops */
+  tr.is-whale .cost-cell .cost-val { color: var(--peach); }
+  /* very cheap rows: the bar is barely visible — dim the value too */
+  tr.is-cheap .cost-cell .cost-val { color: var(--ink-soft); font-weight: 500; }
+
+  /* ---- Skills / subagents counts — small inline pill if 0 */
+  .count-zero { color: var(--ink-faint); }
+  .count-pos { color: var(--ink); font-weight: 600; }
+
+  /* Responsive — at narrow viewports, hide cache-token columns first
+     (they're least important + their data lives in API anyway) and then
+     collapse Models / Tier chips to single most-frequent label. */
+  @media (max-width: 1280px) {
+    .sessions-table col.col-tok-cr,
+    .sessions-table col.col-tok-cc,
+    .sessions-table th.tok-cr, .sessions-table td.tok-cr,
+    .sessions-table th.tok-cc, .sessions-table td.tok-cc {
+      display: none;
+    }
+  }
+
+  /* ----- design-notes block at bottom ----- */
+  .design-notes {
+    margin-top: 28px;
+    padding: 16px 20px;
+    background: var(--bg-panel);
+    border: 1px dashed var(--line-strong);
+    border-radius: var(--r-md);
+    font-size: 12.5px;
+    color: var(--ink-soft);
+    line-height: 1.65;
+  }
+  .design-notes h3 {
+    margin: 0 0 8px;
+    font-size: 13px; font-weight: 600;
+    color: var(--peri);
+    letter-spacing: 0.02em;
+  }
+  .design-notes h4 {
+    margin: 14px 0 4px;
+    font-size: 12px; font-weight: 600;
+    color: var(--ink);
+  }
+  .design-notes ul { margin: 4px 0 0; padding-left: 18px; }
+  .design-notes li { margin-bottom: 3px; }
+  .design-notes code {
+    font-family: var(--ff-mono); font-size: 11px;
+    background: rgba(138,166,255,0.10);
+    color: var(--ink);
+    padding: 1px 5px; border-radius: 4px;
+  }
+  .design-notes .tag {
+    display: inline-block;
+    font-size: 9px; letter-spacing: 0.08em;
+    text-transform: uppercase; font-weight: 700;
+    color: var(--peach);
+    background: rgba(255,201,122,0.10);
+    padding: 1px 5px; border-radius: 3px;
+    margin-right: 6px;
+  }
+</style>
+</head>
+<body>
+  <div class="app">
+
+    <!-- =================================================================
+         PAGE NAV — 5 tabs now (Sessions added between Surface and the
+         heartbeat svg). Sessions tab is .active.
+         ================================================================= -->
+    <nav class="page-nav" role="navigation" aria-label="ダッシュボードページ">
+      <a href="#/"          data-page-link="overview">Overview</a>
+      <a href="#/patterns"  data-page-link="patterns">Patterns</a>
+      <a href="#/quality"   data-page-link="quality">Quality</a>
+      <a href="#/surface"   data-page-link="surface">Surface</a>
+      <a href="#/sessions"  data-page-link="sessions" class="active" aria-current="page">Sessions</a>
+      <svg class="heartbeat" viewBox="0 0 140 22" preserveAspectRatio="none" role="img" aria-label="ライブ更新インジケータ">
+        <polyline points="0,11 14,11 22,4 30,18 40,8 52,13 64,11 78,11 86,4 96,18 108,8 120,13 140,11"/>
+      </svg>
+    </nav>
+
+    <!-- =================================================================
+         SESSIONS PAGE
+         ================================================================= -->
+    <section data-page="sessions" class="page" aria-labelledby="page-sessions-title">
+
+      <header class="header">
+        <div>
+          <h1 id="page-sessions-title"><span class="accent">Sessions</span></h1>
+          <p class="lede">
+            最新 <span class="num">20</span> セッションのトークン消費・コスト・モデル構成を一覧表示。
+            実測トークン × モデル別単価で算出した推計コスト。
+          </p>
+        </div>
+        <div style="display:flex; align-items:center; gap:10px;">
+          <span class="conn-status" data-state="online">● live</span>
+        </div>
+      </header>
+
+      <!-- Proposed KPI strip (4 cards, lightweight, clearly tagged 提案).
+           並びは: 合計 (大局) → 中央値 / 平均 (隣接させて median ≪ mean = whale 偏り
+           を一目で見せる) → Cache 効率 (independent な効率指標)。 -->
+      <div class="kpi-row">
+        <div class="kpi">
+          <div class="k-row">
+            <span class="k">直近20件 合計コスト</span>
+          </div>
+          <div class="v">$12.4831</div>
+          <div class="s">うち opus セッション <em>$10.21</em> (82%)</div>
+        </div>
+        <div class="kpi c-coral">
+          <div class="k-row">
+            <span class="k">セッション中央値</span>
+          </div>
+          <div class="v sm">$0.2348</div>
+          <div class="s">最大 <em>$5.8210</em> · 最小 <em>$0.0011</em></div>
+        </div>
+        <div class="kpi c-peri">
+          <div class="k-row">
+            <span class="k">セッション平均</span>
+          </div>
+          <div class="v sm">$0.6242</div>
+          <div class="s">中央値の <em>2.7×</em> · 上位 1 件で <em>47%</em> 寄与</div>
+        </div>
+        <div class="kpi c-peach">
+          <div class="k-row">
+            <span class="k">Cache 効率</span>
+          </div>
+          <div class="v sm">78%</div>
+          <div class="s">cache_read <em>34.8M</em> / 入力合計 <em>44.6M</em> tokens</div>
+        </div>
+      </div>
+
+      <!-- =================================================================
+           Main panel — Sessions table
+           ================================================================= -->
+      <div class="panel">
+        <div class="panel-head c-mint">
+          <div class="ttl-wrap">
+            <span class="ttl"><span class="dot"></span>セッション一覧 (直近 20 件)</span>
+            <span class="help-host">
+              <button class="help-btn" type="button" aria-label="説明を表示" aria-expanded="false" data-help-id="hp-sessions">?</button>
+              <span class="help-pop" id="hp-sessions" role="tooltip" data-place="right">
+                <span class="pop-ttl">セッション一覧</span>
+                <span class="pop-body">
+                  <code>session_start</code> イベントを起点に、同 <code>session_id</code> 内の
+                  <code>llm_response</code> から model 別 token 数 / service_tier を集計。
+                  開始時刻降順で 20 件。<code>ended_at</code> が未観測のものは
+                  「進行中」として最上部に表示する。
+                </span>
+              </span>
+            </span>
+          </div>
+          <span class="sub">20 sessions · 7 projects · live · last update 09:17:42</span>
+        </div>
+
+        <div class="panel-body" style="padding: 0 12px 4px;">
+          <table class="sessions-table" id="sessionsTable">
+            <colgroup>
+              <col class="col-start">
+              <col class="col-dur">
+              <col class="col-project">
+              <col class="col-models">
+              <col class="col-tok-in">
+              <col class="col-tok-out">
+              <col class="col-tok-cr">
+              <col class="col-tok-cc">
+              <col class="col-cost">
+              <col class="col-tier">
+              <col class="col-skills">
+              <col class="col-sub">
+            </colgroup>
+            <thead>
+              <!-- Token 4 列を束ねる super-group 行。peri tint で「ここから先 4 列は
+                   token 種別ブレイクダウン」と視認させる。help-pop は super-label 側に
+                   付け、Input/Output/Cache R/Cache C 個別ヘッダはマーカーフリーのまま
+                   numeric 揃えに集中させる。 -->
+              <tr class="group-row">
+                <th class="empty" colspan="4"></th>
+                <th colspan="4">
+                  Tokens
+                  <span class="help-host">
+                    <button class="help-btn" type="button" aria-label="トークン種別の説明" aria-expanded="false" data-help-id="hp-tokens">?</button>
+                    <span class="help-pop" id="hp-tokens" role="tooltip" data-place="bottom">
+                      <span class="pop-ttl">トークン種別</span>
+                      <span class="pop-body">
+                        <code>Input</code>: ユーザープロンプト + システムプロンプト + tool 結果として送られた token 数 (cache 経由を除く)。<br>
+                        <code>Output</code>: assistant が生成した token 数 (一番高い単価)。<br>
+                        <code>Cache R</code> (cache read): prompt cache から読み出した token 数。通常 input の 1/10 程度の単価で、長い会話・大きな CLAUDE.md ほどここが膨らむ。<br>
+                        <code>Cache C</code> (cache creation): prompt cache に書き込まれた token 数。通常 input の 1.25 倍の単価。同じ context が再利用されるほど償却されてお得になる。
+                      </span>
+                    </span>
+                  </span>
+                </th>
+                <th class="empty" colspan="4"></th>
+              </tr>
+              <tr class="data-row">
+                <th>開始時刻</th>
+                <th>期間</th>
+                <th>Project</th>
+                <th>Models</th>
+                <th class="num">Input</th>
+                <th class="num">Output</th>
+                <th class="num tok-cr" style="color:var(--ink-faint);">Cache R</th>
+                <th class="num tok-cc" style="color:var(--ink-faint);">Cache C</th>
+                <th class="num">
+                  推計コスト
+                  <span class="help-host">
+                    <button class="help-btn" type="button" aria-label="コストの説明" aria-expanded="false" data-help-id="hp-cost">?</button>
+                    <span class="help-pop" id="hp-cost" role="tooltip" data-place="left">
+                      <span class="pop-ttl">推計コスト</span>
+                      <span class="pop-body">
+                        実測 token × モデル別公開価格表の掛け算による<strong>参考値</strong>。
+                        Anthropic が価格改定すると過去値も再計算で動く。
+                        cache create / read / input / output で単価が異なるため、
+                        token 4 種を分けて積算している。
+                      </span>
+                    </span>
+                  </span>
+                </th>
+                <th>
+                  Service tier
+                  <span class="help-host">
+                    <button class="help-btn" type="button" aria-label="Service tier の説明" aria-expanded="false" data-help-id="hp-tier">?</button>
+                    <span class="help-pop" id="hp-tier" role="tooltip" data-place="left">
+                      <span class="pop-ttl">Service tier</span>
+                      <span class="pop-body">
+                        <code>priority</code> / <code>standard</code> / <code>batch</code> は Anthropic API 側で記録される料金ティア。<br>
+                        <code>priority</code>: Priority Tier (有料の優先度確約枠)。レイテンシ・容量保証の代わりに割増料金。<br>
+                        <code>standard</code>: 通常リクエスト (Claude Code のデフォルト)。<br>
+                        <code>batch</code>: Batch API 経由 (50% 割引・最大 24h で完了)。Claude Code では稀。<br>
+                        1 session 内で混在し得る (<code>/model</code> 切替・再接続で経路が変わる)。
+                      </span>
+                    </span>
+                  </span>
+                </th>
+                <th class="num">Skills</th>
+                <th class="num">Subagents</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- ============== ACTIVE SESSIONS (3) ============== -->
+
+              <!-- ROW: active opus-heavy whale-in-progress -->
+              <tr class="is-active is-whale" tabindex="0">
+                <td class="sess-time">05/06 09:14</td>
+                <td><span class="live-pill">進行中</span></td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-opus">opus <span class="ct">8</span></span>
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num">2.1M</td>
+                <td class="num">38.2k</td>
+                <td class="num tok-cr sess-tok-cache">14.8M</td>
+                <td class="num tok-cc sess-tok-cache">412k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 71%;">
+                    <span class="cost-val">$3.2104</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">10</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">7</td>
+                <td class="num count-pos">3</td>
+              </tr>
+
+              <!-- ROW: active short sonnet -->
+              <tr class="is-active" tabindex="0">
+                <td class="sess-time">05/06 08:51</td>
+                <td><span class="live-pill">進行中</span></td>
+                <td class="sess-proj">personal-website</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">4</span></span>
+                  </div>
+                </td>
+                <td class="num">182k</td>
+                <td class="num">6.3k</td>
+                <td class="num tok-cr sess-tok-cache">920k</td>
+                <td class="num tok-cc sess-tok-cache">48k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 9%;">
+                    <span class="cost-val">$0.1842</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">4</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">2</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: active mixed-model investigation -->
+              <tr class="is-active" tabindex="0">
+                <td class="sess-time">05/06 07:32</td>
+                <td><span class="live-pill">進行中</span></td>
+                <td class="sess-proj">work-rails-api</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-opus">opus <span class="ct">2</span></span>
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">5</span></span>
+                    <span class="model-chip m-haiku">haiku <span class="ct">3</span></span>
+                  </div>
+                </td>
+                <td class="num">621k</td>
+                <td class="num">14.7k</td>
+                <td class="num tok-cr sess-tok-cache">3.8M</td>
+                <td class="num tok-cc sess-tok-cache">126k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 19%;">
+                    <span class="cost-val">$0.7621</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">3</span></span>
+                    <span class="tier-chip t-standard">standard <span class="ct">7</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">5</td>
+                <td class="num count-pos">2</td>
+              </tr>
+
+              <!-- ============== COMPLETED SESSIONS ============== -->
+
+              <!-- ROW: WHALE — closed long opus session -->
+              <tr class="is-whale" tabindex="0">
+                <td class="sess-time">05/05 21:08</td>
+                <td class="sess-dur">4h 47m</td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-opus">opus <span class="ct">23</span></span>
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">6</span></span>
+                  </div>
+                </td>
+                <td class="num">5.4M</td>
+                <td class="num">141.8k</td>
+                <td class="num tok-cr sess-tok-cache">38.2M</td>
+                <td class="num tok-cc sess-tok-cache">1.1M</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 100%;">
+                    <span class="cost-val">$5.8210</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">12</span></span>
+                    <span class="tier-chip t-standard">standard <span class="ct">17</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">14</td>
+                <td class="num count-pos">8</td>
+              </tr>
+
+              <!-- ROW: normal sonnet medium -->
+              <tr tabindex="0">
+                <td class="sess-time">05/05 18:42</td>
+                <td class="sess-dur">2h 14m</td>
+                <td class="sess-proj">experiment-rag-eval</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">9</span></span>
+                  </div>
+                </td>
+                <td class="num">1.2M</td>
+                <td class="num">28.4k</td>
+                <td class="num tok-cr sess-tok-cache">8.4M</td>
+                <td class="num tok-cc sess-tok-cache">241k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 24%;">
+                    <span class="cost-val">$1.0923</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">9</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">6</td>
+                <td class="num count-pos">2</td>
+              </tr>
+
+              <!-- ROW: normal sonnet medium with priority -->
+              <tr tabindex="0">
+                <td class="sess-time">05/05 16:11</td>
+                <td class="sess-dur">1h 38m</td>
+                <td class="sess-proj">work-rails-api</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">7</span></span>
+                  </div>
+                </td>
+                <td class="num">844k</td>
+                <td class="num">19.1k</td>
+                <td class="num tok-cr sess-tok-cache">5.2M</td>
+                <td class="num tok-cc sess-tok-cache">158k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 17%;">
+                    <span class="cost-val">$0.7184</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">5</span></span>
+                    <span class="tier-chip t-standard">standard <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">4</td>
+                <td class="num count-pos">1</td>
+              </tr>
+
+              <!-- ROW: normal sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/05 14:55</td>
+                <td class="sess-dur">52m</td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">5</span></span>
+                  </div>
+                </td>
+                <td class="num">412k</td>
+                <td class="num">9.2k</td>
+                <td class="num tok-cr sess-tok-cache">2.6M</td>
+                <td class="num tok-cc sess-tok-cache">81k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 8%;">
+                    <span class="cost-val">$0.3412</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">5</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">3</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: normal sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/05 12:21</td>
+                <td class="sess-dur">41m</td>
+                <td class="sess-proj">dotfiles</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">3</span></span>
+                  </div>
+                </td>
+                <td class="num">238k</td>
+                <td class="num">5.4k</td>
+                <td class="num tok-cr sess-tok-cache">1.4M</td>
+                <td class="num tok-cc sess-tok-cache">52k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 5%;">
+                    <span class="cost-val">$0.1923</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">3</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">2</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: cheap short sonnet -->
+              <tr class="is-cheap" tabindex="0">
+                <td class="sess-time">05/05 11:44</td>
+                <td class="sess-dur">5m</td>
+                <td class="sess-proj">personal-website</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">1</span></span>
+                  </div>
+                </td>
+                <td class="num">18k</td>
+                <td class="num">412</td>
+                <td class="num tok-cr sess-tok-cache">94k</td>
+                <td class="num tok-cc sess-tok-cache">3.2k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 0.5%;">
+                    <span class="cost-val">$0.0084</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">1</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">1</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: HAIKU-only ultra cheap -->
+              <tr class="is-cheap" tabindex="0">
+                <td class="sess-time">05/05 10:08</td>
+                <td class="sess-dur">12m</td>
+                <td class="sess-proj">experiment-rag-eval</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-haiku">haiku <span class="ct">8</span></span>
+                  </div>
+                </td>
+                <td class="num">96k</td>
+                <td class="num">2.1k</td>
+                <td class="num tok-cr sess-tok-cache">0</td>
+                <td class="num tok-cc sess-tok-cache">0</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 0.02%;">
+                    <span class="cost-val">$0.0011</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-batch">batch <span class="ct">8</span></span>
+                  </div>
+                </td>
+                <td class="num count-zero">0</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: normal sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/04 22:18</td>
+                <td class="sess-dur">1h 22m</td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">6</span></span>
+                  </div>
+                </td>
+                <td class="num">658k</td>
+                <td class="num">14.8k</td>
+                <td class="num tok-cr sess-tok-cache">4.1M</td>
+                <td class="num tok-cc sess-tok-cache">128k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 13%;">
+                    <span class="cost-val">$0.5421</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">6</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">3</td>
+                <td class="num count-pos">1</td>
+              </tr>
+
+              <!-- ROW: opus medium -->
+              <tr tabindex="0">
+                <td class="sess-time">05/04 19:42</td>
+                <td class="sess-dur">2h 03m</td>
+                <td class="sess-proj">work-rails-api</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-opus">opus <span class="ct">4</span></span>
+                  </div>
+                </td>
+                <td class="num">1.8M</td>
+                <td class="num">29.4k</td>
+                <td class="num tok-cr sess-tok-cache">9.6M</td>
+                <td class="num tok-cc sess-tok-cache">288k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 36%;">
+                    <span class="cost-val">$1.4823</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">4</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">5</td>
+                <td class="num count-pos">2</td>
+              </tr>
+
+              <!-- ROW: short cheap haiku batch -->
+              <tr class="is-cheap" tabindex="0">
+                <td class="sess-time">05/04 17:08</td>
+                <td class="sess-dur">8m</td>
+                <td class="sess-proj">dotfiles</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-haiku">haiku <span class="ct">3</span></span>
+                  </div>
+                </td>
+                <td class="num">42k</td>
+                <td class="num">980</td>
+                <td class="num tok-cr sess-tok-cache">0</td>
+                <td class="num tok-cc sess-tok-cache">0</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 0.05%;">
+                    <span class="cost-val">$0.0027</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-batch">batch <span class="ct">3</span></span>
+                  </div>
+                </td>
+                <td class="num count-zero">0</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: normal sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/04 14:33</td>
+                <td class="sess-dur">1h 11m</td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">5</span></span>
+                  </div>
+                </td>
+                <td class="num">534k</td>
+                <td class="num">11.2k</td>
+                <td class="num tok-cr sess-tok-cache">3.4M</td>
+                <td class="num tok-cc sess-tok-cache">102k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 11%;">
+                    <span class="cost-val">$0.4421</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">5</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">2</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: short sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/04 11:02</td>
+                <td class="sess-dur">28m</td>
+                <td class="sess-proj">experiment-rag-eval</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num">128k</td>
+                <td class="num">2.9k</td>
+                <td class="num tok-cr sess-tok-cache">740k</td>
+                <td class="num tok-cc sess-tok-cache">28k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 3%;">
+                    <span class="cost-val">$0.1023</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">1</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: opus medium-cheap -->
+              <tr tabindex="0">
+                <td class="sess-time">05/03 23:14</td>
+                <td class="sess-dur">38m</td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-opus">opus <span class="ct">3</span></span>
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">1</span></span>
+                  </div>
+                </td>
+                <td class="num">412k</td>
+                <td class="num">8.7k</td>
+                <td class="num tok-cr sess-tok-cache">2.1M</td>
+                <td class="num tok-cc sess-tok-cache">68k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 8%;">
+                    <span class="cost-val">$0.3284</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">2</span></span>
+                    <span class="tier-chip t-standard">standard <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">3</td>
+                <td class="num count-pos">1</td>
+              </tr>
+
+              <!-- ROW: normal sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/03 19:51</td>
+                <td class="sess-dur">1h 47m</td>
+                <td class="sess-proj">work-rails-api</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">8</span></span>
+                  </div>
+                </td>
+                <td class="num">912k</td>
+                <td class="num">19.4k</td>
+                <td class="num tok-cr sess-tok-cache">5.8M</td>
+                <td class="num tok-cc sess-tok-cache">172k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 14%;">
+                    <span class="cost-val">$0.6112</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">8</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">4</td>
+                <td class="num count-pos">2</td>
+              </tr>
+
+              <!-- ROW: cheap sonnet -->
+              <tr class="is-cheap" tabindex="0">
+                <td class="sess-time">05/03 16:08</td>
+                <td class="sess-dur">14m</td>
+                <td class="sess-proj">personal-website</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num">82k</td>
+                <td class="num">1.8k</td>
+                <td class="num tok-cr sess-tok-cache">412k</td>
+                <td class="num tok-cc sess-tok-cache">15k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 1.5%;">
+                    <span class="cost-val">$0.0612</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">1</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+              <!-- ROW: opus heavy with priority -->
+              <tr tabindex="0">
+                <td class="sess-time">05/03 11:22</td>
+                <td class="sess-dur">3h 02m</td>
+                <td class="sess-proj">claude-transcript-analyzer</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-opus">opus <span class="ct">12</span></span>
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">3</span></span>
+                  </div>
+                </td>
+                <td class="num">3.1M</td>
+                <td class="num">62.4k</td>
+                <td class="num tok-cr sess-tok-cache">21.8M</td>
+                <td class="num tok-cc sess-tok-cache">612k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 56%;">
+                    <span class="cost-val">$2.4189</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-priority">priority <span class="ct">8</span></span>
+                    <span class="tier-chip t-standard">standard <span class="ct">7</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">9</td>
+                <td class="num count-pos">4</td>
+              </tr>
+
+              <!-- ROW: short sonnet -->
+              <tr tabindex="0">
+                <td class="sess-time">05/03 09:14</td>
+                <td class="sess-dur">22m</td>
+                <td class="sess-proj">dotfiles</td>
+                <td>
+                  <div class="model-chips">
+                    <span class="model-chip m-sonnet">sonnet <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num">98k</td>
+                <td class="num">2.2k</td>
+                <td class="num tok-cr sess-tok-cache">512k</td>
+                <td class="num tok-cc sess-tok-cache">19k</td>
+                <td>
+                  <div class="cost-cell" style="--cost-pct: 1.8%;">
+                    <span class="cost-val">$0.0729</span>
+                    <span class="cost-bar"></span>
+                  </div>
+                </td>
+                <td>
+                  <div class="tier-chips">
+                    <span class="tier-chip t-standard">standard <span class="ct">2</span></span>
+                  </div>
+                </td>
+                <td class="num count-pos">1</td>
+                <td class="num count-zero">0</td>
+              </tr>
+
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <!-- =================================================================
+           Design notes (visible to designer + maintainer; remove before ship)
+           ================================================================= -->
+      <aside class="design-notes" aria-label="design notes">
+        <h3>Design notes <span style="color:var(--ink-faint);font-weight:400;font-size:11px;">— remove from production</span></h3>
+
+        <h4>Typography &amp; spacing</h4>
+        <ul>
+          <li><code>font-family</code> on the table is <code>--ff-mono</code> at <code>12px</code> — exactly matching <code>.surface-table</code>. The chips drop to <code>10px</code> so 2 chips fit in the same vertical rhythm as a single mono number.</li>
+          <li>Row padding is <code>8px</code> vertical (vs. <code>5px</code> on Surface) — Sessions rows carry more chips, so the extra breathing room prevents chip stacks from feeling cramped. The cost cell uses inner <code>4px 8px</code> so the magnitude bar has its own micro-padding.</li>
+          <li><code>letter-spacing: -0.01em</code> on the cost value is the same trick used by KPI <code>.v</code> — tightens the dollar number so <code>$5.8210</code> reads as one glyph cluster.</li>
+        </ul>
+
+        <h4>Why this column layout</h4>
+        <ul>
+          <li><strong>Token columns documented via help-pop, not super-header.</strong> Earlier draft used a visible <code>Tokens</code> column-group label in peri above the 4 numeric columns. Per review, replaced with a single <code>?</code> help-pop on the <code>Input</code> header documenting all 4 token types (input / output / cache read / cache create) and their relative pricing. The popup carries far more useful information than the super-label could (cache R is ~1/10 input price, cache C is 1.25× input, etc.) and matches the existing <code>.help-host/.help-btn/.help-pop</code> grammar already used elsewhere on the dashboard. Cache R/Cache C are still dimmed (<code>--ink-faint</code>) at the column level so they read as supporting evidence rather than headline metrics.</li>
+          <li><strong>Service tier also gets a help-pop.</strong> <code>priority / standard / batch</code> are not self-explanatory — a user seeing all 3 chips on the same row needs to know that priority means a paid latency-guarantee tier (Anthropic-side billing concept, mixable per-message via <code>/model</code> switch / reconnection), not a Claude Code preference.</li>
+          <li><strong>Session ID column dropped per maintainer feedback.</strong> The 8-char shortened ID was rarely actionable in the row-level ledger view: <code>project + 開始時刻</code> already uniquely identifies a session at a glance, and freed width goes to the <code>Project</code> column where long names actually need it. Drill-down to per-message timeline (where the full <code>session_id</code> would be shown in a header) is a future feature.</li>
+          <li><strong>Cost gets the headline treatment.</strong> Inline magnitude bar with <code>--cost-pct</code> custom-property scaling (set per row at render time as <code>max(row_cost) / row_cost</code>). The whale row visually anchors the table at <code>100%</code>; everything else is a fraction. Whale + cheap rows get tinted values (peach / ink-soft) so cost-class is recognizable in &lt;200ms.</li>
+          <li><strong>Models / Tier are chip-stacks, not strings.</strong> Color-coding is intentional and reuses the dashboard's accent palette so cost-class is doubly encoded: opus reads as coral (premium) without needing to know the price table, sonnet reads as mint (workhorse), haiku as peach (cheap-and-fast). Tier reuses peri (priority) / ink-soft (standard) / peach (batch) — peri was chosen for priority instead of mint to avoid color-clash with the active-row mint background tint.</li>
+          <li><strong>進行中 pill</strong> reuses <code>conn-pulse</code> (already in <code>10_components.css</code>) so live sessions inherit the same heartbeat motif as the connection badge. Active rows also get a subtle mint-tinted background (<code>rgba(111,227,200,0.04)</code>) so they pop without needing to be visually heavy.</li>
+        </ul>
+
+        <h4>What was sacrificed</h4>
+        <ul>
+          <li><strong>Per-message granularity.</strong> The chip <code>opus (8)</code> shows count of <code>llm_response</code> events but not their individual cost contribution. Click-through to a per-session detail panel is the natural next step (out of scope for this mock).</li>
+          <li><strong>Sortability indicator.</strong> No header sort glyphs in this draft — the spec says "sorted by start time descending" only. If the maintainer wants ad-hoc sort by cost / duration / token-count, add <code>aria-sort</code> + a small chevron in column headers. Cheap to add later.</li>
+          <li><strong>Filter UI.</strong> No project-filter dropdown / model-filter chips above the table. The Period toggle pattern from Overview/Patterns could be reused for "今日 / 7d / 30d" but that pushes scope past Issue #103. For 20 rows, scrolling is faster than filtering anyway.</li>
+          <li><strong>モデル使用比率のドーナツ/円グラフ</strong>は、本ページではなく <strong>Overview ページの「モデル分布」パネル</strong> (既存「プロジェクト分布」横の stacked bar grammar を流用) として別 Issue で追加予定。Sessions ページは「1 行 = 1 session の台帳」が役割なので、集約系のチャートは持たない。</li>
+        </ul>
+
+        <h4>What changes at narrow viewport</h4>
+        <ul>
+          <li>At <code>&lt;1280px</code>, the two cache-token columns (<code>Cache R</code> / <code>Cache C</code>) hide via <code>display: none</code> on <code>col</code> and <code>th/td</code>. The full numbers stay in the API response, just not in the visual table — they're recoverable via row hover tooltip (proposal: data-tip pattern from <code>20_help_tooltip.css</code>, not implemented in this mock).</li>
+          <li>At <code>&lt;1080px</code>, recommend collapsing chip stacks to "most-frequent label only" (e.g. <code>opus 8</code> instead of <code>opus 8 / sonnet 2</code>) and showing the secondary chip in a hover tooltip. Not implemented — would need JS.</li>
+          <li>At <code>&lt;720px</code>, the table becomes scrollable horizontally with a sticky <code>Session</code> + <code>Project</code> column-pair. CSS-only via <code>position: sticky; left: 0</code> on the first 2 cells. Also not implemented in this mock.</li>
+        </ul>
+
+        <h4>Class additions vs reuse summary</h4>
+        <ul>
+          <li><span class="tag">REUSED</span> <code>.panel</code>, <code>.panel-head</code>, <code>.help-host/.help-btn/.help-pop</code>, <code>.kpi/.kpi-row</code>, <code>.page-nav</code>, <code>conn-pulse</code> keyframes</li>
+          <li><span class="tag">EXTENDED</span> <code>.surface-table</code> grammar (mono / 12px / num-right / hover-row) — namespaced under <code>.sessions-table</code> because of the <code>colgroup</code> + group-header row</li>
+          <li><span class="tag">NEW</span> <code>.model-chip.m-{opus,sonnet,haiku}</code> — mirrors <code>.mode-chip</code> family</li>
+          <li><span class="tag">NEW</span> <code>.tier-chip.t-{priority,standard,batch}</code> — same pattern</li>
+          <li><span class="tag">NEW</span> <code>.cost-cell</code> + <code>.cost-bar</code> — inline magnitude visualisation, scales via <code>--cost-pct</code> CSS var set per-row by aggregator</li>
+          <li><span class="tag">NEW</span> <code>.live-pill</code> — wraps <code>conn-pulse</code> in a pill shape for the 進行中 marker</li>
+        </ul>
+
+        <h4>Open questions for the maintainer</h4>
+        <ul>
+          <li>Whale-row peach left-edge (3px <code>inset box-shadow</code>) — too loud? Could be dialled down to a 1px border instead, or removed entirely if the cost-bar magnitude is sufficient.</li>
+          <li>Cost bar gradient goes <code>mint-soft → peach → coral</code>. An alternative is a single solid <code>peri</code> bar (matches the help-pop trigger color). The gradient encodes "cheap → expensive" as a bonus; flat peri reads as "neutral magnitude bar". Either works; kept the gradient for now because the headline-cost framing in the spec asks for visual prominence.</li>
+          <li>Row tinting for active sessions — currently <code>rgba(111,227,200, 0.04)</code> (very subtle). At very narrow viewports / on glossy displays this can drop below perceptible threshold. Consider bumping to <code>0.06</code> or pairing with a left-edge mint stripe to mirror the whale treatment.</li>
+        </ul>
+      </aside>
+
+    </section>
+
+    <!-- =================================================================
+         FOOTER (verbatim shape, mock values)
+         ================================================================= -->
+    <footer class="app-footer">
+      <div class="meta">
+        <span class="conn-status" data-state="online">● live</span>
+        <span class="meta-item"><span class="k">最終更新</span><span class="v">09:17:42</span></span>
+        <span class="meta-item"><span class="k">sessions</span><span class="v">20</span></span>
+      </div>
+      <div class="credits">
+        <span class="accent">claude-transcript-analyzer</span> · v0.7.4<span class="sep">·</span>stdlib only · no third-party js
+      </div>
+    </footer>
+
+  </div>
+
+<script>
+/* Tiny help-pop toggle — mirrors production behavior of 80_help_popup.js
+   so designers can verify the `?` button works on click as well as hover.
+   Click-toggles aria-expanded + data-open; click outside closes any open. */
+(function(){
+  document.addEventListener('click', function(ev){
+    var btn = ev.target.closest && ev.target.closest('.help-btn');
+    if (btn) {
+      ev.preventDefault();
+      var expanded = btn.getAttribute('aria-expanded') === 'true';
+      // close any other open
+      document.querySelectorAll('.help-btn[aria-expanded="true"]').forEach(function(b){
+        if (b !== btn) {
+          b.setAttribute('aria-expanded', 'false');
+          var p = document.getElementById(b.getAttribute('data-help-id'));
+          if (p) p.removeAttribute('data-open');
+        }
+      });
+      btn.setAttribute('aria-expanded', expanded ? 'false' : 'true');
+      var pop = document.getElementById(btn.getAttribute('data-help-id'));
+      if (pop) {
+        if (expanded) pop.removeAttribute('data-open');
+        else pop.setAttribute('data-open', 'true');
+      }
+      return;
+    }
+    // click outside any help-host closes all
+    if (!ev.target.closest('.help-host')) {
+      document.querySelectorAll('.help-btn[aria-expanded="true"]').forEach(function(b){
+        b.setAttribute('aria-expanded', 'false');
+        var p = document.getElementById(b.getAttribute('data-help-id'));
+        if (p) p.removeAttribute('data-open');
+      });
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/spec/dashboard-runtime.md
+++ b/docs/spec/dashboard-runtime.md
@@ -90,7 +90,7 @@ kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)
 
 ## ダッシュボード複数ページ構成
 
-ダッシュボードは **ハッシュベース router で 4 ページ** に分割。
+ダッシュボードは **ハッシュベース router で 5 ページ** に分割。
 
 ### ページ構成
 
@@ -100,10 +100,11 @@ kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)
 | `#/patterns` | `patterns` | Patterns | 利用パターン (時間帯 / 共起 / project×skill) |
 | `#/quality` | `quality` | Quality | 実行品質と摩擦シグナル (permission / compact / percentile) |
 | `#/surface` | `surface` | Surface | スキル surface (発見性 / 想起性) |
+| `#/sessions` | `sessions` | Sessions | session 単位の token / 推計コスト / model 内訳 / service_tier (Issue #103) |
 
 ### 共通 chrome と Overview 専用 chrome の分離
 
-- **共通頂部 nav** (`<nav class="page-nav">`): 4 タブ。`.app` 直下、全ページに表示
+- **共通頂部 nav** (`<nav class="page-nav">`): 5 タブ。`.app` 直下、全ページに表示
 - **共通 footer** (`<footer class="app-footer">`): conn-status / lastRx / sessVal /
   クレジット行。全ページに表示（接続バッジは Overview 以外のページからも見える）
 - **Overview 専用 header** (`<header class="header">`): h1「Claude Code Usage
@@ -111,7 +112,7 @@ kill $(jq -r .pid ~/.claude/transcript-analyzer/server.json)
 
 ### Router の動作仕様
 
-- **DOM 構造**: 4 つの `<section data-page="...">` を DOM に常駐させ、`hidden`
+- **DOM 構造**: 5 つの `<section data-page="...">` を DOM に常駐させ、`hidden`
   属性切替でページ表示を切り替える（DOM tree から削除しない）
 - **router IIFE**: `<script>` ブロック内に独立した IIFE で実装。`HASH_TO_PAGE`
   テーブル + `applyRoute(rawHash)` + `hashchange` listener。SSE refresh 経路と
@@ -145,9 +146,12 @@ hashchange listener を 1 本持つ。router IIFE は先に登録されている
   hashchange listener で active page slot に DOM を `appendChild` で move する
   (1 DOM 維持 / state sync 不要)。router IIFE (`00_router.js`) の hashchange listener
   で `body.dataset.activePage` が先に更新されてから本 listener が走る (登録順 = 発火順)。
-- **可視範囲**: Overview / Patterns 表示時のみ可視。Quality / Surface には slot が
-  存在しないので move 先が無く、`body[data-active-page="quality"|"surface"] #periodToggle { display: none }`
-  の page-scoped CSS rule で隠す (toggle DOM は前 page の slot に残る)。
+- **可視範囲**: Overview / Patterns 表示時のみ可視。Quality / Surface / Sessions には slot が
+  存在しないので move 先が無く、`body[data-active-page="quality"|"surface"|"sessions"] #periodToggle { display: none }`
+  の page-scoped CSS rule で隠す (toggle DOM は前 page の slot に残る)。Sessions ページの
+  `session_breakdown` 自体は Overview/Patterns で設定した period が継続適用される
+  (`aggregate_session_breakdown` が `period_events_raw` を経由して in-period content を集計)
+  が、Sessions ページから period を切り替える UI は持たない (Issue #103)。
 - **State**: `05_period.js` の closure-private `__periodCurrent` で持ち、
   `window.__period.{getCurrentPeriod, setCurrentPeriod, wirePeriodToggle}` を expose。
   click handler で `aria-pressed` 付け替え + `setCurrentPeriod(p)` + 再 fetch を呼ぶ。

--- a/tests/test_dashboard_heartbeat.py
+++ b/tests/test_dashboard_heartbeat.py
@@ -222,6 +222,10 @@ def _node_eval_heartbeat(prelude: str, script: str) -> object:
     src = _HEARTBEAT_JS.read_text(encoding="utf-8")
     full = prelude + "\n" + src + "\n" + script
     env = os.environ.copy()
+    # Windows GitHub runner では Node の cold-start が 10 秒を超えるバラツキで
+    # subprocess.TimeoutExpired を出して flaky になる (Issue #103 PR で観測)。
+    # 30 秒まで猶予を持たせる: 同 test は通常 1〜2 秒で完了する想定なので、
+    # ここで延ばしても通常 CI 時間に影響なし、Windows tail-latency にだけ効く。
     proc = subprocess.run(
         [_NODE, "-e", full],
         env=env,
@@ -229,7 +233,7 @@ def _node_eval_heartbeat(prelude: str, script: str) -> object:
         text=True,
         encoding="utf-8",
         check=False,
-        timeout=10,
+        timeout=30,
     )
     if proc.returncode != 0:
         raise AssertionError(

--- a/tests/test_dashboard_router.py
+++ b/tests/test_dashboard_router.py
@@ -46,16 +46,16 @@ def _extract_footer(template: str) -> str:
 #  TestRouterShellStructure (10 tests / proposal-1+4 反映)
 # ============================================================
 class TestRouterShellStructure:
-    def test_template_has_four_page_nav_links(self):
-        """nav は 4 タブ (Overview / Patterns / Quality / Surface)"""
+    def test_template_has_five_page_nav_links(self):
+        """nav は 5 タブ (Overview / Patterns / Quality / Surface / Sessions — Issue #103)"""
         template = _load_template()
-        for path in ['#/', '#/patterns', '#/quality', '#/surface']:
+        for path in ['#/', '#/patterns', '#/quality', '#/surface', '#/sessions']:
             assert f'href="{path}"' in template, f"nav link href={path} not found"
 
-    def test_template_has_four_page_sections(self):
-        """4 つの <section data-page="..."> が存在"""
+    def test_template_has_five_page_sections(self):
+        """5 つの <section data-page="..."> が存在 (Issue #103 で sessions 追加)"""
         template = _load_template()
-        for page in ['overview', 'patterns', 'quality', 'surface']:
+        for page in ['overview', 'patterns', 'quality', 'surface', 'sessions']:
             assert f'data-page="{page}"' in template, f"section data-page={page} not found"
 
     def test_overview_page_contains_existing_widgets(self):

--- a/tests/test_dashboard_sessions_ui.py
+++ b/tests/test_dashboard_sessions_ui.py
@@ -1,0 +1,472 @@
+"""tests/test_dashboard_sessions_ui.py — Issue #103 Sessions ページ UI 構造 + 振る舞い。
+
+Sessions ページ (5 番目のタブ / hash route `#/sessions`) の以下を pin する:
+
+1. Template 構造:
+   - nav 5 タブ化 (Overview / Patterns / Quality / Surface / Sessions)
+   - `<section data-page="sessions">` の存在 + 主要 DOM ID (`sessionsKpi` / `sessionsTable` /
+     `sessionsSub`) + colgroup 12 列 + thead 2 行 (group-row + data-row)
+   - help-pop: `hp-sessions` / `hp-tokens` / `hp-cost` / `hp-tier`
+   - JS / CSS の concat 順 (`45_renderers_sessions.js` / `55_sessions.css`)
+   - `00_router.js` の HASH_TO_PAGE 拡張
+   - `20_load_and_render.js` から `renderSessions(data)` を呼び出している
+
+2. Renderer 関数の構造 pin (45_renderers_sessions.js):
+   - `function renderSessions(...)` 定義
+   - `window.__sessions = { ... }` expose
+   - page-scoped early-out (`activePage !== 'sessions'`)
+
+3. Behavior round-trip (Node 経由):
+   - `formatCostUsd($X.XXXX 4 桁)` / `fmtTokens (M / k notation)` / `inferModelFamily`
+   - `buildModelChips` / `buildTierChips`
+   - `buildSessionRow` (active session に live-pill / whale row class)
+   - `computeKpi` (合計 / 中央値 / 平均 / cache 効率)
+
+DOM 描画系 (innerHTML への注入) の最終確認は visual smoke (chrome-devtools MCP) に委譲し、
+本テストでは生成 HTML 文字列の構造のみを検証する。
+"""
+# pylint: disable=line-too-long
+import json
+import os
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+from _dashboard_template_loader import load_assembled_template
+
+_TEMPLATE_DIR = Path(__file__).parent.parent / "dashboard" / "template"
+_HELPERS_JS = _TEMPLATE_DIR / "scripts" / "10_helpers.js"
+_RENDERERS_JS = _TEMPLATE_DIR / "scripts" / "45_renderers_sessions.js"
+_LOAD_RENDER_JS = _TEMPLATE_DIR / "scripts" / "20_load_and_render.js"
+_ROUTER_JS = _TEMPLATE_DIR / "scripts" / "00_router.js"
+_SESSIONS_CSS = _TEMPLATE_DIR / "styles" / "55_sessions.css"
+
+
+def _load_template() -> str:
+    return load_assembled_template()
+
+
+def _extract_section(template: str, page: str) -> str:
+    match = re.search(rf'<section\b[^>]*data-page="{re.escape(page)}"[^>]*>', template)
+    assert match is not None, f"<section data-page={page!r}> not found"
+    section_open = match.start()
+    end = template.index('</section>', match.end())
+    return template[section_open:end + len('</section>')]
+
+
+# ============================================================
+#  TestSessionsPageTemplate — DOM 構造の structural pin
+# ============================================================
+class TestSessionsPageTemplate:
+    def test_nav_has_sessions_link(self):
+        """nav に Sessions リンク (#/sessions) が追加されている。"""
+        template = _load_template()
+        assert 'href="#/sessions"' in template, "nav に href=#/sessions が無い"
+        assert 'data-page-link="sessions"' in template, "data-page-link=sessions が無い"
+
+    def test_nav_has_five_links_in_order(self):
+        """nav に 5 タブ (Overview / Patterns / Quality / Surface / Sessions) が
+        この順番で並ぶ (Sessions は最後 = period toggle の前)。"""
+        template = _load_template()
+        positions = []
+        for path in ['#/', '#/patterns', '#/quality', '#/surface', '#/sessions']:
+            idx = template.index(f'href="{path}"')
+            positions.append((idx, path))
+        assert positions == sorted(positions), \
+            f"nav 順序が overview→patterns→quality→surface→sessions でない: {positions}"
+
+    def test_template_has_sessions_section(self):
+        """<section data-page="sessions"> が存在する。"""
+        template = _load_template()
+        assert 'data-page="sessions"' in template, "section data-page=sessions が無い"
+
+    def test_sessions_section_contains_main_dom_ids(self):
+        """Sessions section に主要 DOM ID (sessionsKpi / sessionsTable / sessionsSub) がある。"""
+        section = _extract_section(_load_template(), 'sessions')
+        for el_id in ['sessionsKpi', 'sessionsTable', 'sessionsSub']:
+            assert f'id="{el_id}"' in section, f"id={el_id} が Sessions section に無い"
+
+    def test_sessions_table_has_colgroup_with_twelve_cols(self):
+        """sessionsTable の colgroup に 12 col 定義が並ぶ (cost / project / tier 等)。"""
+        section = _extract_section(_load_template(), 'sessions')
+        idx = section.index('id="sessionsTable"')
+        cg_start = section.index('<colgroup>', idx)
+        cg_end = section.index('</colgroup>', cg_start)
+        colgroup = section[cg_start:cg_end]
+        # 12 個の <col> 要素 (<colgroup と区別するため space 付で count)
+        col_count = len(re.findall(r'<col\b(?!group)', colgroup))
+        assert col_count == 12, \
+            f"sessionsTable colgroup に <col> が 12 個無い (got {col_count})"
+        # 主要 col クラス
+        for cls in ['col-start', 'col-dur', 'col-project', 'col-models',
+                    'col-tok-in', 'col-tok-out', 'col-tok-cr', 'col-tok-cc',
+                    'col-cost', 'col-tier', 'col-skills', 'col-sub']:
+            assert f'col-{cls.split("-",1)[1]}"' in colgroup or f'col-{cls.split("-",1)[1]}' in colgroup, \
+                f"col class {cls} が colgroup に無い"
+
+    def test_sessions_table_thead_has_group_row_and_data_row(self):
+        """thead に group-row (Tokens super-group) + data-row が両方ある。"""
+        section = _extract_section(_load_template(), 'sessions')
+        idx = section.index('id="sessionsTable"')
+        thead_start = section.index('<thead>', idx)
+        thead_end = section.index('</thead>', thead_start)
+        thead = section[thead_start:thead_end]
+        assert 'class="group-row"' in thead, "thead に class=group-row が無い"
+        assert 'class="data-row"' in thead, "thead に class=data-row が無い"
+        # group-row が data-row より先に現れる
+        assert thead.index('class="group-row"') < thead.index('class="data-row"'), \
+            "group-row は data-row より先に現れる必要がある"
+
+    def test_sessions_table_data_row_columns(self):
+        """data-row に必要列 (Project / Models / Input / Output / 推計コスト / Service tier / Skills / Subagents) がある。"""
+        section = _extract_section(_load_template(), 'sessions')
+        idx = section.index('class="data-row"')
+        end = section.index('</tr>', idx)
+        data_row = section[idx:end]
+        for col in ['開始時刻', '期間', 'プロジェクト', 'Models', 'Input', 'Output',
+                    'Cache R', 'Cache C', '推計コスト', 'Service tier', 'Skills', 'Subagents']:
+            assert col in data_row, f"data-row 列見出し '{col}' が無い"
+
+    def test_sessions_help_popups_present(self):
+        """4 つの help-pop (hp-sessions / hp-tokens / hp-cost / hp-tier) が template に存在。"""
+        template = _load_template()
+        for hid in ['hp-sessions', 'hp-tokens', 'hp-cost', 'hp-tier']:
+            assert f'id="{hid}"' in template, f"help-pop id={hid} が無い"
+
+    def test_session_id_column_not_present(self):
+        """Issue #103 v1 mock 決定: Session ID 列は廃止 (project + 時刻で実質一意)。"""
+        section = _extract_section(_load_template(), 'sessions')
+        idx = section.index('id="sessionsTable"')
+        thead_start = section.index('<thead>', idx)
+        thead_end = section.index('</thead>', thead_start)
+        thead = section[thead_start:thead_end]
+        assert 'Session ID' not in thead, \
+            "Session ID 列見出しが残っている (mock 決定では廃止)"
+
+    def test_router_hash_to_page_includes_sessions(self):
+        """00_router.js の HASH_TO_PAGE に '#/sessions': 'sessions' がある。"""
+        body = _ROUTER_JS.read_text(encoding='utf-8')
+        assert "'#/sessions': 'sessions'" in body, \
+            "HASH_TO_PAGE に '#/sessions': 'sessions' が無い"
+
+    def test_concat_includes_renderers_sessions_js(self):
+        """`_MAIN_JS_FILES` の concat 結果に 45_renderers_sessions.js の内容が含まれる。"""
+        template = _load_template()
+        assert 'function renderSessions' in template, \
+            "_HTML_TEMPLATE に renderSessions の定義が無い (concat 漏れ?)"
+
+    def test_concat_includes_sessions_css(self):
+        """`_CSS_FILES` の concat 結果に 55_sessions.css の内容が含まれる。"""
+        template = _load_template()
+        # sessions-table grammar の鍵スタイル
+        assert '.sessions-table' in template, \
+            "_HTML_TEMPLATE に .sessions-table CSS が無い (concat 漏れ?)"
+        assert '.cost-cell' in template, ".cost-cell CSS が無い"
+        assert '.live-pill' in template, ".live-pill CSS が無い"
+        assert '.model-chip' in template, ".model-chip CSS が無い"
+        assert '.tier-chip' in template, ".tier-chip CSS が無い"
+
+    def test_load_and_render_invokes_render_sessions(self):
+        """20_load_and_render.js から renderSessions(data) が呼び出される。"""
+        body = _LOAD_RENDER_JS.read_text(encoding='utf-8')
+        # window.__sessions?.renderSessions?.(data) 経由 or 直接
+        assert ('renderSessions(data)' in body) or \
+               ('window.__sessions' in body and 'renderSessions' in body), \
+            "20_load_and_render.js から renderSessions(data) 呼び出しが無い"
+
+
+class TestSessionsRendererStructure:
+    def test_renderers_sessions_js_exists(self):
+        """45_renderers_sessions.js ファイルが存在する。"""
+        assert _RENDERERS_JS.is_file(), \
+            f"{_RENDERERS_JS} が存在しない"
+
+    def test_render_sessions_function_defined(self):
+        """`function renderSessions(...)` が定義されている。"""
+        body = _RENDERERS_JS.read_text(encoding='utf-8')
+        assert re.search(r"\bfunction\s+renderSessions\s*\(", body), \
+            "function renderSessions(...) の定義が無い"
+
+    def test_window_sessions_exposed(self):
+        """`window.__sessions` で renderSessions 等が expose される。"""
+        body = _RENDERERS_JS.read_text(encoding='utf-8')
+        assert 'window.__sessions' in body, \
+            "window.__sessions による expose が無い"
+        assert 'renderSessions' in body, \
+            "window.__sessions に renderSessions が含まれない"
+
+    def test_render_sessions_page_scoped_early_out(self):
+        """renderSessions は body[data-active-page="sessions"] 以外で early-out。"""
+        body = _RENDERERS_JS.read_text(encoding='utf-8')
+        # 関数本体の最初 500 文字以内に early-out 条件がある
+        match = re.search(
+            r"function\s+renderSessions\s*\([^)]*\)\s*\{",
+            body,
+        )
+        assert match is not None, "renderSessions 関数本体が見つからない"
+        head = body[match.end():match.end() + 500]
+        assert "activePage !== 'sessions'" in head or 'activePage !== "sessions"' in head, \
+            "renderSessions の page-scoped early-out (activePage !== 'sessions') が無い"
+
+
+# ============================================================
+#  TestSessionsRendererBehavior — Node 経由の振る舞い round-trip
+# ============================================================
+_NODE = shutil.which("node")
+
+
+@unittest.skipUnless(_NODE, "node not installed; skipping behavior round-trip")
+class TestSessionsRendererBehavior(unittest.TestCase):
+    """`window.__sessions` に expose した pure helpers を Node で eval して検証する。
+
+    DOM を伴う `renderSessions` は visual smoke (chrome-devtools MCP) で確認するため
+    本テストは pure 関数 (formatCostUsd / buildModelChips / buildTierChips /
+    buildSessionRow / computeKpi / inferModelFamily) のみを対象にする。
+    """
+
+    @staticmethod
+    def _run_node(call_expr: str) -> object:
+        """helpers.js + 45_renderers_sessions.js を読み込み、call_expr を JSON で返す。
+
+        45_renderers_sessions.js は IIFE wrap されているため、最後で
+        `window.__sessions` に expose したヘルパを Node で `globalThis.__sessions` 経由
+        で呼び出す。`window` shim は eval 前に渡す。
+        """
+        helpers_src = _HELPERS_JS.read_text(encoding='utf-8')
+        renderers_src = _RENDERERS_JS.read_text(encoding='utf-8')
+        # `document` / `window` shim: renderSessions が触るが、本テストは pure helpers のみ呼ぶ。
+        # `window` を globalThis に alias して __sessions が globalThis 経由で取れるようにする。
+        shim = (
+            "const __doc_dataset = { activePage: '__none__' };\n"
+            "globalThis.document = { body: { dataset: __doc_dataset }, "
+            "querySelector: () => null, getElementById: () => null };\n"
+            "globalThis.window = globalThis;\n"
+        )
+        script = (
+            shim
+            + helpers_src
+            + "\n" + renderers_src
+            + "\nconst __out = " + call_expr + ";\n"
+            + "process.stdout.write(JSON.stringify(__out));\n"
+        )
+        env = os.environ.copy()
+        proc = subprocess.run(
+            [_NODE, "-e", script],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if proc.returncode != 0:
+            raise AssertionError(
+                f"node failed (returncode={proc.returncode}): stderr={proc.stderr}"
+            )
+        return json.loads(proc.stdout)
+
+    # ---------- formatCostUsd ----------
+    def test_format_cost_usd_four_decimal_places(self):
+        out = self._run_node("window.__sessions.formatCostUsd(0.001)")
+        self.assertEqual(out, "$0.0010")
+
+    def test_format_cost_usd_zero(self):
+        out = self._run_node("window.__sessions.formatCostUsd(0)")
+        self.assertEqual(out, "$0.0000")
+
+    def test_format_cost_usd_large(self):
+        out = self._run_node("window.__sessions.formatCostUsd(12.4831)")
+        self.assertEqual(out, "$12.4831")
+
+    def test_format_cost_usd_handles_non_finite(self):
+        out = self._run_node("window.__sessions.formatCostUsd(NaN)")
+        self.assertEqual(out, "$0.0000")
+
+    # ---------- fmtTokens ----------
+    def test_fmt_tokens_under_1k(self):
+        out = self._run_node("window.__sessions.fmtTokens(123)")
+        self.assertEqual(out, "123")
+
+    def test_fmt_tokens_kilo(self):
+        out = self._run_node("window.__sessions.fmtTokens(1234)")
+        self.assertEqual(out, "1.2k")
+
+    def test_fmt_tokens_mega(self):
+        out = self._run_node("window.__sessions.fmtTokens(2_100_000)")
+        self.assertEqual(out, "2.1M")
+
+    def test_fmt_tokens_zero(self):
+        out = self._run_node("window.__sessions.fmtTokens(0)")
+        self.assertEqual(out, "0")
+
+    # ---------- inferModelFamily ----------
+    def test_infer_model_family_opus(self):
+        out = self._run_node("window.__sessions.inferModelFamily('claude-opus-4-7')")
+        self.assertEqual(out, "opus")
+
+    def test_infer_model_family_sonnet(self):
+        out = self._run_node("window.__sessions.inferModelFamily('claude-sonnet-4-6')")
+        self.assertEqual(out, "sonnet")
+
+    def test_infer_model_family_haiku(self):
+        out = self._run_node("window.__sessions.inferModelFamily('claude-haiku-4-5-20251001')")
+        self.assertEqual(out, "haiku")
+
+    def test_infer_model_family_unknown_falls_to_sonnet(self):
+        """未知 model 名は cost_metrics.py と整合させて sonnet fallback。"""
+        out = self._run_node("window.__sessions.inferModelFamily('claude-future-99')")
+        self.assertEqual(out, "sonnet")
+
+    # ---------- buildModelChips ----------
+    def test_build_model_chips_single(self):
+        out = self._run_node(
+            "window.__sessions.buildModelChips({'claude-opus-4-7': 3})"
+        )
+        self.assertIn('class="model-chips"', out)
+        self.assertIn('class="model-chip m-opus"', out)
+        self.assertIn('opus', out)
+        self.assertIn('class="ct">3<', out)
+
+    def test_build_model_chips_mixed(self):
+        out = self._run_node(
+            "window.__sessions.buildModelChips({'claude-opus-4-7': 8, 'claude-sonnet-4-6': 2})"
+        )
+        self.assertIn('m-opus', out)
+        self.assertIn('m-sonnet', out)
+
+    def test_build_model_chips_empty(self):
+        out = self._run_node("window.__sessions.buildModelChips({})")
+        self.assertIn('—', out)
+
+    # ---------- buildTierChips ----------
+    def test_build_tier_chips_priority(self):
+        out = self._run_node(
+            "window.__sessions.buildTierChips({priority: 10})"
+        )
+        self.assertIn('class="tier-chips"', out)
+        self.assertIn('class="tier-chip t-priority"', out)
+        self.assertIn('priority', out)
+        self.assertIn('class="ct">10<', out)
+
+    def test_build_tier_chips_mixed(self):
+        out = self._run_node(
+            "window.__sessions.buildTierChips({priority: 3, standard: 7})"
+        )
+        self.assertIn('t-priority', out)
+        self.assertIn('t-standard', out)
+
+    def test_build_tier_chips_empty(self):
+        out = self._run_node("window.__sessions.buildTierChips({})")
+        self.assertIn('—', out)
+
+    # ---------- buildSessionRow ----------
+    def test_build_session_row_active_has_live_pill(self):
+        """active session (ended_at: null) は live-pill を含む。"""
+        session_js = (
+            "{session_id:'s1', project:'foo', "
+            "started_at:'2026-05-06T09:14:00+00:00', ended_at:null, "
+            "duration_seconds:null, "
+            "models:{'claude-sonnet-4-6':2}, "
+            "tokens:{input:1000,output:500,cache_read:0,cache_creation:0}, "
+            "estimated_cost_usd:0.0234, "
+            "service_tier_breakdown:{standard:2}, "
+            "skill_count:1, subagent_count:0}"
+        )
+        out = self._run_node(
+            f"window.__sessions.buildSessionRow({session_js}, 1.0)"
+        )
+        self.assertIn('class="live-pill"', out)
+        self.assertIn('進行中', out)
+        self.assertIn('is-active', out)
+
+    def test_build_session_row_completed_has_duration(self):
+        """完了 session (ended_at あり) は live-pill ではなく duration を表示。"""
+        session_js = (
+            "{session_id:'s1', project:'bar', "
+            "started_at:'2026-05-05T20:00:00+00:00', "
+            "ended_at:'2026-05-06T00:47:00+00:00', "
+            "duration_seconds:17220, "
+            "models:{'claude-opus-4-7':10}, "
+            "tokens:{input:1000,output:500,cache_read:0,cache_creation:0}, "
+            "estimated_cost_usd:5.8210, "
+            "service_tier_breakdown:{priority:10}, "
+            "skill_count:14, subagent_count:8}"
+        )
+        out = self._run_node(
+            f"window.__sessions.buildSessionRow({session_js}, 5.8210)"
+        )
+        self.assertNotIn('live-pill', out)
+        # duration_seconds=17220 = 4h 47m
+        self.assertIn('4h 47m', out)
+        self.assertNotIn('is-active', out)
+
+    def test_build_session_row_whale_class(self):
+        """cost が maxCost と一致する row には is-whale が付く。"""
+        session_js = (
+            "{session_id:'s1', project:'foo', "
+            "started_at:'2026-05-05T20:00:00+00:00', "
+            "ended_at:'2026-05-06T00:00:00+00:00', "
+            "duration_seconds:14400, "
+            "models:{'claude-opus-4-7':10}, "
+            "tokens:{input:1000,output:500,cache_read:0,cache_creation:0}, "
+            "estimated_cost_usd:5.0, "
+            "service_tier_breakdown:{priority:10}, "
+            "skill_count:14, subagent_count:8}"
+        )
+        out = self._run_node(
+            f"window.__sessions.buildSessionRow({session_js}, 5.0)"
+        )
+        self.assertIn('is-whale', out)
+
+    def test_build_session_row_cost_format(self):
+        """cost セルが $X.XXXX (4 桁) で出力される。"""
+        session_js = (
+            "{session_id:'s1', project:'foo', "
+            "started_at:'2026-05-05T20:00:00+00:00', "
+            "ended_at:'2026-05-06T00:00:00+00:00', "
+            "duration_seconds:14400, "
+            "models:{'claude-sonnet-4-6':1}, "
+            "tokens:{input:1000,output:500,cache_read:0,cache_creation:0}, "
+            "estimated_cost_usd:0.1842, "
+            "service_tier_breakdown:{standard:1}, "
+            "skill_count:0, subagent_count:0}"
+        )
+        out = self._run_node(
+            f"window.__sessions.buildSessionRow({session_js}, 5.0)"
+        )
+        self.assertIn('$0.1842', out)
+        self.assertIn('class="cost-cell"', out)
+        self.assertIn('--cost-pct:', out)
+
+    # ---------- computeKpi ----------
+    def test_compute_kpi_three_sessions(self):
+        sessions_js = (
+            "[{estimated_cost_usd:1.0, tokens:{input:1000,output:0,cache_read:9000,cache_creation:0}},"
+            "{estimated_cost_usd:2.0, tokens:{input:2000,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:3.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}}]"
+        )
+        out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
+        # 合計 1+2+3 = 6
+        self.assertAlmostEqual(out['totalCost'], 6.0, places=4)
+        # 中央値 (3 件 → index 1) = 2
+        self.assertAlmostEqual(out['medianCost'], 2.0, places=4)
+        # 平均 = 2.0
+        self.assertAlmostEqual(out['avgCost'], 2.0, places=4)
+        # cache 効率 = 9000 / (1000 + 2000 + 0 + 9000) = 0.75
+        self.assertAlmostEqual(out['cacheEfficiency'], 0.75, places=4)
+
+    def test_compute_kpi_empty(self):
+        out = self._run_node("window.__sessions.computeKpi([])")
+        self.assertEqual(out['totalCost'], 0)
+        self.assertEqual(out['medianCost'], 0)
+        self.assertEqual(out['avgCost'], 0)
+        self.assertEqual(out['cacheEfficiency'], 0)
+
+    def test_compute_kpi_top_cost_tracks_max(self):
+        sessions_js = (
+            "[{estimated_cost_usd:1.5, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:0.2, tokens:{input:0,output:0,cache_read:0,cache_creation:0}}]"
+        )
+        out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
+        self.assertAlmostEqual(out['topCost'], 1.5, places=4)

--- a/tests/test_dashboard_sessions_ui.py
+++ b/tests/test_dashboard_sessions_ui.py
@@ -505,6 +505,48 @@ class TestSessionsRendererBehavior(unittest.TestCase):
         self.assertAlmostEqual(out['opusCost'], 2.0, places=4)
         self.assertAlmostEqual(out['opusShare'], 0.2, places=4)
 
+    def test_compute_kpi_median_multiple_zero_when_median_is_zero(self):
+        """median = 0 (cost=0 session が半数以上) の degenerate case では
+        medianMultiple = 0 (= 倍率定義不可)。renderer 側は dash fallback で「—×」表示。
+
+        topCostShare は totalCost > 0 ならば常に計算可能なので、
+        sub 全体を消すのではなく倍率だけ dash に倒す方針 (ユーザー指摘 #103)。
+        """
+        # 4 件 (sorted=[0, 0, 0, 4]): total=4, median=0, avg=1, topCost=4
+        sessions_js = (
+            "[{estimated_cost_usd:0.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:0.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:0.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:4.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}}]"
+        )
+        out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
+        self.assertEqual(out['medianCost'], 0)
+        self.assertEqual(out['medianMultiple'], 0)
+        self.assertAlmostEqual(out['topCostShare'], 1.0, places=4)
+
+    def test_build_kpi_html_avg_sub_dash_fallback_when_median_is_zero(self):
+        """buildKpiHTML(kpi) の 3 枚目 (kpi-sess-avg) が median=0 でも sub を出す。
+
+        倍率は「—×」(dash) で fallback、上位 1 件 % は通常通り計算する。
+        ユーザー指摘 (#103): 以前は median=0 で sub 全体を空にしていたが、
+        empty card を生むだけで UX 上ノイズになる。
+        """
+        kpi_js = (
+            "{totalCost: 4, medianCost: 0, avgCost: 1, cacheEfficiency: 0, "
+            "topCost: 4, minCost: 0, sessionCount: 4, "
+            "totalInputTokens: 0, totalCacheReadTokens: 0, "
+            "opusCost: 0, opusShare: 0, "
+            "medianMultiple: 0, topCostShare: 1.0}"
+        )
+        html = self._run_node(f"window.__sessions.buildKpiHTML({kpi_js})")
+        # kpi-sess-avg card に「上位 1 件で 100% 寄与」が含まれる
+        self.assertIn('id="kpi-sess-avg"', html)
+        # avg sub が空 (= '&nbsp;') ではなく、寄与率を含む
+        self.assertIn('上位 1 件で', html)
+        self.assertIn('100%', html)
+        # 倍率は dash fallback
+        self.assertIn('中央値の <em>—</em>', html)
+
     def test_compute_kpi_median_multiple_and_top_cost_share(self):
         """3 枚目 KPI sub「中央値の N× · 上位 1 件で M% 寄与」用メトリクス。
 

--- a/tests/test_dashboard_sessions_ui.py
+++ b/tests/test_dashboard_sessions_ui.py
@@ -463,6 +463,22 @@ class TestSessionsRendererBehavior(unittest.TestCase):
         self.assertEqual(out['avgCost'], 0)
         self.assertEqual(out['cacheEfficiency'], 0)
 
+    def test_compute_kpi_even_count_median_is_average_of_middle_two(self):
+        """偶数件 (TOP_N_SESSIONS = 20 の常用ケース) では sorted[n/2-1] と sorted[n/2] の平均。
+
+        codex Round 1 / P2 指摘: median 計算が偶数件のとき上位中央 1 値しか返さず、
+        中央 2 値の平均にならない (= 系統的に高めに偏る)。
+        """
+        # 4 件 → sorted = [1,2,3,4] → median = (2+3)/2 = 2.5
+        sessions_js = (
+            "[{estimated_cost_usd:1.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:2.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:3.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:4.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}}]"
+        )
+        out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
+        self.assertAlmostEqual(out['medianCost'], 2.5, places=4)
+
     def test_compute_kpi_top_cost_tracks_max(self):
         sessions_js = (
             "[{estimated_cost_usd:1.5, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"

--- a/tests/test_dashboard_sessions_ui.py
+++ b/tests/test_dashboard_sessions_ui.py
@@ -486,3 +486,39 @@ class TestSessionsRendererBehavior(unittest.TestCase):
         )
         out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
         self.assertAlmostEqual(out['topCost'], 1.5, places=4)
+
+    def test_compute_kpi_opus_share_attributes_session_to_opus(self):
+        """opus が含まれる session は cost 全額が opusCost に寄与する (按分しない)。
+
+        mock の決定: 1 枚目 KPI sub「うち opus セッション $X.XX (Y%)」は
+        「opus が使われた session」単位の合計を表示する仕様 (model 内訳の按分は UX 上不要)。
+        """
+        # session A (opus 使用) cost=2.0、session B (sonnet のみ) cost=8.0
+        # → opusCost = 2.0、totalCost = 10.0、opusShare = 0.2
+        sessions_js = (
+            "[{estimated_cost_usd:2.0, models:{'claude-opus-4-7':3, 'claude-sonnet-4-6':1}, "
+            "tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:8.0, models:{'claude-sonnet-4-6':5}, "
+            "tokens:{input:0,output:0,cache_read:0,cache_creation:0}}]"
+        )
+        out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
+        self.assertAlmostEqual(out['opusCost'], 2.0, places=4)
+        self.assertAlmostEqual(out['opusShare'], 0.2, places=4)
+
+    def test_compute_kpi_median_multiple_and_top_cost_share(self):
+        """3 枚目 KPI sub「中央値の N× · 上位 1 件で M% 寄与」用メトリクス。
+
+        avg / median = medianMultiple、topCost / totalCost = topCostShare。
+        whale 偏りの可視化に使う (= mean が median から大きく乖離している = 上位寄り)。
+        """
+        # 4 件 (sorted=[1,2,3,4]): total=10, median=2.5, avg=2.5, topCost=4
+        # → medianMultiple = 2.5/2.5 = 1.0、topCostShare = 4/10 = 0.4
+        sessions_js = (
+            "[{estimated_cost_usd:1.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:2.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:3.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}},"
+            "{estimated_cost_usd:4.0, tokens:{input:0,output:0,cache_read:0,cache_creation:0}}]"
+        )
+        out = self._run_node(f"window.__sessions.computeKpi({sessions_js})")
+        self.assertAlmostEqual(out['medianMultiple'], 1.0, places=4)
+        self.assertAlmostEqual(out['topCostShare'], 0.4, places=4)

--- a/tests/test_dashboard_sessions_ui.py
+++ b/tests/test_dashboard_sessions_ui.py
@@ -252,11 +252,15 @@ class TestSessionsRendererBehavior(unittest.TestCase):
             + "process.stdout.write(JSON.stringify(__out));\n"
         )
         env = os.environ.copy()
+        # Windows の subprocess は text=True 時に OS locale (cp932 / charmap) で
+        # decode してしまい、Node が UTF-8 で出力する日本語 (`進行中`) や em dash
+        # (`—`) が mojibake / UnicodeDecodeError で死ぬ。encoding を明示すること。
         proc = subprocess.run(
             [_NODE, "-e", script],
             env=env,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             check=False,
             timeout=10,
         )

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -25,7 +25,7 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 # 改行の取り扱いを含めた byte 等価性を保証する。
 #
 # 意図的な template 変更時は新 hash に更新する (docstring 参照)。
-EXPECTED_TEMPLATE_SHA256 = "12aaff1e12e967166e8539daf2991a5461b558cf001e8faf1b2a121dec3e9afc"
+EXPECTED_TEMPLATE_SHA256 = "72a2ea110de6bdce8a46ad453d9d411e9a1ae46f0381d3bc2653d3a949cca768"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -25,7 +25,7 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 # 改行の取り扱いを含めた byte 等価性を保証する。
 #
 # 意図的な template 変更時は新 hash に更新する (docstring 参照)。
-EXPECTED_TEMPLATE_SHA256 = "9663caf7546cc60ded10fb74d6cab913606f8db5de8603b4d4b4c98e4243fa42"
+EXPECTED_TEMPLATE_SHA256 = "cfa2fa37f641fb70b2bd4fd25308e7a18fc1463a260bbfe39555239fc8454849"
 
 
 def _load_dashboard_module(tmp_path: Path):
@@ -69,8 +69,8 @@ def test_html_template_contains_critical_dom_anchors(tmp_path):
     mod = _load_dashboard_module(tmp_path)
     html = mod._HTML_TEMPLATE  # pylint: disable=protected-access
 
-    # 4 ページ section
-    for page in ("overview", "patterns", "quality", "surface"):
+    # 5 ページ section (Issue #103 で sessions 追加)
+    for page in ("overview", "patterns", "quality", "surface", "sessions"):
         assert f'data-page="{page}"' in html, f"page section '{page}' が消えている"
 
     # JS の getElementById / querySelector が参照する主要 ID

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -25,7 +25,7 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 # 改行の取り扱いを含めた byte 等価性を保証する。
 #
 # 意図的な template 変更時は新 hash に更新する (docstring 参照)。
-EXPECTED_TEMPLATE_SHA256 = "cfa2fa37f641fb70b2bd4fd25308e7a18fc1463a260bbfe39555239fc8454849"
+EXPECTED_TEMPLATE_SHA256 = "ad04640b01b8a504f591c7c7b52edb68d9ec4c335916314847cce809c44b93b6"
 
 
 def _load_dashboard_module(tmp_path: Path):

--- a/tests/test_dashboard_template_split.py
+++ b/tests/test_dashboard_template_split.py
@@ -25,7 +25,7 @@ _DASHBOARD_PATH = Path(__file__).parent.parent / "dashboard" / "server.py"
 # 改行の取り扱いを含めた byte 等価性を保証する。
 #
 # 意図的な template 変更時は新 hash に更新する (docstring 参照)。
-EXPECTED_TEMPLATE_SHA256 = "ad04640b01b8a504f591c7c7b52edb68d9ec4c335916314847cce809c44b93b6"
+EXPECTED_TEMPLATE_SHA256 = "12aaff1e12e967166e8539daf2991a5461b558cf001e8faf1b2a121dec3e9afc"
 
 
 def _load_dashboard_module(tmp_path: Path):


### PR DESCRIPTION
## Summary

- `session_breakdown` API (Issue #99 / PR #105 で merged) を可視化する 5 番目のタブ `#/sessions` を追加
- 12 列テーブル: 開始時刻 / 期間 / プロジェクト / Models / Input / Output / Cache R / Cache C / 推計コスト / Service tier / Skills / Subagents (Session ID 列は廃止 = mock 決定)
- KPI 4 枚 (4 列均等 grid): 直近 N 件 合計コスト (大) / 中央値 / 平均 / Cache 効率
- 進行中 pill (`conn-pulse` keyframe 流用) + whale row (max cost 強調) + cost meter bar (`--cost-pct` で行ごとにスケール)
- model chip (`m-opus/sonnet/haiku`) + service tier chip (`t-priority/standard/batch`)
- Tokens super-group ヘッダ (peri tint) + 4 種別 help-pop (`hp-tokens` / `hp-cost` / `hp-tier` / `hp-sessions`)
- page-scoped early-out (`activePage !== 'sessions'`) で他ページ表示時 no-op
- `_MAIN_JS_FILES` に `45_renderers_sessions.js` を `40_renderers_quality.js` の後 / `50_renderers_surface.js` の前に登録、`_CSS_FILES` に `55_sessions.css` を `50_quality.css` の後 / `60_surface.css` の前に登録
- 既存 4 タブ pin tests (`test_dashboard_router` / `test_dashboard_template_split`) を 5 タブに更新 + `EXPECTED_TEMPLATE_SHA256` bump

## Mock との差分修正

レビュー過程で発見した mock との差分:
- KPI 行の幅 (Overview 8 列 grid をそのまま継承していたので Sessions section scope で 4 列 grid に上書き)
- 1 枚目 (合計コスト) を `<div class="v">` (sm 無し / 26px) で headline metric 化、sub に「うち opus セッション $X.XX (Y%)」
- 3 枚目 (平均) sub に「中央値の N× · 上位 1 件で M% 寄与」(median=0 のとき倍率は dash fallback で sub は必ず出す)

## Renderer 設計

renderer は IIFE 内 pure helpers (`formatCostUsd` / `fmtTokens` / `inferModelFamily` / `buildModelChips` / `buildTierChips` / `buildSessionRow` / `computeKpi` / `buildKpiHTML`) を `window.__sessions` に expose し、Node round-trip テスト (`test_dashboard_sessions_ui.py::TestSessionsRendererBehavior`) で個別検証可能。`renderSessions(data)` 本体は DOM 描画担当で page-scoped early-out。

## codex-review

- **Round 1**: P2 1 件 (median 計算が偶数件で中央 2 値の平均にならない) → 6acf475 で修正
- **Round 2**: zero actionable findings = 収束

## 関連

- Closes #103
- 依存: Issue #99 (PR #105) — `session_breakdown` API が前提
- Plan: `docs/plans/session-page-cost-estimation.md` (sub-issue B 該当節)
- Mock: `docs/plans/sessions-ui-mock.html` (本 PR の commit 1 で repo 永続化)
- 後続: Issue #104 (rescan + reports 拡張)

## Test plan

- [x] `python3 -m pytest tests/` → 1158 passed, 1 skipped (Windows-only)
- [x] 新規 `tests/test_dashboard_sessions_ui.py` (47 件): template 構造 + Node round-trip behavior (cost format / fmtTokens / inferModelFamily / buildModelChips / buildTierChips / buildSessionRow / computeKpi / buildKpiHTML)
- [x] 既存 router / template_split test を 5 タブに更新
- [x] Static export (`reports/export_html.py --output /tmp/issue-103-smoke.html`) → chrome-devtools MCP で `#/sessions` に navigate して KPI 4 枚 / 12 列テーブル / 進行中 pill / whale row / model & tier chip / Tokens super-group を視覚確認、console error/warn 0
- [x] `Session ID` 列の不在を grep で機械検証 (count = 0)
- [x] page-scoped early-out: `#/` に遷移 → sessions section が hidden、再描画されない (DOM は前 state を保持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)